### PR TITLE
python class repr cleanup

### DIFF
--- a/unify/types/base.py
+++ b/unify/types/base.py
@@ -123,7 +123,7 @@ class _Formatted(abc.ABC):
             if len(item) > cutoff:
                 new_items.append("...")
             return new_items
-        if isinstance(item, _FormattedBaseModel):
+        if isinstance(item, BaseModel):
             item = item.model_dump()
         if isinstance(item, dict):
             return {

--- a/unify/types/base.py
+++ b/unify/types/base.py
@@ -10,6 +10,20 @@ import unify
 
 class _Formatted(abc.ABC):
 
+    def _repr(self, item) -> str:
+        class_ = item.__class__
+        item = class_(**self._truncate_model(item))
+        console = Console()
+        with console.capture() as capture:
+            console.print(item)
+        return capture.get().strip("\n")
+
+    def __repr__(self):
+        return self._repr(self)
+
+    def __str__(self):
+        return self._repr(self)
+
     def _prune_dict(self, val, prune_policy):
 
         def keep(v, k=None, prune_pol=None):
@@ -122,20 +136,6 @@ class _Formatted(abc.ABC):
         prune_policy = unify.key_repr(item)
         dct = self._prune_dict(item.model_dump(), prune_policy)
         return self._create_pydantic_model(item, dct)
-
-    def _repr(self, item) -> str:
-        class_ = item.__class__
-        item = class_(**self._truncate_model(item))
-        console = Console()
-        with console.capture() as capture:
-            console.print(item)
-        return capture.get().strip("\n")
-
-    def __repr__(self):
-        return self._repr(self)
-
-    def __str__(self):
-        return self._repr(self)
 
 
 class _FormattedBaseModel(_Formatted, BaseModel):

--- a/unify/types/base.py
+++ b/unify/types/base.py
@@ -1,7 +1,5 @@
 import abc
 import inspect
-import rich.repr
-from io import StringIO
 from rich.console import Console
 from pydantic import BaseModel
 from pydantic import create_model
@@ -9,40 +7,8 @@ from pydantic._internal._model_construction import ModelMetaclass
 
 import unify
 
-RICH_CONSOLE = Console(file=StringIO())
-
 
 class _Formatted(abc.ABC):
-
-    @staticmethod
-    def _indent_text(to_print):
-        chunks = to_print.split("\n")
-        num_chunks = len(chunks)
-        detected = False
-        prev_chunk = chunks[0]
-        for i, chunk in enumerate(chunks[:-1]):
-            if i in (0, num_chunks-2) or chunk.startswith(" "):
-                detected = False
-                continue
-            if not detected:
-                prev_chunk = chunks[i-1]
-            detected = True
-            leading_spaces = len(prev_chunk) - len(prev_chunk.lstrip())
-            chunks[i] = " " * (leading_spaces + 11) + chunk
-        return "\n".join(chunks)
-
-    def _repr(self, to_print):
-        # ToDO find more elegant way to do this
-        global RICH_CONSOLE
-        with RICH_CONSOLE.capture() as capture:
-            RICH_CONSOLE.print(to_print)
-        return self._indent_text(capture.get())
-
-    def __repr__(self) -> str:
-        return self._repr(self)
-
-    def __str__(self) -> str:
-        return self._repr(self)
 
     def _prune_dict(self, val, prune_policy):
 
@@ -135,13 +101,43 @@ class _Formatted(abc.ABC):
             )
         return model(**dct)
 
+    def _truncate_model(self, item, cutoff=5):
+        if isinstance(item, list):
+            new_items = [
+                self._truncate_model(it) for it in item[:cutoff]
+            ]
+            if len(item) > cutoff:
+                new_items.append("...")
+            return new_items
+        if isinstance(item, _FormattedBaseModel):
+            item = item.model_dump()
+        if isinstance(item, dict):
+            return {
+                key: self._truncate_model(value)
+                for key, value in item.items()
+            }
+        return item
+
     def _prune(self, item):
         prune_policy = unify.key_repr(item)
         dct = self._prune_dict(item.model_dump(), prune_policy)
         return self._create_pydantic_model(item, dct)
 
