### PR TITLE
Promote staging to main

### DIFF
--- a/deploy/integrations/bootstrap.production.toml
+++ b/deploy/integrations/bootstrap.production.toml
@@ -17,6 +17,11 @@ mode = "full"
 tool_limit_per_app = 0
 include_all_managed_apps = true
 create_auth_configs = false
+# Operational one-off resync directive (NOT part of the desired-state hash):
+# set true to bypass the manifest-hash and per-unit/checkpoint skips and rewrite
+# every app/tool row (e.g. after a catalog schema or embedding-text change), then
+# set back to false. Leaving it true keeps forcing a full resync on every deploy.
+force = false
 
 [providers.pipedream]
 status = "disabled"

--- a/deploy/integrations/bootstrap.staging.toml
+++ b/deploy/integrations/bootstrap.staging.toml
@@ -17,6 +17,11 @@ mode = "full"
 tool_limit_per_app = 0
 include_all_managed_apps = true
 create_auth_configs = false
+# Operational one-off resync directive (NOT part of the desired-state hash):
+# set true to bypass the manifest-hash and per-unit/checkpoint skips and rewrite
+# every app/tool row (e.g. after a catalog schema or embedding-text change), then
+# set back to false. Leaving it true keeps forcing a full resync on every deploy.
+force = false
 
 [providers.pipedream]
 status = "disabled"

--- a/deploy/integrations/bootstrap.staging.toml
+++ b/deploy/integrations/bootstrap.staging.toml
@@ -21,7 +21,7 @@ create_auth_configs = false
 # set true to bypass the manifest-hash and per-unit/checkpoint skips and rewrite
 # every app/tool row (e.g. after a catalog schema or embedding-text change), then
 # set back to false. Leaving it true keeps forcing a full resync on every deploy.
-force = true
+force = false
 
 [providers.pipedream]
 status = "disabled"

--- a/deploy/integrations/bootstrap.staging.toml
+++ b/deploy/integrations/bootstrap.staging.toml
@@ -21,7 +21,7 @@ create_auth_configs = false
 # set true to bypass the manifest-hash and per-unit/checkpoint skips and rewrite
 # every app/tool row (e.g. after a catalog schema or embedding-text change), then
 # set back to false. Leaving it true keeps forcing a full resync on every deploy.
-force = false
+force = true
 
 [providers.pipedream]
 status = "disabled"

--- a/droid/function_manager/builtins_catalog.py
+++ b/droid/function_manager/builtins_catalog.py
@@ -58,36 +58,68 @@ def _ensure_catalog_storage(project: str) -> None:
     )
 
 
