### PR TITLE
add logging context manager and decorator

### DIFF
--- a/tests/test_utils/test_evals/test_evaluations.py
+++ b/tests/test_utils/test_evals/test_evaluations.py
@@ -1,7 +1,10 @@
 import unittest
+import time
+import asyncio
 
 import unify
 from requests import HTTPError
+import threading
 
 
 class TestEvaluations(unittest.TestCase):
@@ -107,3 +110,65 @@ class TestEvaluations(unittest.TestCase):
             project="my_project",
         )
         assert logs_metric == 0.25
+
+    def test_contextual_logging_threaded(self):
+        project = "my_project"
+        if project in unify.list_projects():
+            unify.delete_project(project)
+        unify.create_project(project)
+        unify.activate(project)
+
+        def inner_fn(data, st):
+            time.sleep(st)
+            unify.add_log_entries(d2=data)
+
+        @unify.trace()
+        def fn1(data1, data2, st):
+            unify.add_log_entries(d1=data1)
+            inner_fn(data2, st)
+        
+        thread1 = threading.Thread(target=fn1, args=("Thread-1", "data1", 1))
+        thread2 = threading.Thread(target=fn1, args=("Thread-2", "data2", 2))
+
+        # Start the threads
+        thread1.start()
+        thread2.start()
+
+        # Wait for both threads to complete
+        thread1.join()
+        thread2.join()
+
+        logs = unify.get_logs("my_project")
+        list1 = [log.entries for log in logs]
+        list2 = [{"d1": "Thread-1", "d2": "data1"}, {"d1": "Thread-2", "d2": "data2"}]
+
+        # Sort each dictionary by keys and then sort the list
+        assert sorted([sorted(d.items()) for d in list1]) == sorted([sorted(d.items()) for d in list2])
+        
+            
+class TestAsyncEvaluations(unittest.IsolatedAsyncioTestCase):
+    async def test_contextual_logging_async(self):
+        project = "my_project"
+        if project in unify.list_projects():
+            unify.delete_project(project)
+        unify.create_project(project)
+        unify.activate(project)
+
+        async def inner_fn(data, st):
+            await asyncio.sleep(st)
+            unify.add_log_entries(d2=data)
+
+        @unify.trace()
+        async def fn1(data1, data2, st):
+            unify.add_log_entries(d1=data1)
+            await inner_fn(data2, st)
+        
+        await asyncio.gather(fn1("Task-1", "data1", 1), fn1("Task-2", "data2", 2))
+
+        logs = unify.get_logs("my_project")
+        list1 = [log.entries for log in logs]
+        list2 = [{"d1": "Task-1", "d2": "data1"}, {"d1": "Task-2", "d2": "data2"}]
+
+        # Sort each dictionary by keys and then sort the list
+        assert sorted([sorted(d.items()) for d in list1]) == sorted([sorted(d.items()) for d in list2])
+    

--- a/tests/test_utils/test_evals/test_evaluations.py
+++ b/tests/test_utils/test_evals/test_evaluations.py
@@ -126,7 +126,7 @@ class TestEvaluations(unittest.TestCase):
         def fn1(data1, data2, st):
             unify.add_log_entries(d1=data1)
             inner_fn(data2, st)
-        
+
         thread1 = threading.Thread(target=fn1, args=("Thread-1", "data1", 1))
         thread2 = threading.Thread(target=fn1, args=("Thread-2", "data2", 2))
 
@@ -143,9 +143,11 @@ class TestEvaluations(unittest.TestCase):
         list2 = [{"d1": "Thread-1", "d2": "data1"}, {"d1": "Thread-2", "d2": "data2"}]
 
         # Sort each dictionary by keys and then sort the list
-        assert sorted([sorted(d.items()) for d in list1]) == sorted([sorted(d.items()) for d in list2])
-        
-            
+        assert sorted([sorted(d.items()) for d in list1]) == sorted(
+            [sorted(d.items()) for d in list2],
+        )
+
+
 class TestAsyncEvaluations(unittest.IsolatedAsyncioTestCase):
     async def test_contextual_logging_async(self):
         project = "my_project"
