### PR TITLE
add `Context` context manager

### DIFF
--- a/tests/test_utils/test_evals/test_evaluations.py
+++ b/tests/test_utils/test_evals/test_evaluations.py
@@ -147,6 +147,33 @@ class TestEvaluations(unittest.TestCase):
             [sorted(d.items()) for d in list2],
         )
 
+    def test_with_Context(self):
+        project = "my_project"
+        if project in unify.list_projects():
+            unify.delete_project(project)
+        unify.create_project(project)
+        unify.activate(project)
+
+        with unify.Context(context="random"):
+            log = unify.log(a="a")
+            with unify.Context(sys="sys"):
+                unify.add_log_entries(log.id, q="some q", r="some r")
+            with unify.Context(tool="tool"):
+                unify.add_log_entries(log.id, t="some t", b="some b")
+
+        expected = {
+            "context": "random",
+            "a": "a",
+            "q": "some q",
+            "t": "some t",
+            "b": "some b",
+            "r": "some r",
+            "sys": "sys",
+            "tool": "tool",
+        }
+        log = unify.get_logs()[0].entries
+        assert expected == log
+
 
 class TestAsyncEvaluations(unittest.IsolatedAsyncioTestCase):
     async def test_contextual_logging_async(self):

--- a/unify/utils/evaluations.py
+++ b/unify/utils/evaluations.py
@@ -16,8 +16,9 @@ from .helpers import _validate_api_key
 # --------#
 
 current_global_active_log = ContextVar("current_global_active_log", default=None)
-current_global_active_log_kwargs = ContextVar("current_global_active_kwargs", default={})
-
+current_global_active_log_kwargs = ContextVar(
+    "current_global_active_kwargs", default={}
+)
 
 
 def _get_and_maybe_create_project(project: str, api_key: Optional[str] = None) -> str:
@@ -637,6 +638,7 @@ class trace:
 
         return async_wrapper if inspect.iscoroutinefunction(fn) else wrapper
 
+
 class Context:
     def __init__(self, **kwargs):
         self.kwargs = kwargs
@@ -648,11 +650,8 @@ class Context:
 
     def __enter__(self):
         self.token = current_global_active_log_kwargs.set(
-            {
-                **current_global_active_log_kwargs.get(),
-                **self.kwargs
-            }
-              )
+            {**current_global_active_log_kwargs.get(), **self.kwargs}
+        )
         if unify.active_project:
             self.trace.__enter__()
 
@@ -662,4 +661,3 @@ class Context:
         # print("After clearing", current_global_active_log_kwargs.get())
         if unify.active_project:
             self.trace.__exit__()
-

--- a/unify/utils/evaluations.py
+++ b/unify/utils/evaluations.py
@@ -354,7 +354,10 @@ def log(
     created_log = Log(response.json(), api_key, **kwargs)
     if current_context_nest_level.get() > 0:
         current_logged_logs.set(
-            {**current_logged_logs.get(), created_log.id: list(current_global_active_log_kwargs.get().keys())}
+            {
+                **current_logged_logs.get(),
+                created_log.id: list(current_global_active_log_kwargs.get().keys()),
+            }
         )
     return created_log
 


### PR DESCRIPTION
usage:
```python
unify.activate("my_project")
with unify.Context(context="logs"):
  log_production_traffic()
with unify.Context(context="evals"):
  for name, system_promt in system_prompts:
    with unify.Context(system_prompt=system_prompt):
    for tool_config in tool_configs:
        with unify.Context(tool_config=tool_config):
          run_eval(system_prompt, tool_config)
```
`unify.log(...)` calls within a context manager (no matter how deeply nested it is) will log whatever context the encompassing context managers include, e.g any call within `log_production_traffic` will have `context="logs"`, with every `Log` created within the function.