-def _delete_rows_for_managers(project: str, class_paths: List[str]) -> None:
-    if not class_paths:
-        return
-    filter_expr = " or ".join(
-        f'primitive_class == "{class_path}"' for class_path in class_paths
-    )
-    logs = unify.get_logs(
+def _read_existing_rows(project: str) -> List[Any]:
+    """Return all stored primitive rows (entries + log id) for reconciliation."""
+    return unify.get_logs(
         project=project,
         context=BUILTINS_PRIMITIVES_CONTEXT,
-        filter=filter_expr,
         exclude_fields=list_private_fields(
             BUILTINS_PRIMITIVES_CONTEXT,
             project=project,
         ),
     )
-    if logs:
-        unify.delete_logs(
-            project=project,
-            context=BUILTINS_PRIMITIVES_CONTEXT,
-            logs=[log.id for log in logs],
-        )
 
 
-def _insert_rows(project: str, rows: List[Dict[str, Any]]) -> None:
+def _name_prefix(manager_alias: str) -> str:
+    """Stable, brand-independent name prefix for a manager's primitives.
+
+    Primitive names are ``primitives.{alias}.{method}`` and the alias never
+    changes when the implementing package or class path is renamed/moved.
+    Using this prefix to scope deletes keeps reconciliation robust to such
+    refactors (e.g. a package rename that shifts ``primitive_class``).
+    """
+    return f"primitives.{manager_alias}."
+
+
+def _replace_rows(
+    project: str,
+    rows: List[Dict[str, Any]],
+    *,
+    existing: List[Any],
+    name_prefixes: List[str],
+) -> None:
+    """Upsert *rows* keyed on the stable ``function_id`` unique key.
+
+    Deletes any stored row that either collides on a ``function_id`` we are
+    about to write or belongs to a pending manager (matched by the stable
+    ``name`` prefix), then inserts the fresh rows. Keying the replace on
+    ``function_id`` -- the context's unique key -- rather than the branded
+    ``primitive_class`` path makes seeding idempotent across package renames:
+    a stale row written under an old class path is still removed before the
+    new row is inserted, so the insert never trips the unique-key constraint.
+    """
     if not rows:
         return
     entries = [
         Function.model_validate(data).model_dump(include=set(data.keys()))
         for data in rows
     ]
+    desired_ids = {entry["function_id"] for entry in entries}
+    stale_ids = [
+        log.id
+        for log in existing
+        if log.entries.get("function_id") in desired_ids
+        or any(
+            str(log.entries.get("name") or "").startswith(prefix)
+            for prefix in name_prefixes
+        )
+    ]
+    if stale_ids:
+        unify.delete_logs(
+            project=project,
+            context=BUILTINS_PRIMITIVES_CONTEXT,
+            logs=stale_ids,
+        )
     unify.create_logs(
         project=project,
         context=BUILTINS_PRIMITIVES_CONTEXT,
@@ -99,10 +131,14 @@ def _insert_rows(project: str, rows: List[Dict[str, Any]]) -> None:
 def seed_builtin_primitives(*, project: str | None = None) -> bool:
     """Seed the global builtins catalogue with every manager's primitives.
 
-    Idempotent and hash-guarded per manager: only managers whose primitive
-    surface (name/argspec/docstring) changed are deleted and re-inserted.
-    Always ensures the ``embedding_text`` vector column exists so read-only
-    consumers can run ranked semantic search without any write access.
+    Idempotent and reconciled per manager. A manager is re-materialized when
+    its public surface hash (name/argspec/docstring) changed, or when its
+    stored rows have drifted from the current shape -- missing, or written
+    under a stale ``primitive_class`` (e.g. after a package rename). Rows are
+    upserted on the stable ``function_id`` unique key, so re-seeding never
+    collides even when the branded class path changes. Always ensures the
+    ``embedding_text`` vector column exists so read-only consumers can run
+    ranked semantic search without any write access.
 
     Returns True when any rows were written, False when already up to date.
     """
@@ -125,28 +161,45 @@ def seed_builtin_primitives(*, project: str | None = None) -> bool:
         len(manager_aliases),
         len(current_hashes),
     )
+    existing_rows = _read_existing_rows(project)
+    existing_by_id = {log.entries.get("function_id"): log for log in existing_rows}
+
     pending: List[Tuple[str, List[Dict[str, Any]], str]] = []
     for manager_alias in manager_aliases:
         expected_hash = registry.compute_hash_for_manager(manager_alias)
-        if current_hashes.get(manager_alias) == expected_hash:
-            continue
         rows = list(
             registry.collect_primitives(PrimitiveScope.single(manager_alias)).values(),
         )
-        pending.append((manager_alias, rows, expected_hash))
+        # Re-materialize when the public surface changed (hash) OR when stored
+        # rows have drifted from the current shape: missing entirely, or stored
+        # under a stale ``primitive_class`` (e.g. after a package rename). The
+        # hash deliberately omits ``primitive_class`` (it tracks only the public
+        # name/argspec/docstring surface), so class-path drift is detected here
+        # to keep the read-time ``primitive_class`` scoping filter accurate.
+        needs_seed = current_hashes.get(manager_alias) != expected_hash
+        if not needs_seed:
+            for row in rows:
+                stored = existing_by_id.get(row["function_id"])
+                if stored is None or stored.entries.get("primitive_class") != row.get(
+                    "primitive_class",
+                ):
+                    needs_seed = True
+                    break
+        if needs_seed:
+            pending.append((manager_alias, rows, expected_hash))
 
     if pending:
-        changed_class_paths = []
-        for manager_alias, _, _ in pending:
-            spec = registry.get_manager_spec(manager_alias)
-            if spec:
-                changed_class_paths.append(spec.primitive_class_path)
-        _delete_rows_for_managers(project, changed_class_paths)
-
         all_rows: List[Dict[str, Any]] = []
-        for _, rows, _ in pending:
+        name_prefixes: List[str] = []
+        for manager_alias, rows, _ in pending:
+            name_prefixes.append(_name_prefix(manager_alias))
             all_rows.extend(rows)
-        _insert_rows(project, all_rows)
+        _replace_rows(
+            project,
+            all_rows,
+            existing=existing_rows,
+            name_prefixes=name_prefixes,
+        )
 
         new_hashes = dict(current_hashes)
         for manager_alias, _, expected_hash in pending:

--- a/droid/function_manager/function_manager.py
+++ b/droid/function_manager/function_manager.py
@@ -83,6 +83,7 @@ from droid.integrations.function_metadata import (
     provider_function_metadata,
 )
 from droid.integrations.builtins_catalog import list_catalog_tools
+from droid.integrations.embedding_text import normalize_embedding_text
 from .custom_functions import (
     compute_custom_functions_hash,
     compute_custom_venvs_hash,
@@ -2124,37 +2125,37 @@ class FunctionManager(BaseFunctionManager):
     @staticmethod
     def _integration_embedding_text(
         *,
-        name: str,
-        signature: str,
-        app: str,
-        tool: str,
+        app_display: str,
+        tool_display: str,
+        tool_name: str,
         description: str,
+        category_text: str,
         input_schema: Dict[str, Any],
-        examples: list[Any],
+        example_prompts: list[Any] | None = None,
     ) -> str:
+        """Build Layer 1-normalized tool embedding text from value fields only.
+
+        Front-loaded by signal: the app/tool header, the identifier-split
+        tool-name leaf (keyword anchor), the description, harvested categories,
+        parameter names, and any example prompts. The dotted function name,
+        argspec, and raw JSON example dump are intentionally dropped;
+        ``normalize_embedding_text`` then strips noise and splits identifiers
+        across the whole text. Mirrors the Orchestra tool row builder.
+        """
+
         properties, _required = FunctionManager._integration_schema_properties(
             input_schema,
         )
         parameter_names = ", ".join(str(key) for key in properties.keys())
-        example_terms: list[str] = []
-        for example in examples:
-            if isinstance(example, dict):
-                text = json.dumps(example, sort_keys=True)
-                example_terms.append(text)
-            if len(example_terms) >= 2:
-                break
         parts = [
-            f"Function Name: {name}",
-            f"Signature: {signature}",
-            f"App: {app}",
-            f"Tool: {tool}",
-            f"Purpose: {description}",
+            f"{app_display} - {tool_display}",
+            tool_name,
+            description,
+            category_text,
+            parameter_names,
         ]
-        if parameter_names:
-            parts.append(f"Parameters: {parameter_names}")
-        if example_terms:
-            parts.append(f"Examples: {'; '.join(example_terms)}")
-        return "\n".join(parts)
+        parts.extend(str(prompt) for prompt in (example_prompts or []) if prompt)
+        return normalize_embedding_text(parts)
 
     def _integration_tool_to_function_row(self, item: Dict[str, Any]) -> Dict[str, Any]:
         tool_id = item["tool_id"]
@@ -2212,14 +2213,24 @@ class FunctionManager(BaseFunctionManager):
             "Use the approved confirmation flow for sensitive, write, destructive, "
             "or bulk-export actions."
         )
+        tool_leaf = name.rsplit(".", 1)[-1]
+        item_app_slug = item.get("app_slug")
+        tag_categories = [
+            tag for tag in (item.get("tags") or []) if tag and tag != item_app_slug
+        ]
+        category_text = ", ".join(
+            dict.fromkeys(
+                value for value in (item.get("category"), *tag_categories) if value
+            ),
+        )
         embedding_text = self._integration_embedding_text(
-            name=name,
-            signature=signature,
-            app=str(app),
-            tool=str(tool),
+            app_display=str(app),
+            tool_display=str(tool),
+            tool_name=tool_leaf,
             description=str(item.get("description") or ""),
+            category_text=category_text,
             input_schema=input_schema,
-            examples=examples,
+            example_prompts=example_prompts,
         )
         metadata = provider_function_metadata(
             {
@@ -2267,7 +2278,9 @@ class FunctionManager(BaseFunctionManager):
             or name.replace(".", "__"),
             "metadata": metadata,
         }
-        return Function.model_validate(row).model_dump(include=set(row.keys()))
+        validated = Function.model_validate(row).model_dump(include=set(row.keys()))
+        validated["description"] = str(item.get("description") or "")
+        return validated
 
     def _function_context_for_root(self, root_context: str, table_name: str) -> str:
         """Return a concrete Functions context under a registry root."""

--- a/droid/gateway/channels/whatsapp/views.py
+++ b/droid/gateway/channels/whatsapp/views.py
@@ -599,7 +599,7 @@ async def create_whatsapp_sender(request: Request):
         "sender_id": f"whatsapp:{phone_number}",
         "profile": {
             "name": data.get("name", "Unify Assistant"),
-            "logo_url": "https://console.unify.ai/ivy_logo_only.png",
+            "logo_url": "https://console.unify.ai/icon.png",
         },
         "webhook": {
             "callback_method": "POST",

--- a/droid/integrations/builtins_catalog.py
+++ b/droid/integrations/builtins_catalog.py
@@ -19,6 +19,10 @@ from droid.common.embed_utils import ensure_vector_column, list_private_fields
 from droid.common.semantic_search import fetch_top_k_by_terms_combined_client_side
 from droid.function_manager.hash_utils import stable_hash_for_rows
 from droid.function_manager.types.function import Function
+from droid.integrations.embedding_text import (
+    humanize_auth_modes,
+    normalize_embedding_text,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -108,6 +112,48 @@ def _ensure_catalog_embeddings_once(project: str) -> None:
     _ENSURED_EMBEDDING_PROJECTS.add(project)
 
 
+def _harvest_category_names(
+    *,
+    category: Any,
+    raw_metadata: Dict[str, Any],
+) -> List[str]:
+    """Collect category names from the canonical field plus raw provider metadata.
+
+    The canonical ``category`` is the primary; additional names are recovered
+    best-effort from the provider's own catalog metadata so multi-category apps
+    contribute richer retrieval signal. Provider-neutral: it probes the common
+    metadata containers and tolerates both ``{"name": ...}`` dicts and strings.
+    """
+
+    names: List[str] = []
+    lowered: set[str] = set()
+
+    def add(value: Any) -> None:
+        text = str(value or "").strip()
+        if text and text.lower() not in lowered:
+            lowered.add(text.lower())
+            names.append(text)
+
+    add(category)
+    if isinstance(raw_metadata, dict):
+        for container_key in ("raw_toolkit_detail", "raw_toolkit", "raw_app"):
+            container = raw_metadata.get(container_key)
+            if not isinstance(container, dict):
+                continue
+            meta = container.get("meta")
+            categories = (
+                meta.get("categories") if isinstance(meta, dict) else None
+            ) or container.get("categories")
+            if not isinstance(categories, list):
+                continue
+            for entry in categories:
+                if isinstance(entry, dict):
+                    add(entry.get("name") or entry.get("slug") or entry.get("id"))
+                else:
+                    add(entry)
+    return names
+
+
 def app_catalog_row(
     app: Dict[str, Any],
     *,
@@ -125,22 +171,22 @@ def app_catalog_row(
         app.get("available_scopes") or app.get("available_scopes_json") or []
     )
     recommended_scopes = app.get("recommended_scopes") or []
+    api_key_schema = app.get("api_key_schema") or app.get("api_key_schema_json")
     category = app.get("category")
-    embedding_text = "\n".join(
-        part
-        for part in (
-            f"Integration App: {display_name}",
-            f"Slug: {slug}",
-            f"Source: {source_type}",
-            f"Category: {category}" if category else "",
-            f"Description: {description}" if description else "",
-            (
-                f"Scopes: {', '.join(str(scope) for scope in available_scopes)}"
-                if available_scopes
-                else ""
-            ),
-        )
-        if part
+    raw_metadata = (
+        app.get("raw_provider_metadata") or app.get("raw_provider_metadata_json") or {}
+    )
+    categories_text = ", ".join(
+        _harvest_category_names(category=category, raw_metadata=raw_metadata),
+    )
+    embedding_text = normalize_embedding_text(
+        [
+            display_name,
+            description,
+            categories_text,
+            humanize_auth_modes(auth_modes),
+            slug,
+        ],
     )
     return {
         "app_id": _stable_int_id("integration_app", f"{backend_id}:{slug}"),
@@ -154,6 +200,7 @@ def app_catalog_row(
         "auth_modes": auth_modes,
         "available_scopes": available_scopes,
         "recommended_scopes": recommended_scopes,
+        "api_key_schema": api_key_schema,
         "tool_count": int(app.get("tool_count") or 0),
         "source_type": source_type,
         "source_label": app.get("source_label")
@@ -196,6 +243,21 @@ def tool_catalog_row(
     return FunctionManager.__new__(
         FunctionManager,
     )._integration_tool_to_function_row(tool)
+
+
+def _materialize_tool_row(row: Dict[str, Any]) -> Dict[str, Any]:
+    """Validate a catalog tool row, preserving catalog-only extra fields.
+
+    ``description`` is a catalog-row field (mirroring the Orchestra tool row) that
+    has no representation on the universal ``Function`` model, so it is re-applied
+    after validation rather than widening the shared model for an
+    integration-only concern.
+    """
+
+    validated = Function.model_validate(row).model_dump(include=set(row.keys()))
+    if "description" in row:
+        validated["description"] = row["description"]
+    return validated
 
 
 def _unit_hash(rows: Iterable[Dict[str, Any]], *, fields: tuple[str, ...]) -> str:
@@ -374,7 +436,7 @@ def seed_builtin_integrations(
         app_catalog_row(app, default_backend_id=seed_backend_id) for app in apps
     ]
     tool_rows = [
-        Function.model_validate(row).model_dump(include=set(row.keys()))
+        _materialize_tool_row(row)
         for row in (
             tool_catalog_row(tool, default_backend_id=seed_backend_id) for tool in tools
         )
@@ -426,6 +488,7 @@ def seed_builtin_integrations(
                 fields=(
                     "function_id",
                     "name",
+                    "description",
                     "argspec",
                     "docstring",
                     "embedding_text",
@@ -582,6 +645,7 @@ def list_catalog_apps(
                 "auth_modes",
                 "available_scopes",
                 "recommended_scopes",
+                "api_key_schema",
                 "tool_count",
                 "source_type",
                 "source_label",

--- a/droid/integrations/embedding_text.py
+++ b/droid/integrations/embedding_text.py
@@ -1,0 +1,92 @@
+"""Deterministic Layer 1 embedding-text normalization for integration catalog rows.
+
+This is integration-scoped only: it normalizes the ``embedding_text`` produced by
+the integration app/tool row builders and must NOT be imported by the shared
+semantic-search infrastructure or any other state manager's embedding text.
+
+The transform is deterministic, label-free, and uses no LLM. It cleans and
+recombines content that already exists in the canonical catalog fields so the
+pooled embedding vector is dominated by signal rather than scaffolding noise
+(dotted identifiers, argspecs, raw JSON, scope URLs, constant ``Field:`` labels).
+
+This module is duplicated byte-for-byte in the orchestra integration layer
+(``orchestra/orchestra/services/integration_embedding_text.py``) so that the
+manifest (Orchestra) and self-host (droid) paths emit identical vectors for the
+same input row.
+"""
+
+from __future__ import annotations
+
+import re
+
+_URL_RE = re.compile(r"https?://\S+")
+_STRUCTURAL_RE = re.compile(r"[{}\[\]\"`|]")
+_CAMEL_BOUNDARY_RE = re.compile(r"(?<=[a-z0-9])(?=[A-Z])")
+_UNDERSCORE_SLASH_RE = re.compile(r"(?<=\w)[_/](?=\w)")
+_INNER_DOT_RE = re.compile(r"(?<=[A-Za-z0-9])\.(?=[A-Za-z0-9])")
+_WHITESPACE_RE = re.compile(r"\s+")
+
+_AUTH_MODE_LABELS = {
+    "api_key": "API key",  # pragma: allowlist secret
+    "oauth": "OAuth",
+    "custom": "Custom",
+}
+
+
+def _split_identifier_token(token: str) -> str:
+    """Split a single token if it is an identifier; otherwise return it unchanged.
+
+    Splits on internal ``_`` / ``/`` separators, inner ``.`` between alphanumerics,
+    and camelCase boundaries. Trailing sentence punctuation (e.g. ``action.``) and
+    prose hyphens (e.g. ``commission-free``) are preserved. Identifier tokens are
+    lowercased; ordinary words and acronyms (``API``, ``OAuth``) are left intact.
+    """
+
+    core = _UNDERSCORE_SLASH_RE.sub(" ", token)
+    core = _INNER_DOT_RE.sub(" ", core)
+    core = _CAMEL_BOUNDARY_RE.sub(" ", core)
+    if core != token:
+        return core.lower()
+    return token
+
+
+def _normalize_line(text: str) -> str:
+    text = _URL_RE.sub(" ", text)
+    text = _STRUCTURAL_RE.sub(" ", text)
+    tokens = (_split_identifier_token(token) for token in text.split(" ") if token)
+    return _WHITESPACE_RE.sub(" ", " ".join(tokens)).strip()
+
+
+def normalize_embedding_text(parts: list[str]) -> str:
+    """Normalize and recombine field values into clean embedding text.
+
+    Each part is URL/structural-noise stripped, identifier-split, and
+    whitespace-collapsed. Empty parts are dropped and exact duplicate lines are
+    removed (preserving first-occurrence order) so the pooled vector is not
+    diluted by repeated scaffolding.
+    """
+
+    lines: list[str] = []
+    seen: set[str] = set()
+    for part in parts:
+        if not part:
+            continue
+        for raw_line in str(part).split("\n"):
+            line = _normalize_line(raw_line)
+            if not line or line in seen:
+                continue
+            seen.add(line)
+            lines.append(line)
+    return "\n".join(lines)
+
+
+def humanize_auth_modes(auth_modes: list[str] | None) -> str:
+    """Render canonical auth-mode ids as a human, embedding-friendly string."""
+
+    labels: list[str] = []
+    for mode in auth_modes or []:
+        key = str(mode).strip().lower()
+        label = _AUTH_MODE_LABELS.get(key, key.replace("_", " ").title())
+        if label and label not in labels:
+            labels.append(label)
+    return ", ".join(labels)

--- a/droid/integrations/primitives.py
+++ b/droid/integrations/primitives.py
@@ -874,6 +874,24 @@ class IntegrationPrimitives:
         multiple connected accounts, review the account the user named or ask
         which account they mean before changing permissions.
 
+        Parameters
+        ----------
+        connection_id : str
+            Identifier of the connected integration account to review, e.g.
+            ``"ic_work"``. Scopes the returned policy to that one account.
+        owner_scope : str, optional
+            Effective connection owner lane. Defaults to the current session's
+            owner scope, usually ``"assistant"``. Use ``"org"``, ``"team"``,
+            or ``"user"`` when explicitly operating at that scope.
+        org_id : int, optional
+            Organization identifier for org-scoped or inherited connections.
+        team_id : int, optional
+            Team identifier for team-scoped connections.
+        user_id : str, optional
+            User identifier for user-scoped connections.
+        assistant_id : int, optional
+            Assistant identifier for assistant-scoped connections.
+
         Examples
         --------
         - ``await primitives.integrations.review_tool_permissions(connection_id="ic_work")``
@@ -921,6 +939,37 @@ class IntegrationPrimitives:
         - ``auto`` means allow this tool for this account without asking first.
         - ``specific_approval`` means ask every time for this account.
         - ``forbidden`` means block this tool for this account.
+
+        Parameters
+        ----------
+        connection_id : str
+            Identifier of the connected integration account to change, e.g.
+            ``"ic_work"``. All changes are scoped to this one account.
+        tool_policies : dict[str, str], optional
+            Per-tool approval levels keyed by fully-qualified tool id, e.g.
+            ``{"composio:gmail:list_labels": "auto"}``. Values are ``auto``,
+            ``specific_approval``, or ``forbidden``.
+        bulk_approval_level : str, optional
+            Approval level to apply in bulk (``auto``, ``specific_approval``,
+            or ``forbidden``), typically combined with ``action_classes``.
+        action_classes : list[str], optional
+            Action classes the bulk change targets, e.g. ``["write"]`` or
+            ``["read", "write"]``.
+        reset_to_defaults : bool, default False
+            When True, discard custom policy for the account and restore the
+            backend defaults.
+        owner_scope : str, optional
+            Effective connection owner lane. Defaults to the current session's
+            owner scope, usually ``"assistant"``. Use ``"org"``, ``"team"``,
+            or ``"user"`` when explicitly operating at that scope.
+        org_id : int, optional
+            Organization identifier for org-scoped or inherited connections.
+        team_id : int, optional
+            Team identifier for team-scoped connections.
+        user_id : str, optional
+            User identifier for user-scoped connections.
+        assistant_id : int, optional
+            Assistant identifier for assistant-scoped connections.
 
         Examples
         --------
@@ -980,6 +1029,44 @@ class IntegrationPrimitives:
         After approval, retry the original tool with the same original
         arguments and the returned ``confirmation_token`` or
         ``approval_audit_id``. Do not start a fresh unrelated tool call.
+
+        Parameters
+        ----------
+        audit_id : int
+            Identifier of the pending execution audit returned alongside the
+            tool's ``pending_approval`` response.
+        decision : str
+            ``"approve"`` to allow the pending execution or ``"deny"`` to block
+            it.
+        scope : str, default "once"
+            Breadth of the decision. ``"once"`` affects only this audit;
+            ``"tool"`` applies to future calls of the same tool when combined
+            with ``persist_policy``.
+        persist_policy : bool, default False
+            When True, also update the connected account's durable policy. Set
+            only when the user explicitly asks to change future behavior.
+        approval_level : str, default "auto"
+            Durable level to persist when ``persist_policy`` is True (``auto``,
+            ``specific_approval``, or ``forbidden``). For denials, ``auto`` is
+            mapped to ``forbidden``.
+        actor_id : str, optional
+            Identifier of the principal recording the decision, for audit.
+        reason : str, optional
+            Human-readable justification, most useful when denying.
+        expires_at : str, optional
+            ISO-8601 timestamp after which a persisted approval lapses.
+        owner_scope : str, optional
+            Effective connection owner lane. Defaults to the current session's
+            owner scope, usually ``"assistant"``. Use ``"org"``, ``"team"``,
+            or ``"user"`` when explicitly operating at that scope.
+        org_id : int, optional
+            Organization identifier for org-scoped or inherited connections.
+        team_id : int, optional
+            Team identifier for team-scoped connections.
+        user_id : str, optional
+            User identifier for user-scoped connections.
+        assistant_id : int, optional
+            Assistant identifier for assistant-scoped connections.
 
         Examples
         --------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,6 @@ dev = [
 include = ["droid", "droid.*"]
 
 [tool.uv.sources]
-unify = { git = "https://github.com/unifyai/unify.git", branch = "staging" }
-unillm = { git = "https://github.com/unifyai/unillm.git", branch = "staging" }
+unify = { path = "../unify", editable = true }
+unillm = { path = "../unillm", editable = true }
 en-core-web-sm = { url = "https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl" }

--- a/scripts/seed_builtins_catalog.py
+++ b/scripts/seed_builtins_catalog.py
@@ -75,6 +75,7 @@ class ProviderBootstrapPlan(NamedTuple):
     desired_config: dict[str, Any]
     backend_payload: dict[str, Any]
     sync_payload: dict[str, Any] | None
+    force: bool = False
 
 
 def _json_dumps(value: Any) -> str:
@@ -103,6 +104,17 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
         default=os.environ.get("DROID_SKIP_BUILTINS_INTEGRATIONS", "").lower()
         in {"1", "true", "yes"},
         help="Seed only primitives and guidance; integration bootstrap is handled elsewhere.",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        default=os.environ.get("DROID_INTEGRATION_BOOTSTRAP_FORCE", "").lower()
+        in {"1", "true", "yes", "on"},
+        help=(
+            "Force a full integration resync: bypass the manifest-hash bootstrap-state "
+            "skip and the server-side per-unit hash/checkpoint skips so every app and "
+            "tool row is rewritten. Defaults to DROID_INTEGRATION_BOOTSTRAP_FORCE."
+        ),
     )
     return parser.parse_args(argv)
 
@@ -219,6 +231,11 @@ def _provider_plan(
                 f"{backend_id}-{desired_hash[:12]}"
             ),
         }
+    # ``force`` is an operational resync directive, not desired state: it is read
+    # from the manifest but deliberately excluded from ``desired_config``/
+    # ``desired_hash`` so toggling it never churns the bootstrap-state hash. Its
+    # only effects are bypassing the manifest-state and per-unit/checkpoint skips.
+    force = bool((config.get("sync") or {}).get("force", False))
     return ProviderBootstrapPlan(
         backend_id=backend_id,
         environment=environment,
@@ -226,6 +243,7 @@ def _provider_plan(
         desired_config=desired_config,
         backend_payload=backend_payload,
         sync_payload=sync_payload,
+        force=force,
     )
 
 
@@ -524,6 +542,7 @@ def _builtins_sync_request_payload(
     *,
     plan: ProviderBootstrapPlan,
     sync_payload: dict[str, Any],
+    force: bool = False,
 ) -> dict[str, Any]:
     return {
         "backend_id": plan.backend_id,
@@ -535,6 +554,7 @@ def _builtins_sync_request_payload(
         "app_slugs": list(sync_payload.get("app_slugs") or []),
         "prune_unlisted_apps": _effective_prune(sync_payload),
         "sync_payload": sync_payload,
+        "force": force,
         "batch_size": int(
             os.environ.get(
                 "DROID_INTEGRATION_BOOTSTRAP_BATCH_SIZE",
@@ -623,15 +643,21 @@ def _sync_and_seed_provider(
     plan: ProviderBootstrapPlan,
     sync_payload: dict[str, Any],
     executor: str = "api",
+    force: bool = False,
 ) -> tuple[bool, dict[str, Any]]:
     logging.info(
-        "Starting Builtins integrations artifact seed backend=%s environment=%s mode=%s executor=%s",
+        "Starting Builtins integrations artifact seed backend=%s environment=%s mode=%s executor=%s force=%s",
         plan.backend_id,
         plan.environment,
         sync_payload.get("sync_mode"),
         executor,
+        force,
     )
-    payload = _builtins_sync_request_payload(plan=plan, sync_payload=sync_payload)
+    payload = _builtins_sync_request_payload(
+        plan=plan,
+        sync_payload=sync_payload,
+        force=force,
+    )
     if executor == "api":
         result = _run_api_executor(
             base_url=base_url,
@@ -677,12 +703,14 @@ def _sync_integration_bootstrap_manifest(
     manifest_path: str,
     base_url: str,
     admin_key: str,
+    force: bool = False,
 ) -> bool:
     manifest = _load_manifest(manifest_path)
     logging.info(
-        "Starting integration bootstrap manifest path=%s providers=%s",
+        "Starting integration bootstrap manifest path=%s providers=%s force=%s",
         manifest_path,
         len(manifest["providers"]),
+        force,
     )
     changed = False
     for backend_id, config in sorted(manifest["providers"].items()):
@@ -694,12 +722,14 @@ def _sync_integration_bootstrap_manifest(
             config=config,
         )
         executor = _integration_bootstrap_executor(plan.environment)
+        provider_force = force or plan.force
         logging.info(
-            "Checking integration bootstrap state backend=%s environment=%s desired_hash=%s executor=%s",
+            "Checking integration bootstrap state backend=%s environment=%s desired_hash=%s executor=%s force=%s",
             plan.backend_id,
             plan.environment,
             plan.desired_hash,
             executor,
+            provider_force,
         )
         state = _bootstrap_state(
             base_url=base_url,
@@ -707,7 +737,12 @@ def _sync_integration_bootstrap_manifest(
             environment=plan.environment,
             backend_id=plan.backend_id,
         )
-        if _bootstrap_state_matches(state=state, plan=plan):
+        if provider_force:
+            logging.info(
+                "Forcing integration bootstrap backend=%s; bypassing manifest-hash skip",
+                backend_id,
+            )
+        elif _bootstrap_state_matches(state=state, plan=plan):
             logging.info(
                 "Skipping integration bootstrap backend=%s; manifest hash already seeded",
                 backend_id,
@@ -748,6 +783,7 @@ def _sync_integration_bootstrap_manifest(
                 plan=plan,
                 sync_payload=plan.sync_payload,
                 executor=executor,
+                force=provider_force,
             )
             logging.info(
                 "Completed integration bootstrap sync backend=%s status=%s "
@@ -813,6 +849,7 @@ def main(argv: list[str] | None = None) -> int:
             manifest_path=args.integration_bootstrap_manifest,
             base_url=base_url,
             admin_key=args.admin_key,
+            force=args.force,
         )
     else:
         integrations_changed = seed_builtin_integrations()

--- a/tests/conversation_manager/core/test_brain.py
+++ b/tests/conversation_manager/core/test_brain.py
@@ -93,6 +93,8 @@ def _make_cm():
         assistant_slack_bot_user_id="",
         assistant_has_teams=False,
         team_summaries=[],
+        coordinator_onboarding_deferred=False,
+        coordinator_onboarding_render=None,
     )
 
 
@@ -161,6 +163,8 @@ class TestBrainSpecStateMessage:
             assistant_slack_bot_user_id="",
             assistant_has_teams=False,
             team_summaries=[],
+            coordinator_onboarding_deferred=False,
+            coordinator_onboarding_render=None,
         )
         snapshot_state = SimpleNamespace(full_render="<state>ready</state>")
 

--- a/tests/conversation_manager/core/test_event_handlers.py
+++ b/tests/conversation_manager/core/test_event_handlers.py
@@ -481,6 +481,7 @@ class TestTextMessageHandlers:
 
         mock_cm.request_llm_run.assert_called_once_with(
             triggering_contact_id=2,
+            credit_gate_reply_context={"medium": "sms_message", "contact_id": 2},
         )
 
     @pytest.mark.asyncio
@@ -1660,7 +1661,7 @@ class TestMeetInteractionEventHandlers:
         import json as _json
 
         data = _json.loads(guidance_calls[0].args[1])
-        content = data.get("payload", {}).get("content", "")
+        content = data.get("payload", {}).get("message", "")
         assert "screen sharing" in content.lower()
 
     @pytest.mark.asyncio
@@ -1733,7 +1734,7 @@ class TestMeetInteractionEventHandlers:
         import json
 
         event_data = json.loads(event_json)
-        content = event_data.get("payload", {}).get("content", "")
+        content = event_data.get("payload", {}).get("message", "")
         assert "screen sharing is now on" in content.lower()
 
     @pytest.mark.asyncio
@@ -2135,9 +2136,24 @@ class TestTaskDueEventHandlers:
             schedule=Schedule(start_at="2026-04-10T09:00:00+00:00"),
             repeat=[RepeatPattern(frequency=Frequency.DAILY)],
         )["details"]["task_id"]
+        # The real scheduler resolves the activation's source task by its
+        # log id (the delegate contract this test exercises), so use the
+        # actual scheduled instance's log id rather than a fabricated value.
+        # The log id lives on the store row (``unify.Log.id``), not on the
+        # sanitized ``Task`` returned by ``_filter_tasks``.
+        source_task_log_id = None
+        for _ctx in scheduler._read_task_contexts():
+            _rows = scheduler._store_for_task_context(_ctx).get_rows(
+                filter=f"task_id == {task_id}",
+                return_ids_only=False,
+            )
+            if _rows:
+                source_task_log_id = int(_rows[0].id)
+                break
+        assert source_task_log_id is not None
         event = TaskDue(
             task_id=task_id,
-            source_task_log_id=555,
+            source_task_log_id=source_task_log_id,
             activation_revision="rev-1",
             scheduled_for="2026-04-10T09:00:00+00:00",
             task_label="Scheduled integration report",
@@ -2146,7 +2162,7 @@ class TestTaskDueEventHandlers:
             assistant_id="42",
             activation_key=f"42:{task_id}",
             task_id=task_id,
-            source_task_log_id=555,
+            source_task_log_id=source_task_log_id,
             activation_revision="rev-1",
             task_name="Scheduled integration report",
         )
@@ -2163,7 +2179,7 @@ class TestTaskDueEventHandlers:
                 task_id=task_id,
                 source_type="scheduled",
                 execution_mode="live",
-                source_task_log_id=555,
+                source_task_log_id=source_task_log_id,
                 activation_revision="rev-1",
                 scheduled_for="2026-04-10T09:00:00+00:00",
                 task_name="Scheduled integration report",
@@ -2315,11 +2331,11 @@ class TestTaskDueEventHandlers:
         assert channel == "app:call:notification"
         guidance = FastBrainNotification.from_json(payload)
         assert guidance.should_speak is False
-        assert "Morning briefing" in guidance.content
+        assert "Morning briefing" in guidance.message
         assert (
-            "Prepare the morning update before the user checks in" in guidance.content
+            "Prepare the morning update before the user checks in" in guidance.message
         )
-        assert "silent action unless the user is needed" in guidance.content
+        assert "silent action unless the user is needed" in guidance.message
 
     @pytest.mark.asyncio
     async def test_task_due_ignores_stale_activation(self, mock_cm):
@@ -2518,7 +2534,7 @@ class TestInitializationCompleteHandler:
         notification = FastBrainNotification.from_json(payload)
         assert notification.should_speak is False
         assert notification.source == "initialization"
-        assert "Initialization complete" in notification.content
+        assert "Initialization complete" in notification.message
 
 
 class TestTriggeredTaskNotifications:
@@ -2650,7 +2666,10 @@ class TestTriggeredTaskNotifications:
         assert remembered.source_medium == "sms_message"
         assert remembered.attempt_token
         mock_offline_dispatch.assert_called_once()
-        mock_cm.request_llm_run.assert_called_once_with(triggering_contact_id=2)
+        mock_cm.request_llm_run.assert_called_once_with(
+            triggering_contact_id=2,
+            credit_gate_reply_context={"medium": "sms_message", "contact_id": 2},
+        )
 
     @pytest.mark.asyncio
     async def test_inbound_call_dispatches_offline_triggers_without_live_notification(
@@ -2793,9 +2812,9 @@ class TestTriggeredTaskNotifications:
         assert channel == "app:call:notification"
         guidance = FastBrainNotification.from_json(payload)
         assert guidance.should_speak is False
-        assert "Handle VIP caller" in guidance.content
-        assert "Prioritize urgent inbound calls from Alice" in guidance.content
-        assert "Do not mention the task unless it naturally helps" in guidance.content
+        assert "Handle VIP caller" in guidance.message
+        assert "Prioritize urgent inbound calls from Alice" in guidance.message
+        assert "Do not mention the task unless it naturally helps" in guidance.message
 
 
 # =============================================================================

--- a/tests/conversation_manager/core/test_prompt_builders.py
+++ b/tests/conversation_manager/core/test_prompt_builders.py
@@ -826,3 +826,102 @@ class TestConsoleUIGate:
     def test_voice_platform_knowledge_absent_in_local_mode(self):
         prompt = _build_voice(is_coordinator=False, console_ui_present=False)
         assert "Platform knowledge" not in prompt
+
+
+_ONBOARDING_RENDER: dict = {
+    "active_step_id": "email-reply",
+    "steps": [
+        {
+            "id": "email-reference",
+            "title": "Email the first reference",
+            "phase": "Quiz",
+            "status": "done",
+            "can_skip": False,
+        },
+        {
+            "id": "email-reply",
+            "title": "Reply to email",
+            "phase": "Quiz",
+            "status": "available",
+            "can_skip": True,
+        },
+    ],
+    "next_targets": [
+        {
+            "id": "email-reply",
+            "title": "Reply to email",
+            "nudge_chat": "Prompt them to reply with their guess to the email clue.",
+            "nudge_voice": "replying with their guess for the email clue",
+            "channel": "email",
+        },
+    ],
+}
+
+
+class TestCoordinatorOnboardingDeferGate:
+    """The global "do onboarding later" switch drops onboarding-specific
+    scaffolding (reactive narration, the checklist/flow map, and the live
+    progress block) but keeps general Console literacy on so the
+    Coordinator can still orient the user and nudge platform behaviours."""
+
+    def test_deferred_drops_onboarding_blocks_but_keeps_console_literacy(self):
+        prompt = _build(
+            is_coordinator=True,
+            coordinator_onboarding_deferred=True,
+            coordinator_onboarding_render=_ONBOARDING_RENDER,
+        )
+        # General platform literacy stays on in every mode.
+        assert "My Console literacy" in prompt
+        # Onboarding-specific scaffolding is suppressed.
+        assert "My onboarding narration" not in prompt
+        assert "My onboarding flow (UI reference)" not in prompt
+        assert "My onboarding progress (live)" not in prompt
+
+    def test_not_deferred_keeps_all_coordinator_blocks(self):
+        prompt = _build(
+            is_coordinator=True,
+            coordinator_onboarding_render=_ONBOARDING_RENDER,
+        )
+        assert "My Console literacy" in prompt
+        assert "My onboarding narration" in prompt
+        assert "My onboarding flow (UI reference)" in prompt
+
+    # Body sentence unique to the standing progress block. The block title
+    # also appears by name inside the narration block (which points the
+    # brain at it), so assertions key off this body line instead.
+    _PROGRESS_BLOCK_MARKER = "always-current picture of the user's onboarding"
+
+    def test_progress_block_renders_next_targets_with_nudge_copy(self):
+        prompt = _build(
+            is_coordinator=True,
+            coordinator_onboarding_render=_ONBOARDING_RENDER,
+        )
+        assert self._PROGRESS_BLOCK_MARKER in prompt
+        # The standing block names the valid next target + its nudge copy
+        # so the brain reads "what's next" rather than deriving it.
+        assert "Reply to email" in prompt
+        assert "Prompt them to reply with their guess to the email clue." in prompt
+
+    def test_progress_block_absent_without_render(self):
+        prompt = _build(is_coordinator=True)
+        assert self._PROGRESS_BLOCK_MARKER not in prompt
+
+    def test_voice_deferred_keeps_literacy_drops_flow_reference(self):
+        prompt = _build_voice(is_coordinator=True, coordinator_onboarding_deferred=True)
+        assert "My Console literacy" in prompt
+        assert "My onboarding flow (UI reference)" not in prompt
+
+    def test_voice_opener_pitches_server_next_target(self):
+        prompt = _build_voice(
+            is_coordinator=True,
+            coordinator_onboarding_next_targets=[
+                {
+                    "id": "apps",
+                    "title": "Connect me with your apps",
+                    "nudge_chat": "Open Integrations and connect an app.",
+                    "nudge_voice": "connecting one of their apps from the Integrations panel",
+                    "channel": None,
+                },
+            ],
+        )
+        assert "connecting one of their apps from the Integrations panel" in prompt

--- a/tests/conversation_manager/voice/test_medium_scripts.py
+++ b/tests/conversation_manager/voice/test_medium_scripts.py
@@ -49,6 +49,43 @@ import pytest_asyncio
 # =============================================================================
 
 
+@pytest.fixture(autouse=True)
+def _preserve_global_logging_state():
+    """Snapshot and restore global logging state around every test.
+
+    Several tests here drive the real voice ``entrypoint``, which calls
+    ``_configure_child_logging`` and, as a global side effect, flips
+    ``LOGGER.propagate`` on and clears handlers (the forkserver relay
+    fix). Without restoration that state leaks across tests in a
+    single-process run and breaks order-dependent expectations — notably
+    ``TestChildProcessLogging``, which asserts the default
+    ``propagate=False`` precondition. Restoring per test keeps the file
+    order-independent regardless of how it's run.
+    """
+    import logging
+
+    from droid.logger import LOGGER
+
+    _logger_names = ("livekit", "livekit.agents", "livekit.plugins")
+    saved = {
+        "droid": (LOGGER.propagate, list(LOGGER.handlers)),
+        **{
+            name: (
+                logging.getLogger(name).propagate,
+                list(logging.getLogger(name).handlers),
+            )
+            for name in _logger_names
+        },
+    }
+    try:
+        yield
+    finally:
+        LOGGER.propagate, LOGGER.handlers = saved["droid"]
+        for name in _logger_names:
+            lg = logging.getLogger(name)
+            lg.propagate, lg.handlers = saved[name]
+
+
 @pytest_asyncio.fixture
 async def event_broker():
     """Local in-memory broker for testing."""
@@ -653,7 +690,7 @@ class TestGuidanceChannelSubscription:
             assert msg is not None
             received = Event.from_json(msg["data"])
             assert isinstance(received, FastBrainNotification)
-            assert received.content == "Test guidance"
+            assert received.message == "Test guidance"
 
     async def test_status_channel_receives_stop_signal(self, event_broker):
         """Status channel receives stop signals."""
@@ -1328,6 +1365,9 @@ class TestFastBrainGuidanceFlow:
             def set_call_received(self):
                 self.call_received = True
 
+            def set_credit_gate_state_provider(self, provider):
+                self.credit_gate_state_provider = provider
+
         async def _noop_async(*args, **kwargs):
             return None
 
@@ -1344,8 +1384,11 @@ class TestFastBrainGuidanceFlow:
                 first_name="Assistant",
                 surname="Example",
                 agent_id=None,
+                user_desktop_for=lambda user_id: None,
             ),
             user=SimpleNamespace(id="default"),
+            is_coordinator=False,
+            org_id=None,
             voice_call=SimpleNamespace(
                 outbound=False,
                 channel="unify_meet",
@@ -1522,6 +1565,9 @@ class TestFastBrainGuidanceFlow:
             def set_call_received(self):
                 self.call_received = True
 
+            def set_credit_gate_state_provider(self, provider):
+                self.credit_gate_state_provider = provider
+
         async def _noop_async(*args, **kwargs):
             return None
 
@@ -1538,7 +1584,14 @@ class TestFastBrainGuidanceFlow:
                 contact_json=json.dumps(contact),
                 boss_json=json.dumps(boss),
             ),
-            assistant=SimpleNamespace(about="Assistant bio", name="David"),
+            assistant=SimpleNamespace(
+                about="Assistant bio",
+                name="David",
+                user_desktop_for=lambda user_id: None,
+            ),
+            user=SimpleNamespace(id="default"),
+            is_coordinator=False,
+            org_id=None,
             unify_key="",
         )
 
@@ -1746,6 +1799,9 @@ class TestFastBrainGuidanceFlow:
             def set_call_received(self):
                 self.call_received = True
 
+            def set_credit_gate_state_provider(self, provider):
+                self.credit_gate_state_provider = provider
+
         async def _noop_async(*args, **kwargs):
             return None
 
@@ -1762,7 +1818,14 @@ class TestFastBrainGuidanceFlow:
                 contact_json=json.dumps(contact),
                 boss_json=json.dumps(boss),
             ),
-            assistant=SimpleNamespace(about="Assistant bio", name="Ava"),
+            assistant=SimpleNamespace(
+                about="Assistant bio",
+                name="Ava",
+                user_desktop_for=lambda user_id: None,
+            ),
+            user=SimpleNamespace(id="default"),
+            is_coordinator=False,
+            org_id=None,
             unify_key="",
         )
 
@@ -1837,7 +1900,7 @@ class TestFastBrainGuidanceFlow:
             for item in session._chat_ctx.items
             if getattr(item, "type", None) == "message"
         ]
-        has_notification = any("No contact named Bob" in txt for txt in session_texts)
+        has_notification = any("no contact named Bob" in txt for txt in session_texts)
         assert has_notification, (
             f"should_speak=True guidance must inject [notification] into chat_ctx "
             f"immediately so the fast brain regenerates with current state.\n"
@@ -1872,7 +1935,7 @@ class TestFastBrainGuidanceFlow:
                 if getattr(item, "type", None) == "message"
             ]
             has_notification_after = any(
-                "No contact named Bob" in txt for txt in session_texts_after
+                "no contact named Bob" in txt for txt in session_texts_after
             )
             assert (
                 has_notification_after
@@ -2057,6 +2120,9 @@ class TestFastBrainGuidanceFlow:
             def set_call_received(self):
                 self.call_received = True
 
+            def set_credit_gate_state_provider(self, provider):
+                self.credit_gate_state_provider = provider
+
         async def _noop_async(*args, **kwargs):
             return None
 
@@ -2073,7 +2139,14 @@ class TestFastBrainGuidanceFlow:
                 contact_json=json.dumps(contact),
                 boss_json=json.dumps(boss),
             ),
-            assistant=SimpleNamespace(about="Assistant bio", name="Ava"),
+            assistant=SimpleNamespace(
+                about="Assistant bio",
+                name="Ava",
+                user_desktop_for=lambda user_id: None,
+            ),
+            user=SimpleNamespace(id="default"),
+            is_coordinator=False,
+            org_id=None,
             unify_key="",
         )
 
@@ -2285,6 +2358,9 @@ class TestFastBrainGuidanceFlow:
             def set_call_received(self):
                 self.call_received = True
 
+            def set_credit_gate_state_provider(self, provider):
+                self.credit_gate_state_provider = provider
+
         async def _noop_async(*args, **kwargs):
             return None
 
@@ -2301,7 +2377,14 @@ class TestFastBrainGuidanceFlow:
                 contact_json=json.dumps(contact),
                 boss_json=json.dumps(boss),
             ),
-            assistant=SimpleNamespace(about="Assistant bio", name="Ava"),
+            assistant=SimpleNamespace(
+                about="Assistant bio",
+                name="Ava",
+                user_desktop_for=lambda user_id: None,
+            ),
+            user=SimpleNamespace(id="default"),
+            is_coordinator=False,
+            org_id=None,
             unify_key="",
         )
 
@@ -2526,6 +2609,9 @@ class TestFastBrainSpeechDedup:
             def set_call_received(self):
                 self.call_received = True
 
+            def set_credit_gate_state_provider(self, provider):
+                self.credit_gate_state_provider = provider
+
         async def _noop_async(*args, **kwargs):
             return None
 
@@ -2542,7 +2628,14 @@ class TestFastBrainSpeechDedup:
                 contact_json=json.dumps(contact),
                 boss_json=json.dumps(boss),
             ),
-            assistant=SimpleNamespace(about="Assistant bio", name="Ava"),
+            assistant=SimpleNamespace(
+                about="Assistant bio",
+                name="Ava",
+                user_desktop_for=lambda user_id: None,
+            ),
+            user=SimpleNamespace(id="default"),
+            is_coordinator=False,
+            org_id=None,
             unify_key="",
         )
 

--- a/tests/function_manager/test_provider_integration_materialization.py
+++ b/tests/function_manager/test_provider_integration_materialization.py
@@ -161,12 +161,16 @@ def test_materializes_connected_provider_tools_with_active_only_search(
     assert "Parameters\n----------" in row["docstring"]
     assert "query : str" in row["docstring"]
     assert "await primitives.integrations.hubspot.search_contacts" in row["docstring"]
-    assert (
-        "Function Name: primitives.integrations.hubspot.search_contacts"
-        in row["embedding_text"]
-    )
-    assert "Signature: (query: str, limit: int = 10) -> dict" in row["embedding_text"]
-    assert "crm.objects.contacts.read" not in row["embedding_text"]
+    embedding_text = row["embedding_text"]
+    # Layer 1 normalization (integrations-only) strips scaffolding labels and the
+    # raw argspec, and splits identifiers into words so the pooled vector is
+    # dominated by signal rather than dotted/cased identifier noise.
+    assert "Function Name:" not in embedding_text
+    assert "Signature:" not in embedding_text
+    assert "search contacts" in embedding_text
+    assert "hub spot" in embedding_text
+    assert "query" in embedding_text and "limit" in embedding_text
+    assert "crm.objects.contacts.read" not in embedding_text
     metadata = row["metadata"]
     assert metadata["source"] == "provider_backed"
     integration = metadata["integration"]

--- a/uv.lock
+++ b/uv.lock
@@ -1249,8 +1249,8 @@ requires-dist = [
     { name = "textual-dev", specifier = ">=1.2.0" },
     { name = "tiktoken", specifier = ">=0.11.0" },
     { name = "twilio", specifier = ">=8.0.0" },
-    { name = "unify", git = "https://github.com/unifyai/unify.git?branch=staging" },
-    { name = "unillm", git = "https://github.com/unifyai/unillm.git?branch=staging" },
+    { name = "unify", editable = "../unify" },
+    { name = "unillm", editable = "../unillm" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.24.0" },
     { name = "websockify", specifier = ">=0.13.0" },
 ]
@@ -2611,7 +2611,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.87.1"
+version = "1.88.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -2627,9 +2627,9 @@ dependencies = [
     { name = "tiktoken" },
     { name = "tokenizers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5d/e5/d0ac1c8f55e2c8d8799589e831bef0d450e69e02ecb511901ffc8de054d9/litellm-1.87.1.tar.gz", hash = "sha256:70ac9d6b25f56ad30de6ff95d26fac3b3fc697a95da582b6072d25d8dc73d493", size = 15455709, upload-time = "2026-06-04T16:23:23.339Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9b/8c/6cfce5d15554e076b8438a955436e9e6e2a2bd39c76539656c1c3861c369/litellm-1.88.0.tar.gz", hash = "sha256:4ff794493e40bd86c6f13e91dcb3e1aad697403fd46a96902196d93356ba48f4", size = 13886026, upload-time = "2026-06-06T23:25:17.93Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ff/18/8275c95ef09e81ab0c01a162c7b780ce3fbc49066b5d532c6b6ab3dc0118/litellm-1.87.1-py3-none-any.whl", hash = "sha256:dd4e00278cdb846d52e99a09d732575a897273540b54eb044247ecbc0d98f67c", size = 17105482, upload-time = "2026-06-04T16:23:20.769Z" },
+    { url = "https://files.pythonhosted.org/packages/da/71/deb6637475253b83eb4577c058863eec4b4ddaef2d08dcd93981b1aa4209/litellm-1.88.0-py3-none-any.whl", hash = "sha256:abd3037e0bf5703f833f5565c87bdfd93578d3de46cbcb36dfa108c3ef58021c", size = 15276203, upload-time = "2026-06-06T23:25:07.257Z" },
 ]
 
 [[package]]
@@ -9459,22 +9459,72 @@ wheels = [
 [[package]]
 name = "unify"
 version = "0.0.0"
-source = { git = "https://github.com/unifyai/unify.git?branch=staging#6f95f21c6aa0675b8a03d08aa58e50d1c92d2ca3" }
+source = { editable = "../unify" }
 dependencies = [
     { name = "aiohttp" },
     { name = "requests" },
     { name = "tqdm" },
 ]
 
+[package.metadata]
+requires-dist = [
+    { name = "aiohttp", specifier = ">=3.12.14" },
+    { name = "requests", specifier = ">=2.32.4" },
+    { name = "tqdm", specifier = ">=4.67.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "autoflake", specifier = ">=1.6.1" },
+    { name = "black", specifier = "==26.3.1" },
+    { name = "flake8", specifier = ">=4.0.1" },
+    { name = "isort", specifier = ">=5.11.4" },
+    { name = "mypy", specifier = ">=1.1.1" },
+    { name = "opentelemetry-api", specifier = ">=1.20.0" },
+    { name = "opentelemetry-exporter-otlp", specifier = ">=1.20.0" },
+    { name = "opentelemetry-sdk", specifier = ">=1.20.0" },
+    { name = "pre-commit", specifier = ">=3.0.1" },
+    { name = "pytest", specifier = ">=8.3.3" },
+    { name = "pytest-asyncio", specifier = ">=0.24.0" },
+    { name = "pytest-dotenv", specifier = ">=0.5.2" },
+    { name = "pytest-timeout", specifier = ">=2.3.1" },
+    { name = "pytest-xdist", specifier = ">=3.8.0" },
+    { name = "python-dotenv", specifier = ">=1.2.1" },
+    { name = "types-requests" },
+]
+
 [[package]]
 name = "unillm"
 version = "0.0.0"
-source = { git = "https://github.com/unifyai/unillm.git?branch=staging#014d461d9a6ab49657dcc4e238f4064ae1e7623e" }
+source = { editable = "../unillm" }
 dependencies = [
     { name = "litellm" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "unify" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "litellm", specifier = "==1.88.0" },
+    { name = "pydantic", specifier = ">=2.12.5" },
+    { name = "pydantic-settings", specifier = ">=2.12.0" },
+    { name = "unify", editable = "../unify" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "autoflake", specifier = ">=2.3.1" },
+    { name = "black", specifier = "==26.3.1" },
+    { name = "opentelemetry-api", specifier = ">=1.20.0" },
+    { name = "opentelemetry-exporter-otlp", specifier = ">=1.20.0" },
+    { name = "opentelemetry-sdk", specifier = ">=1.20.0" },
+    { name = "pre-commit", specifier = ">=4.0.1" },
+    { name = "pytest", specifier = ">=8.4.2" },
+    { name = "pytest-asyncio", specifier = ">=0.24.0" },
+    { name = "pytest-dotenv", specifier = ">=0.5.2" },
+    { name = "pytest-timeout", specifier = ">=2.3.1" },
+    { name = "ruff", specifier = ">=0.15.16" },
 ]
 
 [[package]]


### PR DESCRIPTION
Promote current `staging` to `main` (fast-forward; main was 0 behind at creation).

Includes coordinator onboarding (section-level deferral, capability-driven gating), the Twin rename, self-host comms wiring, and accumulated dependency/infra fixes.