@@ -162,7 +164,7 @@ class TestAsyncEvaluations(unittest.IsolatedAsyncioTestCase):
         async def fn1(data1, data2, st):
             unify.add_log_entries(d1=data1)
             await inner_fn(data2, st)
-        
+
         await asyncio.gather(fn1("Task-1", "data1", 1), fn1("Task-2", "data2", 2))
 
         logs = unify.get_logs("my_project")
@@ -170,5 +172,6 @@ class TestAsyncEvaluations(unittest.IsolatedAsyncioTestCase):
         list2 = [{"d1": "Task-1", "d2": "data1"}, {"d1": "Task-2", "d2": "data2"}]
 
         # Sort each dictionary by keys and then sort the list
-        assert sorted([sorted(d.items()) for d in list1]) == sorted([sorted(d.items()) for d in list2])
-    
+        assert sorted([sorted(d.items()) for d in list1]) == sorted(
+            [sorted(d.items()) for d in list2],
+        )

--- a/unify/utils/evaluations.py
+++ b/unify/utils/evaluations.py
@@ -346,7 +346,9 @@ def log(
 
 
 def add_log_entries(
-    id: Optional[int] = None, api_key: Optional[str] = None, **kwargs,
+    id: Optional[int] = None,
+    api_key: Optional[str] = None,
+    **kwargs,
 ) -> Dict[str, str]:
     """
     Returns the data (id and values) by querying the data based on their values.

--- a/unify/utils/evaluations.py
+++ b/unify/utils/evaluations.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import inspect
+import functools
+from contextvars import ContextVar
 from typing import Any, Dict, List, Optional, Union
 
 import requests
@@ -11,6 +14,8 @@ from .helpers import _validate_api_key
 
 # Helpers #
 # --------#
+
+current_global_active_log = ContextVar("current_global_active_log", default=None)
 
 
 def _get_and_maybe_create_project(project: str, api_key: Optional[str] = None) -> str:
@@ -340,12 +345,12 @@ def log(
     return Log(response.json(), api_key, **kwargs)
 
 
-def add_log_entries(id: int, api_key: Optional[str] = None, **kwargs) -> Dict[str, str]:
+def add_log_entries(id: Optional[int]=None, api_key: Optional[str] = None, **kwargs) -> Dict[str, str]:
     """
     Returns the data (id and values) by querying the data based on their values.
 
     Args:
-        id: The log id to update with extra data.
+        id: The log id to update with extra data. Looks for the current active log if no id is provided.
 
         api_key: If specified, unify API key to be used. Defaults to the value in the
         `UNIFY_KEY` environment variable.
@@ -355,13 +360,15 @@ def add_log_entries(id: int, api_key: Optional[str] = None, **kwargs) -> Dict[st
     Returns:
         A message indicating whether the log was successfully updated.
     """
+    current_active_log: Log = current_global_active_log.get()
+    if current_active_log is None and id is None: raise ValueError("`id` must be set if no current log is active within the context.")
     api_key = _validate_api_key(api_key)
     headers = {
         "accept": "application/json",
         "Authorization": f"Bearer {api_key}",
     }
     body = {"entries": kwargs}
-    response = requests.put(BASE_URL + f"/log/{id}", headers=headers, json=body)
+    response = requests.put(BASE_URL + f"/log/{id if id else current_active_log.id}", headers=headers, json=body)
     response.raise_for_status()
     return response.json()
 
@@ -582,3 +589,34 @@ def get_logs_metric(
     )
     response.raise_for_status()
     return response.json()
+
+
+# if an active log is there, means the function is being called from within another traced function
+# if no active log, create a new log
+class trace:
+
+    def __enter__(self):
+        self.current_global_active_log_already_set = False
+        current_active_log = current_global_active_log.get()
+        if current_active_log is not None:
+            self.current_global_active_log_already_set = True
+        else:
+            self.token = current_global_active_log.set(log())
+            # print(current_global_active_log.get().id)
+    
+    def __exit__(self, *args, **kwargs):
+        if not self.current_global_active_log_already_set:
+            current_global_active_log.reset(self.token)
+
+    def __call__(self, fn):
+        @functools.wraps(fn)
+        async def async_wrapper(*args, **kwargs):
+            with trace():
+                result = await fn(*args, **kwargs)
+                return result
+        @functools.wraps(fn)
+        def wrapper(*args, **kwargs):
+            with trace():
+                result = fn(*args, **kwargs)
+                return result
+        return async_wrapper if inspect.iscoroutinefunction(fn) else wrapper

--- a/unify/utils/evaluations.py
+++ b/unify/utils/evaluations.py
@@ -345,7 +345,9 @@ def log(
     return Log(response.json(), api_key, **kwargs)
 
 
-def add_log_entries(id: Optional[int]=None, api_key: Optional[str] = None, **kwargs) -> Dict[str, str]:
+def add_log_entries(
+    id: Optional[int] = None, api_key: Optional[str] = None, **kwargs,
+) -> Dict[str, str]:
     """
     Returns the data (id and values) by querying the data based on their values.
 
@@ -361,14 +363,21 @@ def add_log_entries(id: Optional[int]=None, api_key: Optional[str] = None, **kwa
         A message indicating whether the log was successfully updated.
     """
     current_active_log: Log = current_global_active_log.get()
-    if current_active_log is None and id is None: raise ValueError("`id` must be set if no current log is active within the context.")
+    if current_active_log is None and id is None:
+        raise ValueError(
+            "`id` must be set if no current log is active within the context.",
+        )
     api_key = _validate_api_key(api_key)
     headers = {
         "accept": "application/json",
         "Authorization": f"Bearer {api_key}",
     }
     body = {"entries": kwargs}
-    response = requests.put(BASE_URL + f"/log/{id if id else current_active_log.id}", headers=headers, json=body)
+    response = requests.put(
+        BASE_URL + f"/log/{id if id else current_active_log.id}",
+        headers=headers,
+        json=body,
+    )
     response.raise_for_status()
     return response.json()
 
@@ -603,7 +612,7 @@ class trace:
         else:
             self.token = current_global_active_log.set(log())
             # print(current_global_active_log.get().id)
-    
+
     def __exit__(self, *args, **kwargs):
         if not self.current_global_active_log_already_set:
             current_global_active_log.reset(self.token)
@@ -614,9 +623,11 @@ class trace:
             with trace():
                 result = await fn(*args, **kwargs)
                 return result
+
         @functools.wraps(fn)
         def wrapper(*args, **kwargs):
             with trace():
                 result = fn(*args, **kwargs)
                 return result
+
         return async_wrapper if inspect.iscoroutinefunction(fn) else wrapper


### PR DESCRIPTION
the PR adds support to contextual logging, the `trace` context-manager or decorator can be used.
It handles both threaded and async code.

Example usage:

```python
import unify
unify.activate("some project")

def inner_fn(data, st):
    time.sleep(st)
    unify.add_log_entries(d2=data)


@unify.trace()
def fn1(data1, data2, st):
    unify.add_log_entries(d1=data1)
    inner_fn(data2, st)

import threading

# Create two threads

thread1 = threading.Thread(target=fn1, args=("Thread-1", "data1", 1))
thread2 = threading.Thread(target=fn1, args=("Thread-2", "data2", 2))

# Start the threads
thread1.start()
thread2.start()

# Wait for both threads to complete
thread1.join()
thread2.join()
```

This will log two logs, with their respective data.

you can also use it as a context manager:

```python

with trace():
    # any call to unify.add_log_entries will be logged to the same log
```
behind the scenes, the context manager/decorator makes a `unify.log` call and holds the returned (empty) log in a context-aware variable that was initially set as `None`, each subsequent call to `unify.add_log_entries` will refer to that log if no explicit `id` is passed, once the function finishes execution (or the context manager exists in the non-deocrator case) the variable becomes `None` once again.