+    def _repr(self, item) -> str:
+        class_ = item.__class__
+        item = class_(**self._truncate_model(item))
+        console = Console()
+        with console.capture() as capture:
+            console.print(item)
+        return capture.get().strip("\n")
 
-@rich.repr.auto
+    def __repr__(self):
+        return self._repr(self)
+
+    def __str__(self):
+        return self._repr(self)
+
+
 class _FormattedBaseModel(_Formatted, BaseModel):
 
     def __repr__(self) -> str:
@@ -149,15 +145,6 @@ class _FormattedBaseModel(_Formatted, BaseModel):
 
     def __str__(self) -> str:
         return self._repr(self._prune(self) if unify.repr_mode() == "concise" else self)
-
-    def __rich_repr__(self):
-        rep = self._prune(self) if unify.repr_mode() == "concise" else self
-        for k in rep.model_fields:
-            yield k, rep.__dict__[k]
-        if rep.model_extra is None:
-            return
-        for k, v in rep.model_extra.items():
-            yield k, v
 
     def full_repr(self):
         """

--- a/unify/types/base.py
+++ b/unify/types/base.py
@@ -18,10 +18,10 @@ class _Formatted(abc.ABC):
             console.print(item)
         return capture.get().strip("\n")
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return self._repr(self)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self._repr(self)
 
     def _prune_dict(self, val, prune_policy):

--- a/unify/types/dataset.py
+++ b/unify/types/dataset.py
@@ -1,5 +1,5 @@
 from pydantic import Extra
-from typing import Optional
+from typing import List, Literal, Optional, Union
 
 import unify
 from .base import _FormattedBaseModel
@@ -46,3 +46,10 @@ class Datum(_FormattedBaseModel, extra=Extra.allow):
 
     def __hash__(self):
         return hash(str(self))
+
+
+class Dataset(_FormattedBaseModel, extra=Extra.allow):
+    prompts: List[Union[Datum, Literal["..."]]] # type: ignore
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)

--- a/unify/utils/datasets.py
+++ b/unify/utils/datasets.py
@@ -4,6 +4,7 @@ from typing import List, Dict, Optional, Union
 
 from unify import BASE_URL
 from unify.types import Prompt, Datum
+from unify.types.dataset import Dataset
 from .helpers import _validate_api_key, _res_to_list
 
 
@@ -74,7 +75,7 @@ def download_dataset(
     path: Optional[str] = None,
     raw_return: bool = False,
     api_key: Optional[str] = None,
-) -> Union[List[Datum], None]:
+) -> Union[Dataset, None]:
     """
     Downloads a dataset from the platform.
 
@@ -107,10 +108,15 @@ def download_dataset(
     ret = json.loads(response.text)
     if raw_return:
         return ret
-    return [Datum(
-        **{k: Prompt(**v) if k == "prompt" else v
-           for k, v in item.items() if k not in ("id", "num_tokens", "timestamp")}
-    ) for item in ret]
+    return Dataset(
+        prompts= [
+            Datum(
+                **{k: Prompt(**v) if k == "prompt" else v
+                for k, v in item.items() if k not in ("id", "num_tokens", "timestamp")}
+            )
+            for item in ret
+        ]
+    )
 
 
 def delete_dataset(name: str, api_key: Optional[str] = None) -> str:


### PR DESCRIPTION
1. Removed the indentation logic as `rich` is doing the indentation anyway
2. Initially tried using a different package like `devtools`, but that had an issue with displaying nested base models with lists in them
3. So reverted back to `rich` and got it working with the python console eval as well. The only thing not working with `rich` is that for jupyter notebooks it adds a newline character, this is present as an [issue](https://github.com/Textualize/rich/issues/3274) on their repo.
4. Added a `Dataset` model to contain the prompts as well. This was required because otherwise the dataset is `List[Prompt]` and so the printing of the `list` doesn't really go through the `__repr__` of the `Prompt` so truncation wouldn't be possible.
5. Added the truncation logic to clip the results with a `...` if they are longer than 5 by default. The cutoff can ofc be modified.

Not sure if there's something I've removed that was being used for a use-case I haven't tested, let me know what you think. Thanks 😄