### PR TITLE
Promote staging to main: consume renamed SDK (unify -> unisdk)

### DIFF
--- a/.env.advanced.example
+++ b/.env.advanced.example
@@ -107,8 +107,8 @@ UNILLM_CACHE=true
 # Shared API key for cross-assistant operations (AssistantJobs project).
 SHARED_UNIFY_KEY=
 
-# Terminal (console) logging for the unify client (file logging via UNIFY_LOG_DIR).
-UNIFY_TERMINAL_LOG=true
+# Terminal (console) logging for the unify client (file logging via UNISDK_LOG_DIR).
+UNISDK_TERMINAL_LOG=true
 
 # --- Test project management (consumed by tests/conftest.py) ---
 

--- a/.github/workflows/flow-smoke.yml
+++ b/.github/workflows/flow-smoke.yml
@@ -174,9 +174,9 @@ jobs:
         pyproject = Path("pyproject.toml")
         text = pyproject.read_text()
         replacements = {
-            'unify = { git = "https://github.com/unifyai/unisdk.git", branch = "staging" }': 'unify = { path = "./unisdk", editable = true }',
+            'unisdk = { git = "https://github.com/unifyai/unisdk.git", branch = "staging" }': 'unisdk = { path = "./unisdk", editable = true }',
             'unillm = { git = "https://github.com/unifyai/unillm.git", branch = "staging" }': 'unillm = { path = "./unillm", editable = true }',
-            'unify = { path = "../unisdk", editable = true }': 'unify = { path = "./unisdk", editable = true }',
+            'unisdk = { path = "../unisdk", editable = true }': 'unisdk = { path = "./unisdk", editable = true }',
             'unillm = { path = "../unillm", editable = true }': 'unillm = { path = "./unillm", editable = true }',
         }
         for old, new in replacements.items():
@@ -186,8 +186,8 @@ jobs:
         unillm_pyproject = Path("unillm/pyproject.toml")
         text = unillm_pyproject.read_text()
         text = text.replace(
-            'unify = { git = "https://github.com/unifyai/unisdk.git", branch = "staging" }',
-            'unify = { path = "../unisdk", editable = true }',
+            'unisdk = { git = "https://github.com/unifyai/unisdk.git", branch = "staging" }',
+            'unisdk = { path = "../unisdk", editable = true }',
         )
         unillm_pyproject.write_text(text)
         PY

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -596,19 +596,19 @@ jobs:
       with:
         python-version: '3.12'
 
-    - name: Install unify client
-      run: pip install unify
+    - name: Install unisdk client
+      run: pip install "unisdk @ git+https://github.com/unifyai/unisdk.git@${{ github.ref_name == 'main' && 'main' || 'staging' }}"
 
     - name: Delete shared project (once, before all runners)
       run: |
         echo "Deleting shared project before tests start..."
         python3 << 'PYEOF'
         import os
-        import unify
+        import unisdk
 
-        project_name = os.environ.get("UNIFY_PROJECT", "UnityTests")
+        project_name = os.environ.get("UNISDK_PROJECT", "UnityTests")
         try:
-            unify.delete_project(project_name)
+            unisdk.delete_project(project_name)
             print(f"✓ Deleted project '{project_name}'")
         except Exception as e:
             print(f"Note: Could not delete project '{project_name}': {e}")
@@ -875,9 +875,9 @@ jobs:
         pyproject = Path("pyproject.toml")
         text = pyproject.read_text()
         replacements = {
-            'unify = { git = "https://github.com/unifyai/unisdk.git", branch = "staging" }': 'unify = { path = "./unisdk", editable = true }',
+            'unisdk = { git = "https://github.com/unifyai/unisdk.git", branch = "staging" }': 'unisdk = { path = "./unisdk", editable = true }',
             'unillm = { git = "https://github.com/unifyai/unillm.git", branch = "staging" }': 'unillm = { path = "./unillm", editable = true }',
-            'unify = { path = "../unisdk", editable = true }': 'unify = { path = "./unisdk", editable = true }',
+            'unisdk = { path = "../unisdk", editable = true }': 'unisdk = { path = "./unisdk", editable = true }',
             'unillm = { path = "../unillm", editable = true }': 'unillm = { path = "./unillm", editable = true }',
         }
         for old, new in replacements.items():
@@ -887,8 +887,8 @@ jobs:
         unillm_pyproject = Path("unillm/pyproject.toml")
         text = unillm_pyproject.read_text()
         text = text.replace(
-            'unify = { git = "https://github.com/unifyai/unisdk.git", branch = "staging" }',
-            'unify = { path = "../unisdk", editable = true }',
+            'unisdk = { git = "https://github.com/unifyai/unisdk.git", branch = "staging" }',
+            'unisdk = { path = "../unisdk", editable = true }',
         )
         unillm_pyproject.write_text(text)
         PY
@@ -910,11 +910,11 @@ jobs:
             print(f'  {p}')
 
         from unillm import AsyncUnify, Unify
-        import unify
+        import unisdk
 
         print(f'✓ unillm: {AsyncUnify.__module__}')
-        print(f'✓ unify: {unify.__file__}')
-        assert hasattr(unify, 'create_project'), f'Wrong unify package!'
+        print(f'✓ unisdk: {unisdk.__file__}')
+        assert hasattr(unisdk, 'create_project'), f'Wrong unisdk package!'
         print('✓ Local packages verified successfully')
         "
 
@@ -1379,19 +1379,19 @@ jobs:
       with:
         python-version: '3.12'
 
-    - name: Install unify client
-      run: pip install unify
+    - name: Install unisdk client
+      run: pip install "unisdk @ git+https://github.com/unifyai/unisdk.git@${{ github.ref_name == 'main' && 'main' || 'staging' }}"
 
     - name: Delete shared project (once, after all runners)
       run: |
         echo "Deleting shared project after all tests complete..."
         python3 << 'PYEOF'
         import os
-        import unify
+        import unisdk
 
-        project_name = os.environ.get("UNIFY_PROJECT", "UnityTests")
+        project_name = os.environ.get("UNISDK_PROJECT", "UnityTests")
         try:
-            unify.delete_project(project_name)
+            unisdk.delete_project(project_name)
             print(f"✓ Deleted project '{project_name}'")
         except Exception as e:
             print(f"Note: Could not delete project '{project_name}': {e}")

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -243,14 +243,14 @@
         "filename": "tests/conversation_manager/core/test_comms_manager.py",
         "hashed_secret": "c0fe13110c381c6d4de6d64eae20c53210bf70bf",
         "is_verified": false,
-        "line_number": 1084
+        "line_number": 1086
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/conversation_manager/core/test_comms_manager.py",
         "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
         "is_verified": false,
-        "line_number": 1138
+        "line_number": 1140
       }
     ],
     "tests/conversation_manager/core/test_event_handlers.py": [
@@ -552,5 +552,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-29T07:33:23Z"
+  "generated_at": "2026-06-29T21:59:11Z"
 }

--- a/conftest.py
+++ b/conftest.py
@@ -484,11 +484,11 @@ def pytest_sessionstart(session):
     unify_log_dir = root_path / "logs" / "unify" / subdir
     unify_log_dir.mkdir(parents=True, exist_ok=True)
     try:
-        from unify.utils.http import configure_log_dir as configure_unify_log_dir
+        from unisdk.utils.http import configure_log_dir as configure_unify_log_dir
 
         configure_unify_log_dir(str(unify_log_dir))
     except ImportError:
-        os.environ["UNIFY_LOG_DIR"] = str(unify_log_dir)
+        os.environ["UNISDK_LOG_DIR"] = str(unify_log_dir)
 
     # Unillm LLM I/O file logging (raw request/response traces)
     unillm_log_dir = root_path / "logs" / "unillm" / subdir

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -140,10 +140,10 @@ ENV TOKENIZERS_PARALLELISM=false
 
 # Logging: Unity emoji logs to terminal, unify/unillm quiet (file traces only)
 ENV UNITY_TERMINAL_LOG=true
-ENV UNIFY_TERMINAL_LOG=false
+ENV UNISDK_TERMINAL_LOG=false
 ENV UNILLM_TERMINAL_LOG=false
 ENV UNITY_LOG_DIR=/var/log/unity
-ENV UNIFY_LOG_DIR=/var/log/unify
+ENV UNISDK_LOG_DIR=/var/log/unify
 ENV UNILLM_LOG_DIR=/var/log/unillm
 ENV MAGNITUDE_LOG_DIR=/var/log/magnitude
 ENV MAGNITUDE_DEBUG=true

--- a/logs/README.md
+++ b/logs/README.md
@@ -105,7 +105,7 @@ All logs are organized under `logs/` with seven main subdirectories:
 | `logs/pytest/` | Test output (stdout/stderr) | One `.txt` per test | Test-only |
 | `logs/unity/` | Unity LOGGER output (async tool loop, managers) | `unity.log` per session | `UNITY_LOG` + `UNITY_LOG_DIR` |
 | `logs/unillm/` | Raw LLM request/response traces | `.txt` files per request | `UNILLM_LOG_DIR` (+ `UNILLM_TERMINAL_LOG` for console) |
-| `logs/unify/` | Unify SDK HTTP traces | JSON files per request | `UNIFY_LOG_DIR` (+ `UNIFY_TERMINAL_LOG` for console) |
+| `logs/unify/` | Unify SDK HTTP traces | JSON files per request | `UNISDK_LOG_DIR` (+ `UNISDK_TERMINAL_LOG` for console) |
 | `logs/orchestra/` | Orchestra API traces | Per-request JSON with OpenTelemetry spans | `ORCHESTRA_LOG_DIR` |
 | `logs/magnitude/` | **Magnitude agent debug** (screenshots, act traces, coordinates) | Per-act bundles with PNGs | `MAGNITUDE_LOG_DIR` + `MAGNITUDE_DEBUG` |
 | `logs/all/` | **Cross-repo OTEL traces** | `{trace_id}.jsonl` per test | `*_OTEL` + `*_OTEL_LOG_DIR` |
@@ -221,8 +221,8 @@ logs/unify/
 The `trace_id` suffix (last 8 chars) enables correlation with pytest `[TRACE] TRACE_ID=...` output and Orchestra traces.
 
 **Environment variables:**
-- `UNIFY_TERMINAL_LOG=true` (default) - Enable terminal (console) output
-- `UNIFY_LOG_DIR=/path/to/logs` - Directory for file-based traces (independent of terminal)
+- `UNISDK_TERMINAL_LOG=true` (default) - Enable terminal (console) output
+- `UNISDK_LOG_DIR=/path/to/logs` - Directory for file-based traces (independent of terminal)
 
 ---
 
@@ -345,13 +345,13 @@ Some test suites use session-scoped fixtures to create shared seed data once, th
 async def contact_scenario(request):
     """Create seeded contacts once per session."""
     ctx = "tests/contact/Scenario"
-    unify.set_context(ctx, relative=False)
+    unisdk.set_context(ctx, relative=False)
 
     # Seed data (idempotent - skips if already exists)
     builder = await ScenarioBuilderContacts.create()
 
     # Commit the initial state for rollback
-    unify.commit_context(ctx, commit_message="Initial seed data")
+    unisdk.commit_context(ctx, commit_message="Initial seed data")
 
     return builder.cm, id_mapping
 
@@ -361,7 +361,7 @@ def contact_manager_scenario(contact_scenario):
     cm, id_map = contact_scenario
 
     # Reset to committed state
-    unify.rollback_context(ctx, commit_hash=initial_commit_hash)
+    unisdk.rollback_context(ctx, commit_hash=initial_commit_hash)
 
     yield cm, id_map
 ```
@@ -385,18 +385,18 @@ Browse to the `UnityTests` project and explore:
 **Via Python:**
 
 ```python
-import unify
+import unisdk
 
-unify.activate("UnityTests")
+unisdk.activate("UnityTests")
 
 # Query Combined context
-logs = unify.get_logs(context="Combined")
+logs = unisdk.get_logs(context="Combined")
 for log in logs:
     print(f"{log['test_fpath']}: {log['duration']:.2f}s")
 
 # Query a specific test's contacts
-unify.set_context("tests/contact_manager/test_basic/test_create/Contacts")
-contacts = unify.get_logs()
+unisdk.set_context("tests/contact_manager/test_basic/test_create/Contacts")
+contacts = unisdk.get_logs()
 ```
 
 ---
@@ -628,16 +628,16 @@ OTEL is enabled automatically by `parallel_run.sh`. To customize:
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `UNITY_OTEL` | `true` (via parallel_run.sh) | Enable Unity OTEL tracing |
-| `UNIFY_OTEL` | `true` (via parallel_run.sh) | Enable Unify SDK OTEL tracing |
+| `UNISDK_OTEL` | `true` (via parallel_run.sh) | Enable Unify SDK OTEL tracing |
 | `UNILLM_OTEL` | `true` (via parallel_run.sh) | Enable Unillm OTEL tracing |
 | `UNITY_OTEL_LOG_DIR` | `logs/all/` | Unity span output directory |
-| `UNIFY_OTEL_LOG_DIR` | `logs/all/` | Unify span output directory |
+| `UNISDK_OTEL_LOG_DIR` | `logs/all/` | Unify span output directory |
 | `UNILLM_OTEL_LOG_DIR` | `logs/all/` | Unillm span output directory |
 | `ORCHESTRA_OTEL_LOG_DIR` | `logs/all/` | Orchestra span output directory |
 
 To disable OTEL tracing:
 ```bash
-parallel_run.sh --env UNITY_OTEL=false --env UNIFY_OTEL=false --env UNILLM_OTEL=false tests/
+parallel_run.sh --env UNITY_OTEL=false --env UNISDK_OTEL=false --env UNILLM_OTEL=false tests/
 ```
 
 ---
@@ -813,13 +813,13 @@ Orchestra's instrumentation is particularly detailed, capturing every SQL query 
 ### Querying Trace Data
 
 ```python
-import unify
+import unisdk
 
-unify.activate("UnityTests")
+unisdk.activate("UnityTests")
 
 # Get trace spans for a specific test
 trace_ctx = "tests/contact_manager/test_ask/test_ask_time_check/DefaultUser/DefaultAssistant/Trace"
-logs = unify.get_logs(context=trace_ctx, limit=100)
+logs = unisdk.get_logs(context=trace_ctx, limit=100)
 
 # Filter by service
 unity_spans = [log for log in logs if log.entries.get("service") == "unity"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "azure-identity>=1.14.0",
     "msgraph-sdk>=1.0.0",
     "uvicorn[standard]>=0.24.0",
-    "unify",
+    "unisdk",
     "unillm",
     # Virtual devices and remote browser setup
     "websockify>=0.13.0",
@@ -108,6 +108,6 @@ include = ["unity", "unity.*"]
 "unity.assets.audio" = ["*.mp3"]
 
 [tool.uv.sources]
-unify = { path = "../unisdk", editable = true }
+unisdk = { path = "../unisdk", editable = true }
 unillm = { path = "../unillm", editable = true }
 en-core-web-sm = { url = "https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl" }

--- a/sandboxes/actor/sandbox.py
+++ b/sandboxes/actor/sandbox.py
@@ -30,7 +30,7 @@ if str(ROOT) not in sys.path:
 from dotenv import load_dotenv
 
 load_dotenv()
-import unify
+import unisdk
 
 from sandboxes.utils import (
     activate_project,
@@ -160,11 +160,11 @@ async def _main_async() -> None:
 
     # ─────────────────── project version handling ────────────────────
     if args.project_version != -1:
-        commits = unify.get_project_commits(args.project_name)
+        commits = unisdk.get_project_commits(args.project_name)
         if commits:
             try:
                 target = commits[args.project_version]
-                unify.rollback_project(args.project_name, target["commit_hash"])
+                unisdk.rollback_project(args.project_name, target["commit_hash"])
                 LG.info("[version] Rolled back to commit %s", target["commit_hash"])
             except IndexError:
                 LG.warning(
@@ -209,7 +209,7 @@ async def _main_async() -> None:
                         continue
                     print(f"Using custom goal: {goal}")
                 elif goal.lower() in {"save_project", "sp"}:
-                    commit_hash = unify.commit_project(
+                    commit_hash = unisdk.commit_project(
                         args.project_name,
                         commit_message=f"Actor sandbox save {datetime.utcnow().isoformat()}",
                     ).get("commit_hash")

--- a/sandboxes/contact_manager/sandbox.py
+++ b/sandboxes/contact_manager/sandbox.py
@@ -27,7 +27,7 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-import unify
+import unisdk
 from pydantic import BaseModel, Field
 from sandboxes.scenario_builder import ScenarioBuilder
 from unity.common.llm_client import new_llm_client
@@ -181,11 +181,11 @@ async def _main_async() -> None:
 
     # ─────────────────── project version handling ────────────────────
     if args.project_version != -1:
-        commits = unify.get_project_commits(args.project_name)
+        commits = unisdk.get_project_commits(args.project_name)
         if commits:
             try:
                 target = commits[args.project_version]
-                unify.rollback_project(args.project_name, target["commit_hash"])
+                unisdk.rollback_project(args.project_name, target["commit_hash"])
                 LG.info("[version] Rolled back to commit %s", target["commit_hash"])
             except IndexError:
                 LG.warning(
@@ -271,7 +271,7 @@ async def _main_async() -> None:
 
             # ─────────────── save project snapshot ────────────────
             if raw.lower() in {"save_project", "sp"}:
-                commit_hash = unify.commit_project(
+                commit_hash = unisdk.commit_project(
                     args.project_name,
                     commit_message=f"Sandbox save {datetime.utcnow().isoformat()}",
                 ).get("commit_hash")

--- a/sandboxes/conversation_manager/command_router.py
+++ b/sandboxes/conversation_manager/command_router.py
@@ -17,7 +17,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, Awaitable, Callable, Optional
 
-import unify
+import unisdk
 
 from sandboxes.conversation_manager.commands import (
     HELP_TEXT,
@@ -144,7 +144,7 @@ class CommandRouter:
                     lines=["⚠️ save_project is not available in this mode."],
                 )
             try:
-                commit_hash = unify.commit_project(
+                commit_hash = unisdk.commit_project(
                     self.args.project_name,
                     commit_message=f"ConversationManager sandbox save {datetime.utcnow().isoformat()}",
                 ).get("commit_hash")

--- a/sandboxes/conversation_manager/config_manager.py
+++ b/sandboxes/conversation_manager/config_manager.py
@@ -20,7 +20,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal, Optional
 
-import unify
+import unisdk
 
 from sandboxes.conversation_manager.agent_service_bootstrap import (
     diagnose_agent_service_setup,
@@ -209,7 +209,7 @@ class ConfigurationManager:
             # Real managers require project connectivity. This is a lightweight probe; it
             # will fail early if the backend session is misconfigured.
             try:
-                _ = unify.get_project_commits(self._project_name)
+                _ = unisdk.get_project_commits(self._project_name)
             except Exception as exc:
                 return ValidationResult(
                     ok=False,
@@ -222,7 +222,7 @@ class ConfigurationManager:
     def snapshot_state(self) -> StateSnapshot:
         """Create a project snapshot (commit) for rollback during config switching."""
         created_at = time.time()
-        commit = unify.commit_project(
+        commit = unisdk.commit_project(
             self._project_name,
             commit_message=(
                 "ConversationManager sandbox auto-snapshot "
@@ -242,7 +242,7 @@ class ConfigurationManager:
         """Rollback the project to a prior snapshot (commit hash)."""
         if snapshot.project_name != self._project_name:
             raise ValueError("snapshot project_name does not match current project")
-        unify.rollback_project(self._project_name, snapshot.commit_hash)
+        unisdk.rollback_project(self._project_name, snapshot.commit_hash)
 
     def _validate_agent_service(self, agent_server_url: str) -> bool:
         # Avoid introducing a hard dependency on `requests`; prefer httpx if available.

--- a/sandboxes/conversation_manager/gui_worker.py
+++ b/sandboxes/conversation_manager/gui_worker.py
@@ -778,7 +778,7 @@ async def _run_worker(*, ui_to_worker, worker_to_ui, config: dict) -> None:
         pass
 
     # Suppress SDK HTTP noise
-    for _noisy in ("unify", "unify_requests", "unillm", "UnifyAsyncLogger"):
+    for _noisy in ("unisdk", "unisdk_requests", "unillm", "UnisdkAsyncLogger"):
         try:
             logging.getLogger(_noisy).setLevel(logging.WARNING)
         except Exception:

--- a/sandboxes/conversation_manager/live_voice.py
+++ b/sandboxes/conversation_manager/live_voice.py
@@ -151,7 +151,7 @@ def _spawn_quiet(log_path: Path):
         py_cmd = [sys.executable, str(Path(script).expanduser().resolve()), *args]
         child_env = {
             **os.environ,
-            "UNIFY_TERMINAL_LOG": "false",
+            "UNISDK_TERMINAL_LOG": "false",
             "UNILLM_TERMINAL_LOG": "false",
         }
         return subprocess.Popen(

--- a/sandboxes/conversation_manager/sandbox.py
+++ b/sandboxes/conversation_manager/sandbox.py
@@ -29,7 +29,7 @@ from dotenv import load_dotenv
 
 load_dotenv(override=True)
 
-import unify
+import unisdk
 
 from pathlib import Path
 
@@ -87,7 +87,7 @@ def _redirect_voice_worker_output(log_path: Path) -> None:
         py_cmd = [sys.executable, str(Path(script).expanduser().resolve()), *args]
         child_env = {
             **os.environ,
-            "UNIFY_TERMINAL_LOG": "false",
+            "UNISDK_TERMINAL_LOG": "false",
             "UNILLM_TERMINAL_LOG": "false",
         }
         return subprocess.Popen(
@@ -404,11 +404,11 @@ async def _main_async() -> None:
 
     # Optional project version rollback (0-indexed)
     if args.project_version != -1:
-        commits = unify.get_project_commits(args.project_name)
+        commits = unisdk.get_project_commits(args.project_name)
         if commits:
             try:
                 target = commits[args.project_version]
-                unify.rollback_project(args.project_name, target["commit_hash"])
+                unisdk.rollback_project(args.project_name, target["commit_hash"])
                 LG.info("[version] Rolled back to commit %s", target["commit_hash"])
             except IndexError:
                 LG.warning(
@@ -438,7 +438,7 @@ async def _main_async() -> None:
 
     # Keep sandbox logs readable by default. Full traces are still available via --debug.
     if not args.debug:
-        for name in ("unify", "unify_requests", "unillm", "UnifyAsyncLogger"):
+        for name in ("unisdk", "unisdk_requests", "unillm", "UnisdkAsyncLogger"):
             try:
                 logging.getLogger(name).setLevel(logging.WARNING)
             except Exception:

--- a/sandboxes/file_manager/managers/file_manager_sandbox.py
+++ b/sandboxes/file_manager/managers/file_manager_sandbox.py
@@ -36,7 +36,7 @@ from dotenv import load_dotenv
 load_dotenv()
 
 import json
-import unify
+import unisdk
 from pydantic import BaseModel, Field
 from sandboxes.scenario_builder import ScenarioBuilder
 from unity.common.llm_client import new_llm_client
@@ -436,11 +436,11 @@ async def _main_async() -> None:
 
     # Optional rollback to a specific project commit (align with other sandboxes)
     if args.project_version != -1:
-        commits = unify.get_project_commits(args.project_name)
+        commits = unisdk.get_project_commits(args.project_name)
         if commits:
             try:
                 target = commits[args.project_version]
-                unify.rollback_project(args.project_name, target["commit_hash"])
+                unisdk.rollback_project(args.project_name, target["commit_hash"])
                 LG.info("[version] Rolled back to commit %s", target["commit_hash"])
             except IndexError:
                 LG.warning(
@@ -528,7 +528,7 @@ async def _main_async() -> None:
                 continue
 
             if raw.lower() in {"save_project", "sp"}:
-                commit_hash = unify.commit_project(
+                commit_hash = unisdk.commit_project(
                     args.project_name,
                     commit_message="Sandbox save",
                 ).get("commit_hash")

--- a/sandboxes/knowledge_manager/sandbox.py
+++ b/sandboxes/knowledge_manager/sandbox.py
@@ -23,7 +23,7 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-import unify
+import unisdk
 from pydantic import BaseModel, Field
 from sandboxes.scenario_builder import ScenarioBuilder
 
@@ -224,11 +224,11 @@ async def _main_async() -> None:
 
     # ─────────────────── project version handling ────────────────────
     if args.project_version != -1:
-        commits = unify.get_project_commits(args.project_name)
+        commits = unisdk.get_project_commits(args.project_name)
         if commits:
             try:
                 target = commits[args.project_version]
-                unify.rollback_project(args.project_name, target["commit_hash"])
+                unisdk.rollback_project(args.project_name, target["commit_hash"])
                 LG.info("[version] Rolled back to commit %s", target["commit_hash"])
             except IndexError:
                 LG.warning(
@@ -302,7 +302,7 @@ async def _main_async() -> None:
                 continue
 
             if raw.lower() in {"save_project", "sp"}:
-                commit_hash = unify.commit_project(
+                commit_hash = unisdk.commit_project(
                     args.project_name,
                     commit_message=f"Sandbox save {datetime.utcnow().isoformat()}",
                 ).get("commit_hash")
@@ -386,7 +386,7 @@ async def _main_async() -> None:
 
             # ─────────────── save project snapshot ────────────────
             if raw.lower() in {"save_project", "sp"}:
-                commit_hash = unify.commit_project(
+                commit_hash = unisdk.commit_project(
                     args.project_name,
                     commit_message=f"Sandbox save {datetime.utcnow().isoformat()}",
                 ).get("commit_hash")

--- a/sandboxes/memory_manager/sandbox.py
+++ b/sandboxes/memory_manager/sandbox.py
@@ -48,7 +48,7 @@ from typing import List, Dict, Any
 from dotenv import load_dotenv
 
 load_dotenv()
-import unify
+import unisdk
 
 # ───────── project-local imports ─────────
 ROOT = Path(__file__).resolve().parents[1]
@@ -101,12 +101,12 @@ def _chunk_to_text(messages: List[Dict[str, Any]]) -> str:
 
 
 def _clear_contacts() -> None:
-    unify.delete_context("Contacts")
+    unisdk.delete_context("Contacts")
 
 
 def _clear_knowledge() -> None:
-    for name in unify.get_contexts(prefix="Knowledge").keys():
-        unify.delete_context(name)
+    for name in unisdk.get_contexts(prefix="Knowledge").keys():
+        unisdk.delete_context(name)
 
 
 # ---------------------------------------------------------------------------
@@ -260,11 +260,11 @@ async def _main_async() -> None:
 
     # ─────────────────── project version handling ────────────────────
     if args.project_version != -1:
-        commits = unify.get_project_commits(args.project_name)
+        commits = unisdk.get_project_commits(args.project_name)
         if commits:
             try:
                 target = commits[args.project_version]
-                unify.rollback_project(args.project_name, target["commit_hash"])
+                unisdk.rollback_project(args.project_name, target["commit_hash"])
                 LG.info("[version] Rolled back to commit %s", target["commit_hash"])
             except IndexError:
                 LG.warning(

--- a/sandboxes/secret_manager/sandbox.py
+++ b/sandboxes/secret_manager/sandbox.py
@@ -27,7 +27,7 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-import unify
+import unisdk
 from pydantic import BaseModel, Field
 from unity.common.llm_client import new_llm_client
 
@@ -129,11 +129,11 @@ async def _main_async() -> None:
 
     # ─────────────────── project version handling ────────────────────
     if getattr(args, "project_version", -1) != -1:
-        commits = unify.get_project_commits(args.project_name)
+        commits = unisdk.get_project_commits(args.project_name)
         if commits:
             try:
                 target = commits[args.project_version]
-                unify.rollback_project(args.project_name, target["commit_hash"])
+                unisdk.rollback_project(args.project_name, target["commit_hash"])
                 LG.info("[version] Rolled back to commit %s", target["commit_hash"])
             except IndexError:
                 LG.warning(
@@ -211,7 +211,7 @@ async def _main_async() -> None:
 
             # save project snapshot
             if raw.lower() in {"save_project", "sp"}:
-                commit_hash = unify.commit_project(
+                commit_hash = unisdk.commit_project(
                     args.project_name,
                     commit_message=f"Secret sandbox save {datetime.utcnow().isoformat()}",
                 ).get("commit_hash")

--- a/sandboxes/task_scheduler/sandbox.py
+++ b/sandboxes/task_scheduler/sandbox.py
@@ -23,7 +23,7 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-import unify
+import unisdk
 from pydantic import BaseModel, Field
 from sandboxes.scenario_builder import ScenarioBuilder
 from unity.common.llm_client import new_llm_client
@@ -627,11 +627,11 @@ async def _main_async() -> None:
 
     # ─────────────────── project version handling ────────────────────
     if args.project_version != -1:
-        commits = unify.get_project_commits(args.project_name)
+        commits = unisdk.get_project_commits(args.project_name)
         if commits:
             try:
                 target = commits[args.project_version]
-                unify.rollback_project(args.project_name, target["commit_hash"])
+                unisdk.rollback_project(args.project_name, target["commit_hash"])
                 LG.info("[version] Rolled back to commit %s", target["commit_hash"])
             except IndexError:
                 LG.warning(
@@ -711,7 +711,7 @@ async def _main_async() -> None:
 
             # ─────────────── save project snapshot ────────────────
             if raw.lower() in {"save_project", "sp"}:
-                commit_hash = unify.commit_project(
+                commit_hash = unisdk.commit_project(
                     args.project_name,
                     commit_message=f"Sandbox save {datetime.utcnow().isoformat()}",
                 ).get("commit_hash")

--- a/sandboxes/transcript_manager/sandbox.py
+++ b/sandboxes/transcript_manager/sandbox.py
@@ -26,7 +26,7 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-import unify
+import unisdk
 from sandboxes.utils import TranscriptGenerator
 
 # Ensure repository root resolves for local execution
@@ -140,11 +140,11 @@ async def _main_async() -> None:
 
     # ─────────────────── project version handling ────────────────────
     if args.project_version != -1:
-        commits = unify.get_project_commits(args.project_name)
+        commits = unisdk.get_project_commits(args.project_name)
         if commits:
             try:
                 target = commits[args.project_version]
-                unify.rollback_project(args.project_name, target["commit_hash"])
+                unisdk.rollback_project(args.project_name, target["commit_hash"])
                 LG.info("[version] Rolled back to commit %s", target["commit_hash"])
             except IndexError:
                 LG.warning(
@@ -229,7 +229,7 @@ async def _main_async() -> None:
 
             # ─────────────── save project snapshot ────────────────
             if raw.lower() in {"save_project", "sp"}:
-                commit_hash = unify.commit_project(
+                commit_hash = unisdk.commit_project(
                     args.project_name,
                     commit_message=f"Sandbox save {datetime.utcnow().isoformat()}",
                 ).get("commit_hash")

--- a/sandboxes/utils.py
+++ b/sandboxes/utils.py
@@ -1138,13 +1138,13 @@ def configure_sandbox_logging(
         _fh.setFormatter(_fmt)
 
         # Exclude HTTP-level SDK noise from the main log file.
-        # The unify/unillm loggers emit verbose request/response dumps at
+        # The unisdk/unillm loggers emit verbose request/response dumps at
         # DEBUG level that drown out the conversation-level flow.
         _SDK_NOISE_PREFIXES = (
-            "unify_requests",
-            "unify",
+            "unisdk_requests",
+            "unisdk",
             "unillm",
-            "UnifyAsyncLogger",
+            "UnisdkAsyncLogger",
         )
 
         class _LazyHTTPExcludeFilter(_logging.Filter):
@@ -1201,7 +1201,7 @@ def configure_sandbox_logging(
     else:
         # Restrict to only Unify Request logs by default
         _HTTP_PREFIXES = [
-            "unify_requests",  # Unify SDK dedicated request logger
+            "unisdk_requests",  # Unify SDK dedicated request logger
         ]
 
     # Optional TCP broadcast for external terminals (main logs)
@@ -2654,7 +2654,7 @@ class TranscriptGenerator:
                     )
                     from pydantic import BaseModel
                     from unity.events.event_bus import Event
-                    import unify
+                    import unisdk
 
                     event_obj = None
                     if medium == "sms_message":
@@ -2683,8 +2683,8 @@ class TranscriptGenerator:
                             if isinstance(ev_dict.payload, BaseModel)
                             else Event._to_python(ev_dict.payload)
                         )
-                        unify.create_logs(
-                            project=unify.active_project(),
+                        unisdk.create_logs(
+                            project=unisdk.active_project(),
                             context="Assistant/Events/Comms",
                             params={},
                             entries={
@@ -2807,7 +2807,7 @@ def _seed_session_details_for_sandbox() -> None:
     # User UUID from Orchestra — sets user_context component so contexts land
     # under ``{user_uuid}/{agent_id}/...`` matching what the Console expects.
     try:
-        import unify as _unify
+        import unisdk as _unify
 
         info = _unify.get_user_basic_info()
         user_id = info.get("user_id") or ""
@@ -2833,7 +2833,7 @@ def activate_project(project_name: str, overwrite: bool = False) -> None:
     def _maybe_autostart_local_orchestra() -> None:
         """Best-effort local Orchestra autostart for sandbox runs.
 
-        Sandboxes call `unify.activate()` during startup, which requires a reachable
+        Sandboxes call `unisdk.activate()` during startup, which requires a reachable
         Unify API backend. In tests, `tests/parallel_run.sh` auto-starts local
         Orchestra when `ORCHESTRA_URL` targets localhost. Sandbox entrypoints are
         typically run directly, so we replicate that behavior here (sandbox-only).

--- a/sandboxes/web_searcher/sandbox.py
+++ b/sandboxes/web_searcher/sandbox.py
@@ -19,7 +19,7 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-import unify
+import unisdk
 
 # Ensure repository root resolves for local execution
 ROOT = Path(__file__).resolve().parents[1]
@@ -85,11 +85,11 @@ async def _main_async() -> None:
 
     # Optional rollback to previous commit
     if args.project_version != -1:
-        commits = unify.get_project_commits(args.project_name)
+        commits = unisdk.get_project_commits(args.project_name)
         if commits:
             try:
                 target = commits[args.project_version]
-                unify.rollback_project(args.project_name, target["commit_hash"])
+                unisdk.rollback_project(args.project_name, target["commit_hash"])
                 LG.info("[version] Rolled back to commit %s", target["commit_hash"])
             except IndexError:
                 LG.warning(
@@ -163,7 +163,7 @@ async def _main_async() -> None:
                 continue
 
             if raw.lower() in {"save_project", "sp"}:
-                commit_hash = unify.commit_project(
+                commit_hash = unisdk.commit_project(
                     args.project_name,
                     commit_message="WebSearcher sandbox save",
                 ).get("commit_hash")

--- a/scripts/check_no_release_versioning.py
+++ b/scripts/check_no_release_versioning.py
@@ -10,7 +10,7 @@ FIRST_PARTY = {
     "communication",
     "console",
     "orchestra",
-    "unify",
+    "unisdk",
     "unillm",
     "unity",
     "unity-deploy",

--- a/scripts/debug_project.py
+++ b/scripts/debug_project.py
@@ -4,15 +4,15 @@ from dotenv import load_dotenv
 load_dotenv()
 import os
 import requests
-import unify
+import unisdk
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--overwrite", type=bool, default=False)
     args = parser.parse_args()
-    unify.activate("Debug")
+    unisdk.activate("Debug")
     if args.overwrite:
-        unify.create_context("startup_events")
+        unisdk.create_context("startup_events")
     users = [
         "7bea302d-2518-48ac-b21d-61a0c53c5d0f",
         # "clxlmko0900539b72enccyi1o",

--- a/scripts/prompt_byok_keys.sh
+++ b/scripts/prompt_byok_keys.sh
@@ -382,7 +382,7 @@ ensure_sdk_logging_defaults() {
   # Suppress SDK request/response terminal spam — these are frozen at Python
   # import time from the .env file, which load_dotenv reads before SDK modules
   # are imported. File-based traces (logs/unillm/) are still written normally.
-  upsert_env "UNIFY_TERMINAL_LOG" "false"
+  upsert_env "UNISDK_TERMINAL_LOG" "false"
   upsert_env "UNILLM_TERMINAL_LOG" "false"
 }
 

--- a/tests/_prepare_shared_project.py
+++ b/tests/_prepare_shared_project.py
@@ -66,10 +66,10 @@ def _orchestra_reachable() -> bool:
 def prepare_shared_project() -> None:
     """Prepare the shared UnityTests project and Combined context."""
     try:
-        import unify
+        import unisdk
     except ImportError:
         print(
-            "Error: 'unify' package not found. Ensure the virtualenv is active.",
+            "Error: 'unisdk' package not found. Ensure the virtualenv is active.",
             file=sys.stderr,
         )
         sys.exit(1)
@@ -86,24 +86,24 @@ def prepare_shared_project() -> None:
 
     # 1. Activate/create project (idempotent - does not overwrite if exists)
     try:
-        unify.activate(PROJECT, overwrite=False)
+        unisdk.activate(PROJECT, overwrite=False)
     except Exception as e:
         # Tolerate activation failures (e.g., project already active in another process)
         print(f"Note: Project activation returned: {e}", file=sys.stderr)
 
-    unify.set_user_logging(False)
+    unisdk.set_user_logging(False)
 
     # 2. Ensure Combined context with fields (idempotent). Wrapped because the
     # project-activate above may have raced with another worker / partial
     # connectivity, leaving us in a state where create_context still fails.
     try:
-        unify.create_context("Combined")
+        unisdk.create_context("Combined")
     except Exception as e:
         print(f"Note: create_context('Combined') returned: {e}", file=sys.stderr)
 
     # Ensure fields exist (idempotent - create_fields tolerates existing fields)
     try:
-        unify.create_fields(
+        unisdk.create_fields(
             context="Combined",
             fields={
                 "test_fpath": {"type": "str", "mutable": True},

--- a/tests/actor/state_managers/simulated/coordinator/test_workspace_manager_code_act.py
+++ b/tests/actor/state_managers/simulated/coordinator/test_workspace_manager_code_act.py
@@ -89,7 +89,7 @@ async def test_code_act_routes_to_coordinator_list_assistants(monkeypatch) -> No
         return expected_assistants
 
     monkeypatch.setattr(
-        "unity.coordinator_manager.coordinator_manager.unify.list_assistants",
+        "unity.coordinator_manager.coordinator_manager.unisdk.list_assistants",
         _fake_list_assistants,
     )
     primitives = Primitives(primitive_scope=PrimitiveScope.single("coordinator"))
@@ -128,7 +128,7 @@ async def test_code_act_enforces_coordinator_permission_gate(monkeypatch) -> Non
         raise AssertionError(f"Unexpected upstream call: {kwargs}")
 
     monkeypatch.setattr(
-        "unity.coordinator_manager.coordinator_manager.unify.list_assistants",
+        "unity.coordinator_manager.coordinator_manager.unisdk.list_assistants",
         _should_not_call_upstream,
     )
     primitives = Primitives(primitive_scope=PrimitiveScope.single("coordinator"))

--- a/tests/async_tool_loop/test_otel.py
+++ b/tests/async_tool_loop/test_otel.py
@@ -318,8 +318,8 @@ class TestUnityToUnifyHierarchy:
 
         exporter = reset_otel["exporter"]
 
-        # Simulate unify's HTTP span
-        unify_tracer = trace.get_tracer("unify")
+        # Simulate unisdk's HTTP span
+        unify_tracer = trace.get_tracer("unisdk")
 
         with logger.unity_span("ContactManager.update") as unity_span:
             unity_ctx = unity_span.get_span_context()
@@ -360,7 +360,7 @@ class TestFullStackHierarchy:
         exporter = reset_otel["exporter"]
 
         unillm_tracer = trace.get_tracer("unillm")
-        unify_tracer = trace.get_tracer("unify")
+        unify_tracer = trace.get_tracer("unisdk")
 
         # Unity -> Unillm -> Unify
         with logger.unity_span("Actor.act") as unity_span:
@@ -398,7 +398,7 @@ class TestFullStackHierarchy:
 
         exporter = reset_otel["exporter"]
 
-        unify_tracer = trace.get_tracer("unify")
+        unify_tracer = trace.get_tracer("unisdk")
 
         with logger.unity_span("ContactManager.ask") as unity_span:
             # Two HTTP calls (e.g., list then get)
@@ -476,7 +476,7 @@ class TestCrossPackageIntegration:
 
         # Tracers from other packages will also use the same provider
         unillm_tracer = trace.get_tracer("unillm")
-        unify_tracer = trace.get_tracer("unify")
+        unify_tracer = trace.get_tracer("unisdk")
 
         # All tracers should be non-None
         assert unillm_tracer is not None
@@ -492,7 +492,7 @@ class TestCrossPackageIntegration:
 
         exporter = reset_otel["exporter"]
         unillm_tracer = trace.get_tracer("unillm")
-        unify_tracer = trace.get_tracer("unify")
+        unify_tracer = trace.get_tracer("unisdk")
 
         with logger.unity_span("Actor.act", method="ask") as unity_span:
             unity_span.set_attribute("unity.query", "find contacts")
@@ -771,7 +771,7 @@ class TestFileSpanExporterIntegration:
         provider.add_span_processor(SimpleSpanProcessor(file_exporter))
 
         unillm_tracer = trace.get_tracer("unillm")
-        unify_tracer = trace.get_tracer("unify")
+        unify_tracer = trace.get_tracer("unisdk")
 
         with logger.unity_span("Actor.act"):
             with unillm_tracer.start_as_current_span("LLM gpt-4"):

--- a/tests/blacklist_manager/test_destination_routing.py
+++ b/tests/blacklist_manager/test_destination_routing.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import uuid
 
 import pytest
-import unify
+import unisdk
 
 from tests.helpers import _handle_project
 from unity.blacklist_manager.blacklist_manager import BlackListManager
@@ -37,7 +37,7 @@ def _configure_teams() -> tuple[int, int]:
 def _reset_teams(team_ids: tuple[int, int]) -> None:
     for team_id in team_ids:
         try:
-            unify.delete_context(f"Teams/{team_id}/BlackList")
+            unisdk.delete_context(f"Teams/{team_id}/BlackList")
         except Exception:
             pass
     SESSION_DETAILS.team_ids = []
@@ -77,7 +77,7 @@ def test_blacklist_writes_route_to_destination_and_reads_merge_roots():
         assert destinations_by_detail[personal_detail] == "personal"
         assert destinations_by_detail[shared_detail] == f"team:{team_ids[0]}"
 
-        shared_rows = unify.get_logs(
+        shared_rows = unisdk.get_logs(
             context=f"Teams/{team_ids[0]}/BlackList",
             filter=f"contact_detail == '{shared_detail}'",
         )

--- a/tests/common/test_backfill.py
+++ b/tests/common/test_backfill.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import unify
+import unisdk
 from tests.helpers import _handle_project
 from unity.common.backfill import (
     backfill_assistant_field,
@@ -21,16 +21,16 @@ def test_backfill_assistant_field():
     ctx = "TestAssistant/TestBackfill"
 
     # Create context with required fields
-    unify.delete_context(ctx)
-    unify.create_context(ctx)
-    unify.create_fields({"name": "str", "_assistant": "str"}, context=ctx)
+    unisdk.delete_context(ctx)
+    unisdk.create_context(ctx)
+    unisdk.create_fields({"name": "str", "_assistant": "str"}, context=ctx)
 
     # Create logs without _assistant
     for i in range(5):
-        unify.log(context=ctx, name=f"item_{i}", new=True)
+        unisdk.log(context=ctx, name=f"item_{i}", new=True)
 
     # Verify they don't have _assistant (client-side check)
-    logs = unify.get_logs(context=ctx)
+    logs = unisdk.get_logs(context=ctx)
     assert (
         _count_logs_missing_assistant(logs) == 5
     ), f"Expected 5 logs without _assistant, got {_count_logs_missing_assistant(logs)}"
@@ -41,13 +41,13 @@ def test_backfill_assistant_field():
     assert result["context"] == ctx
 
     # Verify all now have _assistant (client-side check)
-    logs_after = unify.get_logs(context=ctx)
+    logs_after = unisdk.get_logs(context=ctx)
     assert (
         _count_logs_missing_assistant(logs_after) == 0
     ), "All logs should now have _assistant"
 
     # Verify correct value was set
-    logs_with = unify.get_logs(context=ctx, filter="_assistant == 'TestAssistant'")
+    logs_with = unisdk.get_logs(context=ctx, filter="_assistant == 'TestAssistant'")
     assert len(logs_with) == 5, f"Expected 5 logs with _assistant, got {len(logs_with)}"
 
 
@@ -57,9 +57,9 @@ def test_backfill_assistant_field_empty_context():
     ctx = "TestAssistant/TestBackfillEmpty"
 
     # Create empty context
-    unify.delete_context(ctx)
-    unify.create_context(ctx)
-    unify.create_fields({"name": "str", "_assistant": "str"}, context=ctx)
+    unisdk.delete_context(ctx)
+    unisdk.create_context(ctx)
+    unisdk.create_fields({"name": "str", "_assistant": "str"}, context=ctx)
 
     # Run backfill on empty context
     result = backfill_assistant_field(ctx, "TestAssistant")
@@ -72,18 +72,18 @@ def test_backfill_assistant_field_with_filter():
     """Backfill should respect additional filter."""
     ctx = "TestAssistant/TestBackfillFilter"
 
-    unify.delete_context(ctx)
-    unify.create_context(ctx)
-    unify.create_fields(
+    unisdk.delete_context(ctx)
+    unisdk.create_context(ctx)
+    unisdk.create_fields(
         {"name": "str", "category": "str", "_assistant": "str"},
         context=ctx,
     )
 
     # Create logs with different categories
     for i in range(3):
-        unify.log(context=ctx, name=f"item_a_{i}", category="A", new=True)
+        unisdk.log(context=ctx, name=f"item_a_{i}", category="A", new=True)
     for i in range(2):
-        unify.log(context=ctx, name=f"item_b_{i}", category="B", new=True)
+        unisdk.log(context=ctx, name=f"item_b_{i}", category="B", new=True)
 
     # Backfill only category A
     result = backfill_assistant_field(
@@ -94,14 +94,14 @@ def test_backfill_assistant_field_with_filter():
     assert result["total_updated"] == 3
 
     # Verify category A has _assistant
-    logs_a = unify.get_logs(
+    logs_a = unisdk.get_logs(
         context=ctx,
         filter="category == 'A' and _assistant == 'TestAssistant'",
     )
     assert len(logs_a) == 3
 
     # Verify category B does not have _assistant (client-side check)
-    logs_b = unify.get_logs(context=ctx, filter="category == 'B'")
+    logs_b = unisdk.get_logs(context=ctx, filter="category == 'B'")
     assert (
         _count_logs_missing_assistant(logs_b) == 2
     ), "Category B logs should not have _assistant"
@@ -117,15 +117,15 @@ def test_backfill_all_contexts_for_assistant():
     ctx2 = f"{assistant}/ContextTwo"
 
     for ctx in [ctx1, ctx2]:
-        unify.delete_context(ctx)
-        unify.create_context(ctx)
-        unify.create_fields({"name": "str", "_assistant": "str"}, context=ctx)
+        unisdk.delete_context(ctx)
+        unisdk.create_context(ctx)
+        unisdk.create_fields({"name": "str", "_assistant": "str"}, context=ctx)
 
     # Create logs in each context
     for i in range(3):
-        unify.log(context=ctx1, name=f"ctx1_item_{i}", new=True)
+        unisdk.log(context=ctx1, name=f"ctx1_item_{i}", new=True)
     for i in range(2):
-        unify.log(context=ctx2, name=f"ctx2_item_{i}", new=True)
+        unisdk.log(context=ctx2, name=f"ctx2_item_{i}", new=True)
 
     # Backfill all contexts
     results = backfill_all_contexts_for_assistant(assistant)
@@ -141,12 +141,12 @@ def test_backfill_idempotent():
     """Running backfill twice should not update already-backfilled logs."""
     ctx = "TestAssistant/TestBackfillIdempotent"
 
-    unify.delete_context(ctx)
-    unify.create_context(ctx)
-    unify.create_fields({"name": "str", "_assistant": "str"}, context=ctx)
+    unisdk.delete_context(ctx)
+    unisdk.create_context(ctx)
+    unisdk.create_fields({"name": "str", "_assistant": "str"}, context=ctx)
 
     for i in range(3):
-        unify.log(context=ctx, name=f"item_{i}", new=True)
+        unisdk.log(context=ctx, name=f"item_{i}", new=True)
 
     # First backfill
     result1 = backfill_assistant_field(ctx, "TestAssistant")

--- a/tests/common/test_context_registry.py
+++ b/tests/common/test_context_registry.py
@@ -1,7 +1,7 @@
 from unittest.mock import patch
 
 import pytest
-from unify.logs import CONTEXT_READ, CONTEXT_WRITE
+from unisdk.logs import CONTEXT_READ, CONTEXT_WRITE
 
 from unity.common.context_registry import ContextRegistry, TableContext
 from unity.common.tool_outcome import ToolErrorException

--- a/tests/common/test_federated_search.py
+++ b/tests/common/test_federated_search.py
@@ -220,7 +220,7 @@ def test_default_filter_fetcher_combines_context_and_caller_filters(monkeypatch)
         calls.append(kwargs)
         return [Row({"name": "row"})]
 
-    monkeypatch.setattr("unity.common.federated_search.unify.get_logs", fake_get_logs)
+    monkeypatch.setattr("unity.common.federated_search.unisdk.get_logs", fake_get_logs)
 
     rows = default_filter_fetcher(
         FederatedSearchContext(
@@ -259,7 +259,7 @@ def test_default_filter_fetcher_fetches_all_rows_when_missing_first(monkeypatch)
         calls.append(kwargs)
         return [Row({"name": f"row-{kwargs['offset']}"})]
 
-    monkeypatch.setattr("unity.common.federated_search.unify.get_logs", fake_get_logs)
+    monkeypatch.setattr("unity.common.federated_search.unisdk.get_logs", fake_get_logs)
 
     rows = default_filter_fetcher(
         FederatedSearchContext("ctx", "source"),

--- a/tests/common/test_foreign_keys_integration.py
+++ b/tests/common/test_foreign_keys_integration.py
@@ -17,7 +17,7 @@ Phase 4: Integration testing across all managers with FK relationships
 from __future__ import annotations
 
 import pytest
-import unify
+import unisdk
 from datetime import datetime
 from tests.helpers import _handle_project
 from unity.contact_manager.contact_manager import ContactManager
@@ -56,7 +56,10 @@ def test_delete_contact_transcripts_fk():
         phone_number="3333333333",
     )
 
-    contacts = unify.get_logs(context=cm._ctx, from_fields=["contact_id", "first_name"])
+    contacts = unisdk.get_logs(
+        context=cm._ctx,
+        from_fields=["contact_id", "first_name"],
+    )
     contact_map = {
         c.entries["first_name"]: int(c.entries["contact_id"]) for c in contacts
     }
@@ -95,7 +98,7 @@ def test_delete_contact_transcripts_fk():
     )
 
     # Verify 3 messages
-    messages = unify.get_logs(
+    messages = unisdk.get_logs(
         context=tm._transcripts_ctx,
         from_fields=["message_id", "sender_id", "receiver_ids"],
     )
@@ -107,7 +110,7 @@ def test_delete_contact_transcripts_fk():
     # Verify all 3 messages still exist (SET NULL on sender_id preserves messages)
     # Alice's message survives with null sender_id
     # Bob's and Carol's messages survive with Alice replaced by None in receiver_ids (in-place)
-    messages_after = unify.get_logs(
+    messages_after = unisdk.get_logs(
         context=tm._transcripts_ctx,
         from_fields=["message_id", "sender_id", "receiver_ids", "content"],
     )
@@ -187,7 +190,10 @@ def test_delete_image_nullifies_refs():
         email_address="bob@test.com",
         phone_number="2222222222",
     )
-    contacts = unify.get_logs(context=cm._ctx, from_fields=["contact_id", "first_name"])
+    contacts = unisdk.get_logs(
+        context=cm._ctx,
+        from_fields=["contact_id", "first_name"],
+    )
     alice_id = next(
         int(c.entries["contact_id"])
         for c in contacts
@@ -237,33 +243,36 @@ def test_delete_image_nullifies_refs():
     )
 
     # Verify image in both
-    messages = unify.get_logs(context=tm._transcripts_ctx, from_fields=["images"])
+    messages = unisdk.get_logs(context=tm._transcripts_ctx, from_fields=["images"])
     assert (
         messages[0].entries["images"][0]["raw_image_ref"]["image_id"] == shared_img_id
     )
 
-    guidance = unify.get_logs(context=gm._ctx, from_fields=["images"])
+    guidance = unisdk.get_logs(context=gm._ctx, from_fields=["images"])
     assert (
         guidance[0].entries["images"][0]["raw_image_ref"]["image_id"] == shared_img_id
     )
 
     # Delete the shared image
-    img_logs = unify.get_logs(
+    img_logs = unisdk.get_logs(
         context=im._ctx,
         filter=f"image_id == {shared_img_id}",
         return_ids_only=True,
     )
     assert img_logs, "Image not found"
-    unify.delete_logs(context=im._ctx, logs=img_logs[0])
+    unisdk.delete_logs(context=im._ctx, logs=img_logs[0])
 
     # Verify image_id replaced with None in both transcript and guidance (in-place SET NULL)
-    messages_after = unify.get_logs(context=tm._transcripts_ctx, from_fields=["images"])
+    messages_after = unisdk.get_logs(
+        context=tm._transcripts_ctx,
+        from_fields=["images"],
+    )
     msg_images = messages_after[0].entries.get("images", [])
     assert len(msg_images) == 1  # Array length unchanged
     assert msg_images[0]["raw_image_ref"]["image_id"] is None  # image_id set to None
     assert msg_images[0]["annotation"] == "Screenshot"  # Annotation preserved
 
-    guidance_after = unify.get_logs(context=gm._ctx, from_fields=["images"])
+    guidance_after = unisdk.get_logs(context=gm._ctx, from_fields=["images"])
     guid_images = guidance_after[0].entries.get("images", [])
     assert len(guid_images) == 1  # Array length unchanged
     assert guid_images[0]["raw_image_ref"]["image_id"] is None  # image_id set to None
@@ -295,7 +304,7 @@ def test_function_guidance_bidirectional_cascade():
     gm.add_guidance(title="Setup Guide", content="Setup instructions")
     gm.add_guidance(title="Usage Guide", content="Usage instructions")
 
-    guidance_list = unify.get_logs(
+    guidance_list = unisdk.get_logs(
         context=gm._ctx,
         from_fields=["guidance_id", "title"],
     )
@@ -306,7 +315,7 @@ def test_function_guidance_bidirectional_cascade():
     fm.add_functions(implementations=src)
 
     # Get function ID
-    func_logs = unify.get_logs(
+    func_logs = unisdk.get_logs(
         context=fm._compositional_ctx,
         filter="name == 'setup_system'",
         return_ids_only=True,
@@ -314,7 +323,7 @@ def test_function_guidance_bidirectional_cascade():
     assert func_logs, "Function not created"
 
     # Update function to reference both guidance entries
-    unify.update_logs(
+    unisdk.update_logs(
         context=fm._compositional_ctx,
         logs=func_logs[0],
         entries={"guidance_ids": [g_map["Setup Guide"], g_map["Usage Guide"]]},
@@ -322,20 +331,20 @@ def test_function_guidance_bidirectional_cascade():
     )
 
     # Get function ID
-    funcs = unify.get_logs(
+    funcs = unisdk.get_logs(
         context=fm._compositional_ctx,
         from_fields=["function_id", "guidance_ids"],
     )
     func_id = int(funcs[0].entries["function_id"])
 
-    # Update guidance entries to reference the function (using unify.update_logs)
+    # Update guidance entries to reference the function (using unisdk.update_logs)
     for title in ["Setup Guide", "Usage Guide"]:
-        guid_logs = unify.get_logs(
+        guid_logs = unisdk.get_logs(
             context=gm._ctx,
             filter=f"title == '{title}'",
             return_ids_only=True,
         )
-        unify.update_logs(
+        unisdk.update_logs(
             context=gm._ctx,
             logs=guid_logs[0],
             entries={"function_ids": [func_id]},
@@ -344,7 +353,7 @@ def test_function_guidance_bidirectional_cascade():
 
     # Verify bidirectional linkage
     # Function → Guidance
-    func_data = unify.get_logs(
+    func_data = unisdk.get_logs(
         context=fm._compositional_ctx,
         filter=f"function_id == {func_id}",
         from_fields=["guidance_ids"],
@@ -354,7 +363,7 @@ def test_function_guidance_bidirectional_cascade():
     )
 
     # Guidance → Function
-    guidance_after = unify.get_logs(
+    guidance_after = unisdk.get_logs(
         context=gm._ctx,
         from_fields=["guidance_id", "function_ids"],
     )
@@ -365,7 +374,7 @@ def test_function_guidance_bidirectional_cascade():
     gm.delete_guidance(guidance_id=g_map["Setup Guide"])
 
     # Verify removed from function's guidance_ids array (CASCADE behavior)
-    func_after = unify.get_logs(
+    func_after = unisdk.get_logs(
         context=fm._compositional_ctx,
         filter=f"function_id == {func_id}",
         from_fields=["guidance_ids"],
@@ -378,7 +387,7 @@ def test_function_guidance_bidirectional_cascade():
     fm.delete_function(function_id=func_id)
 
     # Verify removed from guidance's function_ids array (CASCADE behavior)
-    usage_guidance = unify.get_logs(
+    usage_guidance = unisdk.get_logs(
         context=gm._ctx,
         filter=f"guidance_id == {g_map['Usage Guide']}",
         from_fields=["function_ids"],
@@ -418,7 +427,7 @@ def test_delete_function_cascades_tasks_guidance():
     src = "def worker():\n    return 'work'\n"
     fm.add_functions(implementations=src)
 
-    funcs = unify.get_logs(context=fm._compositional_ctx, from_fields=["function_id"])
+    funcs = unisdk.get_logs(context=fm._compositional_ctx, from_fields=["function_id"])
     func_id = int(funcs[0].entries["function_id"])
 
     # Create task using this function
@@ -437,21 +446,21 @@ def test_delete_function_cascades_tasks_guidance():
     )
 
     # Verify references
-    task = unify.get_logs(
+    task = unisdk.get_logs(
         context=ts._ctx,
         filter=f"task_id == {task_id}",
         from_fields=["entrypoint"],
     )
     assert task[0].entries["entrypoint"] == func_id
 
-    guidance = unify.get_logs(context=gm._ctx, from_fields=["function_ids"])
+    guidance = unisdk.get_logs(context=gm._ctx, from_fields=["function_ids"])
     assert func_id in guidance[0].entries["function_ids"]
 
     # Delete the function
     fm.delete_function(function_id=func_id)
 
     # Verify task survives with null entrypoint (SET NULL behavior)
-    task_after = unify.get_logs(
+    task_after = unisdk.get_logs(
         context=ts._ctx,
         filter=f"task_id == {task_id}",
         from_fields=["task_id", "entrypoint"],
@@ -460,7 +469,7 @@ def test_delete_function_cascades_tasks_guidance():
     assert task_after[0].entries.get("entrypoint") is None  # SET NULL
 
     # Verify function_id removed from guidance array (CASCADE behavior)
-    guidance_after = unify.get_logs(context=gm._ctx, from_fields=["function_ids"])
+    guidance_after = unisdk.get_logs(context=gm._ctx, from_fields=["function_ids"])
     assert func_id not in guidance_after[0].entries.get(
         "function_ids",
         [],
@@ -521,7 +530,10 @@ def test_complex_fk_workflow():
         email_address="bob@test.com",
         phone_number="2222222222",
     )
-    contacts = unify.get_logs(context=cm._ctx, from_fields=["contact_id", "first_name"])
+    contacts = unisdk.get_logs(
+        context=cm._ctx,
+        from_fields=["contact_id", "first_name"],
+    )
     alice_id = next(
         int(c.entries["contact_id"])
         for c in contacts
@@ -554,7 +566,7 @@ def test_complex_fk_workflow():
     # Step 3: Create function
     src = "def process():\n    return 'processed'\n"
     fm.add_functions(implementations=src)
-    funcs = unify.get_logs(context=fm._compositional_ctx, from_fields=["function_id"])
+    funcs = unisdk.get_logs(context=fm._compositional_ctx, from_fields=["function_id"])
     func_id = int(funcs[0].entries["function_id"])
 
     # Step 4: Create guidance with images and function reference
@@ -564,7 +576,7 @@ def test_complex_fk_workflow():
         images=[{"raw_image_ref": {"image_id": img1_id}, "annotation": "Setup"}],
         function_ids=[func_id],
     )
-    guidance_list = unify.get_logs(context=gm._ctx, from_fields=["guidance_id"])
+    guidance_list = unisdk.get_logs(context=gm._ctx, from_fields=["guidance_id"])
     guidance_id = int(guidance_list[0].entries["guidance_id"])
 
     # Step 5: Create task with function entrypoint
@@ -590,7 +602,7 @@ def test_complex_fk_workflow():
     )
 
     # Verify all relationships established
-    messages = unify.get_logs(
+    messages = unisdk.get_logs(
         context=tm._transcripts_ctx,
         from_fields=["sender_id", "receiver_ids", "images"],
     )
@@ -600,15 +612,15 @@ def test_complex_fk_workflow():
     assert messages[0].entries["images"][0]["raw_image_ref"]["image_id"] == img2_id
 
     # Step 7: Delete img1 (used in guidance) - SET NULL behavior
-    img1_logs = unify.get_logs(
+    img1_logs = unisdk.get_logs(
         context=im._ctx,
         filter=f"image_id == {img1_id}",
         return_ids_only=True,
     )
     assert img1_logs, "Image not found"
-    unify.delete_logs(context=im._ctx, logs=img1_logs[0])
+    unisdk.delete_logs(context=im._ctx, logs=img1_logs[0])
 
-    guidance_check = unify.get_logs(
+    guidance_check = unisdk.get_logs(
         context=gm._ctx,
         filter=f"guidance_id == {guidance_id}",
         from_fields=["images"],
@@ -623,7 +635,7 @@ def test_complex_fk_workflow():
     fm.delete_function(function_id=func_id)
 
     # Task: SET NULL behavior (entrypoint becomes null)
-    task_check = unify.get_logs(
+    task_check = unisdk.get_logs(
         context=ts._ctx,
         filter=f"task_id == {task_id}",
         from_fields=[
@@ -634,7 +646,7 @@ def test_complex_fk_workflow():
     assert task_check[0].entries.get("entrypoint") is None  # SET NULL
 
     # Guidance: CASCADE behavior (function_id removed from array)
-    guidance_check2 = unify.get_logs(
+    guidance_check2 = unisdk.get_logs(
         context=gm._ctx,
         filter=f"guidance_id == {guidance_id}",
         from_fields=["function_ids"],
@@ -647,7 +659,7 @@ def test_complex_fk_workflow():
     # Step 9: Delete Alice - SET NULL behavior (message survives with null sender)
     cm._delete_contact(contact_id=alice_id)
 
-    messages_check = unify.get_logs(
+    messages_check = unisdk.get_logs(
         context=tm._transcripts_ctx,
         from_fields=["message_id", "sender_id", "receiver_ids"],
     )
@@ -684,7 +696,7 @@ def test_bulk_delete_preserves_fk_integrity():
             phone_number=f"{i:010d}",
         )
 
-    contacts = unify.get_logs(
+    contacts = unisdk.get_logs(
         context=cm._ctx,
         filter="contact_id > 1",
         from_fields=["contact_id"],
@@ -706,7 +718,7 @@ def test_bulk_delete_preserves_fk_integrity():
             )
 
     # Should have 5*5 = 25 messages
-    messages = unify.get_logs(context=tm._transcripts_ctx, from_fields=["message_id"])
+    messages = unisdk.get_logs(context=tm._transcripts_ctx, from_fields=["message_id"])
     assert len(messages) == 25
 
     # Bulk delete first 5 contacts (senders)
@@ -714,7 +726,7 @@ def test_bulk_delete_preserves_fk_integrity():
         cm._delete_contact(contact_id=cid)
 
     # All messages should survive with SET NULL on sender_id
-    messages_after = unify.get_logs(
+    messages_after = unisdk.get_logs(
         context=tm._transcripts_ctx,
         from_fields=["message_id", "sender_id", "receiver_ids"],
     )
@@ -754,21 +766,21 @@ def test_circular_fk_deletion_safety():
     # Create function
     src = "def circular():\n    return 'loop'\n"
     fm.add_functions(implementations=src)
-    funcs = unify.get_logs(context=fm._compositional_ctx, from_fields=["function_id"])
+    funcs = unisdk.get_logs(context=fm._compositional_ctx, from_fields=["function_id"])
     func_id = int(funcs[0].entries["function_id"])
 
     # Create guidance referencing function
     gm.add_guidance(title="Circular Guide", content="Guide", function_ids=[func_id])
-    guidance_list = unify.get_logs(context=gm._ctx, from_fields=["guidance_id"])
+    guidance_list = unisdk.get_logs(context=gm._ctx, from_fields=["guidance_id"])
     guidance_id = int(guidance_list[0].entries["guidance_id"])
 
     # Update function to reference guidance (circular reference)
-    func_logs = unify.get_logs(
+    func_logs = unisdk.get_logs(
         context=fm._compositional_ctx,
         filter=f"function_id == {func_id}",
         return_ids_only=True,
     )
-    unify.update_logs(
+    unisdk.update_logs(
         context=fm._compositional_ctx,
         logs=func_logs[0],
         entries={"guidance_ids": [guidance_id]},
@@ -776,14 +788,14 @@ def test_circular_fk_deletion_safety():
     )
 
     # Verify circular reference exists
-    func_data = unify.get_logs(
+    func_data = unisdk.get_logs(
         context=fm._compositional_ctx,
         filter=f"function_id == {func_id}",
         from_fields=["guidance_ids"],
     )
     assert guidance_id in func_data[0].entries["guidance_ids"]
 
-    guidance_data = unify.get_logs(
+    guidance_data = unisdk.get_logs(
         context=gm._ctx,
         filter=f"guidance_id == {guidance_id}",
         from_fields=["function_ids"],
@@ -794,7 +806,7 @@ def test_circular_fk_deletion_safety():
     fm.delete_function(function_id=func_id)
 
     # Verify guidance survives with function_id removed (CASCADE behavior)
-    guidance_after = unify.get_logs(
+    guidance_after = unisdk.get_logs(
         context=gm._ctx,
         filter=f"guidance_id == {guidance_id}",
         from_fields=["function_ids"],
@@ -829,7 +841,10 @@ def test_delete_exchange_cascades_messages():
         email_address="bob@test.com",
         phone_number="2222222222",
     )
-    contacts = unify.get_logs(context=cm._ctx, from_fields=["contact_id", "first_name"])
+    contacts = unisdk.get_logs(
+        context=cm._ctx,
+        from_fields=["contact_id", "first_name"],
+    )
     alice_id = next(
         int(c.entries["contact_id"])
         for c in contacts
@@ -875,7 +890,7 @@ def test_delete_exchange_cascades_messages():
         )
 
     # Verify 5 messages in exchange
-    messages_in_exchange = unify.get_logs(
+    messages_in_exchange = unisdk.get_logs(
         context=tm._transcripts_ctx,
         filter=f"exchange_id == {exchange_id}",
         from_fields=["message_id"],
@@ -883,16 +898,16 @@ def test_delete_exchange_cascades_messages():
     assert len(messages_in_exchange) == 5
 
     # Delete the exchange (CASCADE should delete all messages)
-    exchange_logs = unify.get_logs(
+    exchange_logs = unisdk.get_logs(
         context=tm._exchanges_ctx,
         filter=f"exchange_id == {exchange_id}",
         return_ids_only=True,
     )
     assert exchange_logs, "Exchange not found"
-    unify.delete_logs(context=tm._exchanges_ctx, logs=exchange_logs[0])
+    unisdk.delete_logs(context=tm._exchanges_ctx, logs=exchange_logs[0])
 
     # Verify all messages deleted (CASCADE behavior)
-    messages_after = unify.get_logs(
+    messages_after = unisdk.get_logs(
         context=tm._transcripts_ctx,
         from_fields=["message_id"],
     )

--- a/tests/common/test_metrics_utils.py
+++ b/tests/common/test_metrics_utils.py
@@ -2,20 +2,20 @@ from __future__ import annotations
 
 import uuid
 
-import unify
+import unisdk
 
 from unity.common.metrics_utils import reduce_logs, SUPPORTED_REDUCTION_METRICS
 
 
 def _create_test_context() -> str:
     ctx = f"tests/common/metrics_utils/{uuid.uuid4().hex}"
-    unify.create_context(
+    unisdk.create_context(
         ctx,
         unique_keys={"row_id": "int"},
         auto_counting={"row_id": None},
         description="metrics_utils test context",
     )
-    unify.create_fields(
+    unisdk.create_fields(
         {
             "row_id": {"type": "int"},
             "value": {"type": "float"},
@@ -24,9 +24,9 @@ def _create_test_context() -> str:
         context=ctx,
     )
     # Three simple rows for deterministic aggregates
-    unify.log(context=ctx, new=True, row_id=1, value=1.0, category="a")
-    unify.log(context=ctx, new=True, row_id=2, value=2.0, category="a")
-    unify.log(context=ctx, new=True, row_id=3, value=3.0, category="b")
+    unisdk.log(context=ctx, new=True, row_id=1, value=1.0, category="a")
+    unisdk.log(context=ctx, new=True, row_id=2, value=2.0, category="a")
+    unisdk.log(context=ctx, new=True, row_id=3, value=3.0, category="b")
     return ctx
 
 
@@ -46,7 +46,7 @@ def test_reduce_logs_single_key_and_filter():
         )
         assert mean_gt1 == 2.5
     finally:
-        unify.delete_context(ctx)
+        unisdk.delete_context(ctx)
 
 
 def test_reduce_logs_multi_key_and_group_by():
@@ -77,7 +77,7 @@ def test_reduce_logs_multi_key_and_group_by():
         )
         assert isinstance(grouped_multi, dict)
     finally:
-        unify.delete_context(ctx)
+        unisdk.delete_context(ctx)
 
 
 def test_reduce_logs_rejects_unsupported_metric():
@@ -91,4 +91,4 @@ def test_reduce_logs_rejects_unsupported_metric():
         except ValueError:
             pass
     finally:
-        unify.delete_context(ctx)
+        unisdk.delete_context(ctx)

--- a/tests/common/test_multi_term_client_combine.py
+++ b/tests/common/test_multi_term_client_combine.py
@@ -68,8 +68,8 @@ def _fake_get_context(context, *, project=None, **kwargs):
 
 
 def test_combined_client_side_mean_with_missing_penalty(monkeypatch):
-    monkeypatch.setattr(unify, "get_logs", _fake_get_logs)
-    monkeypatch.setattr(unify, "get_context", _fake_get_context)
+    monkeypatch.setattr(unisdk, "get_logs", _fake_get_logs)
+    monkeypatch.setattr(unisdk, "get_context", _fake_get_context)
 
     rows, score_key = fetch_top_k_by_terms_combined_client_side(
         "Guidance",
@@ -93,8 +93,8 @@ def test_combined_client_side_mean_with_missing_penalty(monkeypatch):
 
 
 def test_combined_client_side_applies_k_window(monkeypatch):
-    monkeypatch.setattr(unify, "get_logs", _fake_get_logs)
-    monkeypatch.setattr(unify, "get_context", _fake_get_context)
+    monkeypatch.setattr(unisdk, "get_logs", _fake_get_logs)
+    monkeypatch.setattr(unisdk, "get_context", _fake_get_context)
 
     rows, _ = fetch_top_k_by_terms_combined_client_side(
         "Guidance",
@@ -142,7 +142,7 @@ def test_multi_term_foreign_project_routes_to_client_side(monkeypatch):
 
 
 def test_single_term_foreign_project_stays_on_sort_distance_path(monkeypatch):
-    monkeypatch.setattr(unify, "get_logs", _fake_get_logs)
+    monkeypatch.setattr(unisdk, "get_logs", _fake_get_logs)
 
     rows, score_key = fetch_top_k_by_terms_with_score(
         "Guidance",

--- a/tests/common/test_multi_term_client_combine.py
+++ b/tests/common/test_multi_term_client_combine.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 import re
 from types import SimpleNamespace
 
-import unify
 
 import unity.common.semantic_search as semantic_search
 from unity.common.semantic_search import (

--- a/tests/common/test_prompt_helpers.py
+++ b/tests/common/test_prompt_helpers.py
@@ -46,7 +46,7 @@ def test_assistant_timezone_lookup_caches_within_ttl(monkeypatch):
 
     monkeypatch.setattr(module, "_contacts_context", lambda: "User/Assistant/Contacts")
     monkeypatch.setattr(module.time, "monotonic", lambda: 1000.0)
-    monkeypatch.setattr("unify.get_logs", fake_get_logs)
+    monkeypatch.setattr("unisdk.get_logs", fake_get_logs)
 
     assert module.get_assistant_timezone() == "Asia/Karachi"
     assert module.get_assistant_timezone() == "Asia/Karachi"
@@ -66,7 +66,7 @@ def test_assistant_timezone_lookup_refreshes_after_ttl(monkeypatch):
 
     monkeypatch.setattr(module, "_contacts_context", lambda: "User/Assistant/Contacts")
     monkeypatch.setattr(module.time, "monotonic", lambda: monotonic_now["value"])
-    monkeypatch.setattr("unify.get_logs", fake_get_logs)
+    monkeypatch.setattr("unisdk.get_logs", fake_get_logs)
 
     assert module.get_assistant_timezone() == "Asia/Karachi"
     monotonic_now["value"] += 299
@@ -93,7 +93,7 @@ def test_now_recomputes_current_time_while_reusing_cached_timezone(monkeypatch):
     monkeypatch.setattr(module, "_contacts_context", lambda: "User/Assistant/Contacts")
     monkeypatch.setattr(module.time, "monotonic", lambda: 1000.0)
     monkeypatch.setattr(module, "_utc_now", lambda: next(current_times))
-    monkeypatch.setattr("unify.get_logs", fake_get_logs)
+    monkeypatch.setattr("unisdk.get_logs", fake_get_logs)
 
     first = module.now(as_string=False)
     second = module.now(as_string=False)
@@ -118,7 +118,7 @@ def test_now_falls_back_to_utc_when_timezone_lookup_fails(monkeypatch):
         "_utc_now",
         lambda: datetime(2026, 5, 7, 8, 0, 0, tzinfo=timezone.utc),
     )
-    monkeypatch.setattr("unify.get_logs", fake_get_logs)
+    monkeypatch.setattr("unisdk.get_logs", fake_get_logs)
 
     assert module.get_assistant_timezone() is None
     assert module.now() == "Thursday, May 07, 2026 at 08:00 AM UTC"
@@ -137,7 +137,7 @@ def test_failed_assistant_timezone_lookup_does_not_poison_cache(monkeypatch):
 
     monkeypatch.setattr(module, "_contacts_context", lambda: "User/Assistant/Contacts")
     monkeypatch.setattr(module.time, "monotonic", lambda: 1000.0)
-    monkeypatch.setattr("unify.get_logs", fake_get_logs)
+    monkeypatch.setattr("unisdk.get_logs", fake_get_logs)
 
     assert module.get_assistant_timezone() is None
     assert module.get_assistant_timezone() == "Asia/Karachi"
@@ -156,7 +156,7 @@ def test_missing_assistant_timezone_row_does_not_poison_cache(monkeypatch):
 
     monkeypatch.setattr(module, "_contacts_context", lambda: "User/Assistant/Contacts")
     monkeypatch.setattr(module.time, "monotonic", lambda: 1000.0)
-    monkeypatch.setattr("unify.get_logs", fake_get_logs)
+    monkeypatch.setattr("unisdk.get_logs", fake_get_logs)
 
     assert module.get_assistant_timezone() is None
     assert module.get_assistant_timezone() == "Asia/Karachi"

--- a/tests/common/test_schemas.py
+++ b/tests/common/test_schemas.py
@@ -14,7 +14,7 @@ from datetime import date, datetime, time, UTC
 from enum import Enum
 
 import pytest
-import unify
+import unisdk
 from pydantic import BaseModel, Field
 
 from tests.helpers import _handle_project
@@ -803,7 +803,7 @@ def test_nested_image_schema_enforcement() -> None:
 
     # Build a per-test context under the active write context (mirrors other tests)
     try:
-        ctxs = unify.get_active_context()
+        ctxs = unisdk.get_active_context()
         base_ctx = ctxs.get("write") if isinstance(ctxs, dict) else None
     except Exception:
         base_ctx = None
@@ -820,7 +820,7 @@ def test_nested_image_schema_enforcement() -> None:
     store.ensure_context()
 
     # 1) The created field should include a nested schema – assert key substrings
-    fields = unify.get_fields(context=ctx)
+    fields = unisdk.get_fields(context=ctx)
     assert "images" in fields
     dtype = str(fields["images"].get("data_type"))
     # Expect array/list with object items including raw_image_ref + annotation
@@ -831,7 +831,7 @@ def test_nested_image_schema_enforcement() -> None:
         "medium": "email",
         "sender_id": 1,
         "receiver_ids": [2],
-        # Pass ISO-8601 string – unify.log's JSON body must be serializable
+        # Pass ISO-8601 string – unisdk.log's JSON body must be serializable
         "timestamp": datetime.now(UTC).isoformat(),
         "content": "hello",
     }
@@ -843,7 +843,7 @@ def test_nested_image_schema_enforcement() -> None:
             {"raw_image_ref": {"image_id": 101}, "annotation": "blue square"},
         ],
     }
-    _ = unify.log(context=ctx, **valid_payload, new=True, mutable=True)
+    _ = unisdk.log(context=ctx, **valid_payload, new=True, mutable=True)
 
     # 3) Invalid nested payload – wrong key name for image id → must be rejected
     invalid_payload_bad_key = {
@@ -853,7 +853,7 @@ def test_nested_image_schema_enforcement() -> None:
         ],
     }
     with pytest.raises(Exception):
-        unify.log(context=ctx, **invalid_payload_bad_key, new=True, mutable=True)
+        unisdk.log(context=ctx, **invalid_payload_bad_key, new=True, mutable=True)
 
     # 4) Invalid nested payload – wrong type for annotation → must be rejected
     invalid_payload_bad_type = {
@@ -863,7 +863,7 @@ def test_nested_image_schema_enforcement() -> None:
         ],
     }
     with pytest.raises(Exception):
-        unify.log(context=ctx, **invalid_payload_bad_type, new=True, mutable=True)
+        unisdk.log(context=ctx, **invalid_payload_bad_type, new=True, mutable=True)
 
 
 # --------------------------------------------------------------------------- #
@@ -905,7 +905,7 @@ def test_nested_pydantic_schema_enforcement() -> None:
 
     # Create a dedicated context for this test
     try:
-        ctxs = unify.get_active_context()
+        ctxs = unisdk.get_active_context()
         base_ctx = ctxs.get("write") if isinstance(ctxs, dict) else None
     except Exception:
         base_ctx = None
@@ -922,7 +922,7 @@ def test_nested_pydantic_schema_enforcement() -> None:
     store.ensure_context()
 
     # Field typing should contain nested property names for the payload schema
-    fields = unify.get_fields(context=ctx)
+    fields = unisdk.get_fields(context=ctx)
     assert "payload" in fields
     dtype = str(fields["payload"].get("data_type"))
     # Assert several nested keys appear in the serialized schema
@@ -950,7 +950,7 @@ def test_nested_pydantic_schema_enforcement() -> None:
             "primary_pet": {"name": "Rex", "kind": "dog", "age": 5},
         },
     }
-    _ = unify.log(context=ctx, **valid, new=True, mutable=True)
+    _ = unisdk.log(context=ctx, **valid, new=True, mutable=True)
 
     # Invalid 1: wrong nested key (zip instead of zip_code) → reject
     invalid_bad_key = {
@@ -962,7 +962,7 @@ def test_nested_pydantic_schema_enforcement() -> None:
         },
     }
     with pytest.raises(Exception):
-        unify.log(context=ctx, **invalid_bad_key, new=True, mutable=True)
+        unisdk.log(context=ctx, **invalid_bad_key, new=True, mutable=True)
 
     # Invalid 2: wrong type in list (pets elements must be objects) → reject
     invalid_bad_list = {
@@ -974,7 +974,7 @@ def test_nested_pydantic_schema_enforcement() -> None:
         },
     }
     with pytest.raises(Exception):
-        unify.log(context=ctx, **invalid_bad_list, new=True, mutable=True)
+        unisdk.log(context=ctx, **invalid_bad_list, new=True, mutable=True)
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/common/test_search.py
+++ b/tests/common/test_search.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import pytest
-import unify
+import unisdk
 
 from tests.helpers import _handle_project
 from unity.common.context_store import TableStore
@@ -27,7 +27,7 @@ async def test_concurrent_semantic_search(capfd):
 
     # Build a per-test context under the active write context
     try:
-        ctxs = unify.get_active_context()
+        ctxs = unisdk.get_active_context()
         base_ctx = ctxs.get("write") if isinstance(ctxs, dict) else None
     except Exception:
         base_ctx = None
@@ -48,21 +48,21 @@ async def test_concurrent_semantic_search(capfd):
     store.ensure_context()
 
     # Seed a few rows to take the semantic path on the 'bio' column
-    unify.log(
+    unisdk.log(
         context=ctx,
         first_name="Alice",
         bio="Enjoys email threads and detailed reports",
         new=True,
         mutable=True,
     )
-    unify.log(
+    unisdk.log(
         context=ctx,
         first_name="Bob",
         bio="Prefers short text messages, hates long emails",
         new=True,
         mutable=True,
     )
-    unify.log(
+    unisdk.log(
         context=ctx,
         first_name="Carol",
         bio="Commutes by train; likes concise updates over email",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,7 +28,7 @@ import hashlib
 
 import httpx
 import pytest
-import unify
+import unisdk
 from pytest_metadata.plugin import metadata_key
 
 from datetime import datetime, timezone
@@ -124,12 +124,12 @@ def _set_unify_context_for_test(item: pytest.Item) -> None:
         skip_ctx_create = ctx in PRECREATED_CONTEXTS
     else:
         try:
-            unify.delete_context(ctx)
+            unisdk.delete_context(ctx)
         except Exception:
             pass
 
     try:
-        unify.set_context(ctx, relative=False, skip_create=skip_ctx_create)
+        unisdk.set_context(ctx, relative=False, skip_create=skip_ctx_create)
     except Exception:
         pass  # Project may not exist yet; tests that need it will fail on their own
 
@@ -159,12 +159,12 @@ def _unset_unify_context_for_test(item: pytest.Item) -> None:
     try:
         if ctx and SETTINGS.UNIFY_DELETE_CONTEXT_ON_EXIT:
             try:
-                unify.delete_context(ctx)
+                unisdk.delete_context(ctx)
             except Exception:
                 pass
     finally:
         try:
-            unify.unset_context()
+            unisdk.unset_context()
         except Exception:
             pass
 
@@ -174,7 +174,7 @@ def pytest_report_header(config):
     return [
         f"orchestra_url={os.environ.get('ORCHESTRA_URL')}",
         f"unity_comms_url={os.environ.get('UNITY_COMMS_URL')}",
-        f"unify_project={unify.active_project()}",
+        f"unify_project={unisdk.active_project()}",
         f"UNILLM_CACHE={os.environ.get('UNILLM_CACHE', 'not set')}",
     ] + settings_str
 
@@ -474,7 +474,7 @@ def pytest_sessionstart(session):
         and not SETTINGS.UNIFY_SKIP_SESSION_SETUP
     ):
         try:
-            unify.delete_project(project_name)
+            unisdk.delete_project(project_name)
         except Exception:
             pass  # Project may not exist yet
 
@@ -490,14 +490,14 @@ def pytest_sessionstart(session):
     if SETTINGS.UNIFY_SKIP_SESSION_SETUP:
         # Project and shared contexts already prepared externally (e.g., by
         # ._prepare_shared_project.sh). Just activate without overwrite.
-        unify.activate(project_name, overwrite=False)
-        unify.set_user_logging(False)
+        unisdk.activate(project_name, overwrite=False)
+        unisdk.set_user_logging(False)
     else:
-        unify.activate(
+        unisdk.activate(
             project_name,
             overwrite=SETTINGS.UNIFY_OVERWRITE_PROJECT,
         )
-        unify.set_user_logging(False)
+        unisdk.set_user_logging(False)
 
     # ------------------------------------------------------------------
     #  Ensure the unity runtime is fully initialised for the test suite
@@ -559,9 +559,9 @@ def pytest_sessionstart(session):
         # Combined context already prepared externally; skip creation
         pass
     else:
-        unify.create_context("Combined")
+        unisdk.create_context("Combined")
         try:
-            unify.create_fields(
+            unisdk.create_fields(
                 context="Combined",
                 fields={
                     "test_fpath": {"type": "str", "mutable": True},
@@ -602,7 +602,7 @@ def pytest_sessionfinish(session, exitstatus):
         pass
 
     if SETTINGS.UNIFY_TESTS_DELETE_PROJ_ON_EXIT:
-        unify.delete_project(unify.active_project())
+        unisdk.delete_project(unisdk.active_project())
 
 
 def pytest_unconfigure(config):
@@ -765,7 +765,7 @@ def pytest_runtest_setup(item):
 def _normalize_pytest_nodeid(nodeid):
     """
     Try to normalize the pytest nodeid to an alphanumeric string that is
-    accepted for unify.Context path. If not possible, return None.
+    accepted for unisdk.Context path. If not possible, return None.
     Will fallback to invocation count if empty.
     """
     bracket_match = re.search(r"\[([^\]]+)\]", nodeid)
@@ -932,7 +932,7 @@ def pytest_collection_finish(session):
         # TODO: Should delete contexts before creating them
         # But this is mostly fine now for CI purpose, as we create
         # a fresh project anyway
-        unify.create_contexts(list(contexts))
+        unisdk.create_contexts(list(contexts))
         PRECREATED_CONTEXTS.update(contexts)
 
 

--- a/tests/contact_manager/conftest.py
+++ b/tests/contact_manager/conftest.py
@@ -5,7 +5,7 @@ import pytest_asyncio
 from typing import List, Dict, Tuple, Any
 import os
 
-import unify
+import unisdk
 from unity.contact_manager.contact_manager import ContactManager
 from unity.manager_registry import ManagerRegistry
 from unity.common.context_registry import ContextRegistry
@@ -125,7 +125,7 @@ def _ensure_embeddings_exist(context: str) -> bool:
     Returns True if any embeddings were created (scenario needs recommit).
     """
     try:
-        fields = unify.get_fields(context=context)
+        fields = unisdk.get_fields(context=context)
     except Exception:
         return False
 
@@ -154,9 +154,9 @@ def _rebuild_commit_hashes(
     commit_hashes: Dict[str, Any],
 ) -> None:
     """Rebuild commit hashes from existing context commits."""
-    existing_contexts = unify.get_contexts(prefix=ctx_prefix)
+    existing_contexts = unisdk.get_contexts(prefix=ctx_prefix)
     for ctx_name in existing_contexts.keys():
-        history = unify.get_context_commits(ctx_name)
+        history = unisdk.get_context_commits(ctx_name)
         if history:
             commit_hashes[ctx_name] = history[0]["commit_hash"]
 
@@ -166,9 +166,9 @@ def _commit_contexts_for_rollback(
     commit_hashes: Dict[str, Any],
 ) -> None:
     """Commit all contexts under prefix and store hashes for rollback."""
-    existing_contexts = unify.get_contexts(prefix=ctx_prefix)
+    existing_contexts = unisdk.get_contexts(prefix=ctx_prefix)
     for ctx_name in existing_contexts.keys():
-        commit_info = unify.commit_context(
+        commit_info = unisdk.commit_context(
             name=ctx_name,
             commit_message="Initial seed data for contact manager tests",
         )
@@ -201,13 +201,13 @@ def _setup_scenario(
 
     # If --overwrite-scenarios is set, delete existing contexts first
     if overwrite_scenarios:
-        existing_contexts = unify.get_contexts(prefix=ctx)
+        existing_contexts = unisdk.get_contexts(prefix=ctx)
         for ctx_name in existing_contexts.keys():
-            unify.delete_context(ctx_name)
+            unisdk.delete_context(ctx_name)
 
     # Set context before any operations
-    unify.create_context(ctx)  # exist_ok=True by default
-    unify.set_context(ctx, relative=False)
+    unisdk.create_context(ctx)  # exist_ok=True by default
+    unisdk.set_context(ctx, relative=False)
 
     # Use file lock to coordinate ContactManager creation and seeding.
     # ContactManager.__init__ creates system contacts (assistant id=0, user id=1)
@@ -236,7 +236,7 @@ def _setup_scenario(
             _precompute_embeddings(cm._ctx)
             _commit_contexts_for_rollback(ctx, commit_hashes)
 
-    unify.unset_context()
+    unisdk.unset_context()
     return cm, id_mapping
 
 
@@ -281,7 +281,7 @@ def contact_manager_scenario(contact_read_scenario):
     cm, id_map = contact_read_scenario
 
     def rollback_context(ctx):
-        unify.rollback_context(
+        unisdk.rollback_context(
             name=ctx,
             commit_hash=_READ_SCENARIO_COMMIT_HASHES[ctx],
         )
@@ -292,7 +292,7 @@ def contact_manager_scenario(contact_read_scenario):
         # from rolling back while this test is running
         ctx_names = list(_READ_SCENARIO_COMMIT_HASHES.keys())
         if ctx_names:
-            unify.map(rollback_context, ctx_names, mode="asyncio")
+            unisdk.map(rollback_context, ctx_names, mode="asyncio")
 
         restore_scenario_context("tests/contact/ReadScenario")
         yield cm, id_map
@@ -342,7 +342,7 @@ def contact_manager_mutation_scenario(contact_mutation_scenario):
     cm, id_map = contact_mutation_scenario
 
     def rollback_context(ctx):
-        unify.rollback_context(
+        unisdk.rollback_context(
             name=ctx,
             commit_hash=_MUTATION_SCENARIO_COMMIT_HASHES[ctx],
         )
@@ -353,7 +353,7 @@ def contact_manager_mutation_scenario(contact_mutation_scenario):
         # from rolling back while this test is running
         ctx_names = list(_MUTATION_SCENARIO_COMMIT_HASHES.keys())
         if ctx_names:
-            unify.map(rollback_context, ctx_names, mode="asyncio")
+            unisdk.map(rollback_context, ctx_names, mode="asyncio")
 
         restore_scenario_context("tests/contact/MutationScenario")
         yield cm, id_map

--- a/tests/contact_manager/test_data_store.py
+++ b/tests/contact_manager/test_data_store.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 import time
-import unify
+import unisdk
 
 from unity.contact_manager.contact_manager import ContactManager
 from unity.common.context_registry import ContextRegistry
@@ -277,7 +277,7 @@ def test_get_info_cache_fallback_reads_accessible_space_roots():
             personal_ds[cid]
     finally:
         try:
-            unify.delete_context(f"Teams/{team_id}/Contacts")
+            unisdk.delete_context(f"Teams/{team_id}/Contacts")
         except Exception:
             pass
         SESSION_DETAILS.team_ids = []

--- a/tests/contact_manager/test_move_to_blacklist_destination.py
+++ b/tests/contact_manager/test_move_to_blacklist_destination.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import uuid
 import time
 
-import unify
+import unisdk
 
 from tests.helpers import _handle_project
 from unity.common.context_registry import ContextRegistry
@@ -34,7 +34,7 @@ def _reset_space(team_id: int) -> None:
         f"Teams/{team_id}/BlackList",
     ):
         try:
-            unify.delete_context(context)
+            unisdk.delete_context(context)
         except Exception:
             pass
     SESSION_DETAILS.team_ids = []
@@ -66,14 +66,14 @@ def test_move_to_blacklist_preserves_shared_team_destination():
 
         contact_rows = []
         for _ in range(10):
-            contact_rows = unify.get_logs(
+            contact_rows = unisdk.get_logs(
                 context=f"Teams/{team_id}/Contacts",
                 filter=f"contact_id == {contact_id}",
             )
             if not contact_rows:
                 break
             time.sleep(0.2)
-        blacklist_rows = unify.get_logs(
+        blacklist_rows = unisdk.get_logs(
             context=f"Teams/{team_id}/BlackList",
             filter=f"contact_detail == '{email}'",
         )

--- a/tests/contact_manager/test_reduce_metrics.py
+++ b/tests/contact_manager/test_reduce_metrics.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 import time
-import unify
+import unisdk
 
 from tests.helpers import _handle_project
 from unity.common.context_registry import ContextRegistry
@@ -121,7 +121,7 @@ def test_contact_reduce_reads_personal_and_accessible_space_roots():
         )
     finally:
         try:
-            unify.delete_context(f"Teams/{team_id}/Contacts")
+            unisdk.delete_context(f"Teams/{team_id}/Contacts")
         except Exception:
             pass
         SESSION_DETAILS.team_ids = []

--- a/tests/contact_manager/test_sys_msgs.py
+++ b/tests/contact_manager/test_sys_msgs.py
@@ -173,14 +173,14 @@ def _build_prompt_in_subprocess(method: str, test_context: str) -> str:
         f"""
         import os, sys
         sys.path.insert(0, os.getcwd())
-        import unify
+        import unisdk
         # Activate the test project before setting context
         project_name = os.environ.get("UNITY_TEST_PROJECT_NAME", "UnityTests")
-        unify.activate(project_name, overwrite=False)
+        unisdk.activate(project_name, overwrite=False)
         # Set test-specific context before creating ContactManager to avoid races
         test_ctx = os.environ.get("_TEST_CONTEXT")
         if test_ctx:
-            unify.set_context(test_ctx, relative=False)
+            unisdk.set_context(test_ctx, relative=False)
         import unity.common.prompt_helpers as _ph
         from datetime import datetime, timezone
         def _static_now(time_only: bool = False):

--- a/tests/contact_manager/test_tool_docstrings.py
+++ b/tests/contact_manager/test_tool_docstrings.py
@@ -74,14 +74,14 @@ def _build_tools_schema_in_subprocess(method: str, test_context: str) -> str:
         f"""
 		import os, sys, json
 		sys.path.insert(0, os.getcwd())
-		import unify
+		import unisdk
 		# Activate the test project before setting context
 		project_name = os.environ.get("UNITY_TEST_PROJECT_NAME", "UnityTests")
-		unify.activate(project_name, overwrite=False)
+		unisdk.activate(project_name, overwrite=False)
 		# Set test-specific context before creating ContactManager to avoid races
 		test_ctx = os.environ.get("_TEST_CONTEXT")
 		if test_ctx:
-			unify.set_context(test_ctx, relative=False)
+			unisdk.set_context(test_ctx, relative=False)
 		from unity.common.llm_helpers import method_to_schema
 		def _unwrap_callable(tool):
 			return getattr(tool, "fn", tool)

--- a/tests/contact_manager/test_update.py
+++ b/tests/contact_manager/test_update.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 import asyncio
 import pytest
 import time
-import unify
+import unisdk
 from typing import Dict, Any
-from unify.utils.http import RequestError
+from unisdk.utils.http import RequestError
 
 from unity.contact_manager.contact_manager import ContactManager
 from unity.contact_manager.types.contact import Contact
@@ -54,7 +54,7 @@ def _programmatic_contact_check(
 
 def _contacts_with_email(context: str, email: str) -> list:
     try:
-        return unify.get_logs(
+        return unisdk.get_logs(
             context=context,
             filter=f"email_address == '{email}'",
             limit=10,
@@ -81,7 +81,7 @@ def _configure_contact_routing_space(team_id: int) -> None:
 
 def _reset_contact_routing_space(team_id: int) -> None:
     try:
-        unify.delete_context(f"Teams/{team_id}/Contacts")
+        unisdk.delete_context(f"Teams/{team_id}/Contacts")
     except Exception:
         pass
     SESSION_DETAILS.team_ids = []

--- a/tests/conversation_manager/actions/integration/helpers.py
+++ b/tests/conversation_manager/actions/integration/helpers.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Awaitable, Callable, TypeVar
 
-import unify
+import unisdk
 
 from tests.conversation_manager.cm_helpers import filter_events_by_type
 from unity.conversation_manager.events import (
@@ -672,7 +672,7 @@ def verify_transcript_logged(
         "receiver_ids",
         "exchange_id",
     ]
-    logs = unify.get_logs(
+    logs = unisdk.get_logs(
         context=ctx,
         limit=limit,
         sorting={"timestamp": "descending"},

--- a/tests/conversation_manager/core/test_brain.py
+++ b/tests/conversation_manager/core/test_brain.py
@@ -402,7 +402,7 @@ class TestBuildBrainSpecCoordinatorPrompt:
         SESSION_DETAILS.unify_key = "owner-key"
 
         with patch(
-            "unity.coordinator_manager.coordinator_manager.unify.list_assistants",
+            "unity.coordinator_manager.coordinator_manager.unisdk.list_assistants",
         ) as list_assistants:
             spec = build_brain_spec(_make_cm(), _make_snapshot())
 
@@ -419,11 +419,11 @@ class TestBuildBrainSpecCoordinatorPrompt:
 
         with (
             patch(
-                "unity.coordinator_manager.coordinator_manager.unify.list_org_members",
+                "unity.coordinator_manager.coordinator_manager.unisdk.list_org_members",
                 return_value=[{"first_name": "Dana", "surname": "Owner"}],
             ) as list_org_members,
             patch(
-                "unity.coordinator_manager.coordinator_manager.unify.list_assistants",
+                "unity.coordinator_manager.coordinator_manager.unisdk.list_assistants",
             ) as list_assistants,
         ):
             spec = build_brain_spec(_make_cm(), _make_snapshot())
@@ -447,7 +447,7 @@ class TestBuildBrainSpecCoordinatorPrompt:
         SESSION_DETAILS.assistant.is_coordinator = False
 
         with patch(
-            "unity.coordinator_manager.coordinator_manager.unify.list_assistants",
+            "unity.coordinator_manager.coordinator_manager.unisdk.list_assistants",
             return_value=[],
         ) as list_assistants:
             spec = build_brain_spec(_make_cm(), _make_snapshot())
@@ -465,10 +465,10 @@ class TestBuildBrainSpecCoordinatorPrompt:
 
         with (
             patch(
-                "unity.coordinator_manager.coordinator_manager.unify.list_org_members",
+                "unity.coordinator_manager.coordinator_manager.unisdk.list_org_members",
             ) as list_org_members,
             patch(
-                "unity.coordinator_manager.coordinator_manager.unify.list_assistants",
+                "unity.coordinator_manager.coordinator_manager.unisdk.list_assistants",
             ) as list_assistants,
         ):
             spec = build_brain_spec(_make_cm(), _make_snapshot())

--- a/tests/conversation_manager/core/test_coordinator_persistence_eval.py
+++ b/tests/conversation_manager/core/test_coordinator_persistence_eval.py
@@ -12,10 +12,10 @@ from typing import Any
 
 import pytest
 import requests
-import unify
-from unify.utils import http
-from unify.utils.helpers import _create_request_header
-from unify.utils.http import RequestError
+import unisdk
+from unisdk.utils import http
+from unisdk.utils.helpers import _create_request_header
+from unisdk.utils.http import RequestError
 
 from tests.conversation_manager.core.test_coordinator_product_literacy_eval import (
     _BOSS_CONTACT,
@@ -62,7 +62,7 @@ def _reset_runtime_context() -> Iterator[None]:
     SESSION_DETAILS.reset()
     ContextRegistry.clear()
     try:
-        unify.unset_context()
+        unisdk.unset_context()
     except Exception:
         pass
     try:
@@ -71,7 +71,7 @@ def _reset_runtime_context() -> Iterator[None]:
         SESSION_DETAILS.reset()
         ContextRegistry.clear()
         try:
-            unify.unset_context()
+            unisdk.unset_context()
         except Exception:
             pass
 
@@ -210,7 +210,7 @@ def _managed_test_organization() -> Iterator[LiveOrganization]:
     admin_key = _require_admin_key()
     user_key = _require_user_key()
     try:
-        owner = unify.get_user_basic_info(api_key=user_key)
+        owner = unisdk.get_user_basic_info(api_key=user_key)
     except (RequestError, requests.exceptions.RequestException) as exc:
         pytest.skip(f"Coordinator persistence eval needs a valid user key: {exc}")
     org_name = f"Coordinator Eval {uuid.uuid4().hex[:12]}"
@@ -268,7 +268,7 @@ def _create_test_assistant(
     first_name: str,
     organization: LiveOrganization,
 ) -> dict[str, Any]:
-    return unify.create_assistant(
+    return unisdk.create_assistant(
         first_name=first_name,
         surname="Ops",
         config={
@@ -306,12 +306,15 @@ def _activate_assistant_context(
     organization: LiveOrganization,
     assistant: dict[str, Any],
 ) -> None:
-    unify.activate(
+    unisdk.activate(
         _ASSISTANTS_PROJECT_NAME,
         overwrite=False,
         api_key=organization.api_key,
     )
-    unify.set_context(f"{assistant['user_id']}/{assistant['agent_id']}", relative=False)
+    unisdk.set_context(
+        f"{assistant['user_id']}/{assistant['agent_id']}",
+        relative=False,
+    )
 
 
 def _row_entries_text(rows: list[Any]) -> str:
@@ -342,7 +345,7 @@ async def _run_coordinator_code_act_query(query: str) -> Any:
 
 
 def _logs(context: str, organization: LiveOrganization) -> list[Any]:
-    return unify.get_logs(
+    return unisdk.get_logs(
         project=_ASSISTANTS_PROJECT_NAME,
         context=context,
         api_key=organization.api_key,
@@ -448,14 +451,14 @@ async def test_coordinator_persists_confirmed_shared_team_guidance():
             "Shared launch coordination memory for revenue operations, "
             "support handoffs, launch SOPs, and escalation rules."
         )
-        team = unify.create_team(
+        team = unisdk.create_team(
             name=f"Launch War Room {suffix}",
             description=team_description,
             api_key=organization.api_key,
         )
         team_id = int(team["team_id"])
         for assistant in (revenue, support):
-            unify.add_team_member(
+            unisdk.add_team_member(
                 team_id,
                 int(assistant["agent_id"]),
                 api_key=organization.api_key,

--- a/tests/conversation_manager/core/test_coordinator_tools.py
+++ b/tests/conversation_manager/core/test_coordinator_tools.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 import requests
-from unify.utils.http import RequestError
+from unisdk.utils.http import RequestError
 
 from unity.coordinator_manager.coordinator_manager import (
     COORDINATOR_TOOL_METHOD_NAMES,
@@ -22,7 +22,7 @@ class TestCoordinatorManager:
     @pytest.fixture(autouse=True)
     def _mock_default_org_role(self, monkeypatch):
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.list_organizations",
+            "unity.coordinator_manager.coordinator_manager.unisdk.list_organizations",
             lambda **_: [{"id": 7, "name": "Acme", "role_name": "Owner"}],
         )
 
@@ -68,7 +68,7 @@ class TestCoordinatorManager:
             return [{"agent_id": 42, "first_name": "Ops", "organization_id": 7}]
 
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.list_assistants",
+            "unity.coordinator_manager.coordinator_manager.unisdk.list_assistants",
             fake_list_assistants,
         )
 
@@ -97,7 +97,7 @@ class TestCoordinatorManager:
             return [{"agent_id": 41, "organization_id": 13}]
 
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.list_assistants",
+            "unity.coordinator_manager.coordinator_manager.unisdk.list_assistants",
             fake_list_assistants,
         )
 
@@ -124,11 +124,11 @@ class TestCoordinatorManager:
             return [{"agent_id": 42}]
 
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.list_assistants",
+            "unity.coordinator_manager.coordinator_manager.unisdk.list_assistants",
             fake_list_assistants,
         )
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.delete_assistant",
+            "unity.coordinator_manager.coordinator_manager.unisdk.delete_assistant",
             lambda *args, **kwargs: delete_calls.append((args, kwargs)),
         )
 
@@ -152,7 +152,7 @@ class TestCoordinatorManager:
             lambda self, agent_id: captured.update({"agent_id": agent_id}) or True,
         )
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.delete_assistant",
+            "unity.coordinator_manager.coordinator_manager.unisdk.delete_assistant",
             lambda *args, **kwargs: delete_calls.append((args, kwargs))
             or {"status": "deleted"},
         )
@@ -178,11 +178,11 @@ class TestCoordinatorManager:
 
         delete_calls = []
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.list_assistants",
+            "unity.coordinator_manager.coordinator_manager.unisdk.list_assistants",
             fake_list_assistants,
         )
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.delete_assistant",
+            "unity.coordinator_manager.coordinator_manager.unisdk.delete_assistant",
             lambda *args, **kwargs: delete_calls.append((args, kwargs)) or {},
         )
 
@@ -207,7 +207,7 @@ class TestCoordinatorManager:
             raise RequestError("https://api.unify.ai", "POST", response)
 
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.create_assistant",
+            "unity.coordinator_manager.coordinator_manager.unisdk.create_assistant",
             failing_create_assistant,
         )
 
@@ -228,7 +228,7 @@ class TestCoordinatorManager:
         calls = []
 
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.create_assistant",
+            "unity.coordinator_manager.coordinator_manager.unisdk.create_assistant",
             lambda **kwargs: calls.append(kwargs) or {"agent_id": 42},
         )
 
@@ -259,7 +259,7 @@ class TestCoordinatorManager:
     def test_create_assistant_requires_explicit_about(self, monkeypatch):
         create_calls = []
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.create_assistant",
+            "unity.coordinator_manager.coordinator_manager.unisdk.create_assistant",
             lambda **kwargs: create_calls.append(kwargs) or {"agent_id": 42},
         )
 
@@ -281,7 +281,7 @@ class TestCoordinatorManager:
         create_calls = []
 
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.create_assistant",
+            "unity.coordinator_manager.coordinator_manager.unisdk.create_assistant",
             lambda **kwargs: create_calls.append(kwargs) or {"agent_id": 42},
         )
 
@@ -302,7 +302,7 @@ class TestCoordinatorManager:
         SESSION_DETAILS.assistant.timezone = "Asia/Karachi"
         SESSION_DETAILS.assistant.nationality = "United States"
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.create_assistant",
+            "unity.coordinator_manager.coordinator_manager.unisdk.create_assistant",
             lambda **kwargs: calls.append(kwargs) or {"agent_id": 42},
         )
 
@@ -342,7 +342,7 @@ class TestCoordinatorManager:
             lambda self, agent_id: captured.update({"agent_id": agent_id}) or True,
         )
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.update_assistant_config",
+            "unity.coordinator_manager.coordinator_manager.unisdk.update_assistant_config",
             lambda *args, **kwargs: update_calls.append((args, kwargs))
             or {"agent_id": 42, "about": "updated"},
         )
@@ -370,7 +370,7 @@ class TestCoordinatorManager:
         calls = []
 
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.create_assistant",
+            "unity.coordinator_manager.coordinator_manager.unisdk.create_assistant",
             lambda **kwargs: calls.append(kwargs) or {"agent_id": 42},
         )
 
@@ -402,7 +402,7 @@ class TestCoordinatorManager:
             raise RequestError("https://api.unify.ai", "POST", response)
 
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.create_assistant",
+            "unity.coordinator_manager.coordinator_manager.unisdk.create_assistant",
             failing_create_assistant,
         )
 
@@ -427,11 +427,11 @@ class TestCoordinatorManager:
         calls = []
 
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.list_assistants",
+            "unity.coordinator_manager.coordinator_manager.unisdk.list_assistants",
             lambda **_: [{"agent_id": 42, "organization_id": 7}],
         )
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.delegate_to_colleague",
+            "unity.coordinator_manager.coordinator_manager.unisdk.delegate_to_colleague",
             lambda *args, **kwargs: calls.append((args, kwargs))
             or {"target_assistant_id": 42},
         )
@@ -464,11 +464,11 @@ class TestCoordinatorManager:
         calls = []
 
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.list_assistants",
+            "unity.coordinator_manager.coordinator_manager.unisdk.list_assistants",
             lambda **_: [{"agent_id": 42, "organization_id": 7}],
         )
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.delegate_to_colleague",
+            "unity.coordinator_manager.coordinator_manager.unisdk.delegate_to_colleague",
             lambda *args, **kwargs: calls.append((args, kwargs)),
         )
 
@@ -485,7 +485,7 @@ class TestCoordinatorManager:
     def test_delegate_to_colleague_rejects_blank_instruction(self, monkeypatch):
         calls = []
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.delegate_to_colleague",
+            "unity.coordinator_manager.coordinator_manager.unisdk.delegate_to_colleague",
             lambda *args, **kwargs: calls.append((args, kwargs)),
         )
 
@@ -511,7 +511,7 @@ class TestCoordinatorManager:
             lambda self, agent_id: captured.update({"agent_id": agent_id}) or True,
         )
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.delegate_to_colleague",
+            "unity.coordinator_manager.coordinator_manager.unisdk.delegate_to_colleague",
             lambda *args, **kwargs: delegate_calls.append((args, kwargs))
             or {"status": "attached_to_startup"},
         )
@@ -545,7 +545,7 @@ class TestCoordinatorManager:
             return [{"user_id": "member-1"}]
 
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.list_org_members",
+            "unity.coordinator_manager.coordinator_manager.unisdk.list_org_members",
             fake_list_org_members,
         )
 
@@ -560,7 +560,7 @@ class TestCoordinatorManager:
         SESSION_DETAILS.org_id = None
         calls = []
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.list_org_members",
+            "unity.coordinator_manager.coordinator_manager.unisdk.list_org_members",
             lambda *args, **kwargs: calls.append((args, kwargs)),
         )
 
@@ -582,7 +582,7 @@ class TestCoordinatorManager:
             }
 
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.invite_org_member",
+            "unity.coordinator_manager.coordinator_manager.unisdk.invite_org_member",
             fake_invite_org_member,
         )
 
@@ -610,7 +610,7 @@ class TestCoordinatorManager:
         SESSION_DETAILS.org_id = None
         calls = []
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.invite_org_member",
+            "unity.coordinator_manager.coordinator_manager.unisdk.invite_org_member",
             lambda *args, **kwargs: calls.append((args, kwargs)),
         )
 
@@ -625,7 +625,7 @@ class TestCoordinatorManager:
     def test_invite_org_member_rejects_unknown_role_name(self, monkeypatch):
         calls = []
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.invite_org_member",
+            "unity.coordinator_manager.coordinator_manager.unisdk.invite_org_member",
             lambda *args, **kwargs: calls.append((args, kwargs)),
         )
 
@@ -648,7 +648,7 @@ class TestCoordinatorManager:
             raise RequestError("https://api.unify.ai", "POST", response)
 
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.invite_org_member",
+            "unity.coordinator_manager.coordinator_manager.unisdk.invite_org_member",
             failing_invite_org_member,
         )
 
@@ -666,60 +666,60 @@ class TestCoordinatorManager:
         mutation_calls = []
 
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.invite_org_member",
+            "unity.coordinator_manager.coordinator_manager.unisdk.invite_org_member",
             lambda *args, **kwargs: mutation_calls.append(
                 ("invite_org_member", args, kwargs),
             )
             or {"ok": True},
         )
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.create_team",
+            "unity.coordinator_manager.coordinator_manager.unisdk.create_team",
             lambda *args, **kwargs: mutation_calls.append(("create_team", args, kwargs))
             or {"team_id": 11},
         )
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.delete_team",
+            "unity.coordinator_manager.coordinator_manager.unisdk.delete_team",
             lambda *args, **kwargs: mutation_calls.append(
                 ("delete_team", args, kwargs),
             )
             or {"ok": True},
         )
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.update_team",
+            "unity.coordinator_manager.coordinator_manager.unisdk.update_team",
             lambda *args, **kwargs: mutation_calls.append(
                 ("update_team", args, kwargs),
             )
             or {"team_id": 11},
         )
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.add_team_member",
+            "unity.coordinator_manager.coordinator_manager.unisdk.add_team_member",
             lambda *args, **kwargs: mutation_calls.append(
                 ("add_team_member", args, kwargs),
             )
             or {"membership_status": "active"},
         )
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.remove_team_member",
+            "unity.coordinator_manager.coordinator_manager.unisdk.remove_team_member",
             lambda *args, **kwargs: mutation_calls.append(
                 ("remove_team_member", args, kwargs),
             )
             or {"ok": True},
         )
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.create_assistant",
+            "unity.coordinator_manager.coordinator_manager.unisdk.create_assistant",
             lambda **kwargs: mutation_calls.append(("create_assistant", kwargs))
             or {"agent_id": 42},
         )
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.list_teams",
+            "unity.coordinator_manager.coordinator_manager.unisdk.list_teams",
             lambda *_, **__: [{"team_id": 11, "name": "Ops"}],
         )
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.list_assistants",
+            "unity.coordinator_manager.coordinator_manager.unisdk.list_assistants",
             lambda **_: [{"agent_id": 42, "organization_id": 7}],
         )
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.list_team_members",
+            "unity.coordinator_manager.coordinator_manager.unisdk.list_team_members",
             lambda *args, **kwargs: [],
         )
 
@@ -763,7 +763,7 @@ class TestCoordinatorManager:
         calls = []
 
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.create_team",
+            "unity.coordinator_manager.coordinator_manager.unisdk.create_team",
             lambda *args, **kwargs: calls.append((args, kwargs))
             or {"team_id": 11, "name": "Ops"},
         )
@@ -792,15 +792,15 @@ class TestCoordinatorManager:
         member_calls = []
 
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.list_teams",
+            "unity.coordinator_manager.coordinator_manager.unisdk.list_teams",
             lambda *_, **__: [{"team_id": 11}],
         )
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.list_assistants",
+            "unity.coordinator_manager.coordinator_manager.unisdk.list_assistants",
             lambda **_: [{"agent_id": 42, "organization_id": 7}],
         )
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.add_team_member",
+            "unity.coordinator_manager.coordinator_manager.unisdk.add_team_member",
             lambda *args, **kwargs: member_calls.append((args, kwargs))
             or {"membership_status": "active"},
         )
@@ -826,15 +826,15 @@ class TestCoordinatorManager:
         member_calls = []
 
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.list_teams",
+            "unity.coordinator_manager.coordinator_manager.unisdk.list_teams",
             lambda *_, **__: [{"team_id": 11}],
         )
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.list_org_members",
+            "unity.coordinator_manager.coordinator_manager.unisdk.list_org_members",
             lambda *_, **__: [{"user_id": "member-1"}],
         )
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.add_team_member",
+            "unity.coordinator_manager.coordinator_manager.unisdk.add_team_member",
             lambda *args, **kwargs: member_calls.append((args, kwargs))
             or {"membership_status": "active", "assistant_id": 91},
         )
@@ -882,29 +882,29 @@ class TestCoordinatorManager:
         calls = []
 
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.list_teams",
+            "unity.coordinator_manager.coordinator_manager.unisdk.list_teams",
             lambda *_, **__: [{"team_id": 11, "name": "Ops"}],
         )
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.list_assistants",
+            "unity.coordinator_manager.coordinator_manager.unisdk.list_assistants",
             lambda **_: [{"agent_id": 42, "organization_id": 7}],
         )
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.update_team",
+            "unity.coordinator_manager.coordinator_manager.unisdk.update_team",
             lambda *args, **kwargs: calls.append(("update", args, kwargs))
             or {"team_id": 11, "name": "Ops Team"},
         )
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.remove_team_member",
+            "unity.coordinator_manager.coordinator_manager.unisdk.remove_team_member",
             lambda *args, **kwargs: calls.append(("remove", args, kwargs)) or {},
         )
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.list_team_members",
+            "unity.coordinator_manager.coordinator_manager.unisdk.list_team_members",
             lambda *args, **kwargs: calls.append(("members", args, kwargs))
             or [{"assistant_id": 42}],
         )
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.list_teams_for_assistant",
+            "unity.coordinator_manager.coordinator_manager.unisdk.list_teams_for_assistant",
             lambda *args, **kwargs: calls.append(("assistant_teams", args, kwargs))
             or [{"team_id": 11}],
         )
@@ -951,7 +951,7 @@ class TestCoordinatorManager:
             lambda self, agent_id: captured.update({"agent_id": agent_id}) or True,
         )
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.list_teams_for_assistant",
+            "unity.coordinator_manager.coordinator_manager.unisdk.list_teams_for_assistant",
             lambda *args, **kwargs: list_calls.append((args, kwargs))
             or [{"team_id": 11}],
         )
@@ -971,15 +971,15 @@ class TestCoordinatorManager:
         member_calls = []
 
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.list_teams",
+            "unity.coordinator_manager.coordinator_manager.unisdk.list_teams",
             lambda *_, **__: [{"team_id": 11}],
         )
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.list_assistants",
+            "unity.coordinator_manager.coordinator_manager.unisdk.list_assistants",
             lambda **_: [{"agent_id": 42, "organization_id": 7}],
         )
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.add_team_member",
+            "unity.coordinator_manager.coordinator_manager.unisdk.add_team_member",
             lambda *args, **kwargs: member_calls.append((args, kwargs)),
         )
 
@@ -1000,11 +1000,11 @@ class TestCoordinatorManager:
             raise RequestError("https://api.unify.ai", "DELETE", response)
 
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.list_teams",
+            "unity.coordinator_manager.coordinator_manager.unisdk.list_teams",
             lambda *_, **__: [{"team_id": 11}],
         )
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.delete_team",
+            "unity.coordinator_manager.coordinator_manager.unisdk.delete_team",
             failing_delete_team,
         )
 
@@ -1020,16 +1020,16 @@ class TestCoordinatorManager:
         calls = []
 
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.list_assistants",
+            "unity.coordinator_manager.coordinator_manager.unisdk.list_assistants",
             lambda **kwargs: calls.append(("list_assistants", kwargs)) or [],
         )
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.create_assistant",
+            "unity.coordinator_manager.coordinator_manager.unisdk.create_assistant",
             lambda **kwargs: calls.append(("create_assistant", kwargs))
             or {"agent_id": 42, "first_name": "Ops", "surname": "Bot"},
         )
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.list_teams",
+            "unity.coordinator_manager.coordinator_manager.unisdk.list_teams",
             lambda *args, **kwargs: calls.append(("list_teams", args, kwargs))
             or (
                 [{"team_id": 11, "name": "Ops HQ"}]
@@ -1038,17 +1038,17 @@ class TestCoordinatorManager:
             ),
         )
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.create_team",
+            "unity.coordinator_manager.coordinator_manager.unisdk.create_team",
             lambda *args, **kwargs: calls.append(("create_team", args, kwargs))
             or {"team_id": 11, "name": "Ops HQ"},
         )
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.list_team_members",
+            "unity.coordinator_manager.coordinator_manager.unisdk.list_team_members",
             lambda *args, **kwargs: calls.append(("list_team_members", args, kwargs))
             or [],
         )
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.add_team_member",
+            "unity.coordinator_manager.coordinator_manager.unisdk.add_team_member",
             lambda *args, **kwargs: calls.append(("add_team_member", args, kwargs))
             or {"membership_status": "active"},
         )
@@ -1141,11 +1141,11 @@ class TestCoordinatorManager:
     ):
         create_calls = []
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.list_assistants",
+            "unity.coordinator_manager.coordinator_manager.unisdk.list_assistants",
             lambda **_: [],
         )
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.create_assistant",
+            "unity.coordinator_manager.coordinator_manager.unisdk.create_assistant",
             lambda **kwargs: create_calls.append(kwargs) or {"agent_id": 42},
         )
 
@@ -1168,20 +1168,20 @@ class TestCoordinatorManager:
         SESSION_DETAILS.assistant.timezone = "Asia/Karachi"
         SESSION_DETAILS.assistant.nationality = "United States"
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.list_assistants",
+            "unity.coordinator_manager.coordinator_manager.unisdk.list_assistants",
             lambda **_: [],
         )
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.create_assistant",
+            "unity.coordinator_manager.coordinator_manager.unisdk.create_assistant",
             lambda **kwargs: create_calls.append(kwargs)
             or {"agent_id": 42, "first_name": "Ops", "surname": "Bot"},
         )
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.list_teams",
+            "unity.coordinator_manager.coordinator_manager.unisdk.list_teams",
             lambda *_, **__: [{"team_id": 11, "name": "Ops HQ"}],
         )
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.list_team_members",
+            "unity.coordinator_manager.coordinator_manager.unisdk.list_team_members",
             lambda *_, **__: [{"assistant_id": 42}],
         )
 
@@ -1215,7 +1215,7 @@ class TestCoordinatorManager:
     ):
         add_calls = []
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.list_assistants",
+            "unity.coordinator_manager.coordinator_manager.unisdk.list_assistants",
             lambda **_: [
                 {
                     "agent_id": 42,
@@ -1226,15 +1226,15 @@ class TestCoordinatorManager:
             ],
         )
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.list_teams",
+            "unity.coordinator_manager.coordinator_manager.unisdk.list_teams",
             lambda *_, **__: [{"team_id": 11, "name": "Ops HQ"}],
         )
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.list_team_members",
+            "unity.coordinator_manager.coordinator_manager.unisdk.list_team_members",
             lambda *_, **__: [{"assistant_id": 42}],
         )
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.add_team_member",
+            "unity.coordinator_manager.coordinator_manager.unisdk.add_team_member",
             lambda *args, **kwargs: add_calls.append((args, kwargs)) or {},
         )
 
@@ -1256,7 +1256,7 @@ class TestCoordinatorManager:
     ):
         create_calls = []
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.list_assistants",
+            "unity.coordinator_manager.coordinator_manager.unisdk.list_assistants",
             lambda **kwargs: (
                 [
                     {
@@ -1271,23 +1271,23 @@ class TestCoordinatorManager:
             ),
         )
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.list_teams",
+            "unity.coordinator_manager.coordinator_manager.unisdk.list_teams",
             lambda *_, **__: [{"team_id": 11, "name": "Ops HQ"}],
         )
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.list_team_members",
+            "unity.coordinator_manager.coordinator_manager.unisdk.list_team_members",
             lambda *_, **__: [],
         )
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.add_team_member",
+            "unity.coordinator_manager.coordinator_manager.unisdk.add_team_member",
             lambda *args, **kwargs: {"membership_status": "active"},
         )
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.create_assistant",
+            "unity.coordinator_manager.coordinator_manager.unisdk.create_assistant",
             lambda **kwargs: create_calls.append(("assistant", kwargs)),
         )
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.create_team",
+            "unity.coordinator_manager.coordinator_manager.unisdk.create_team",
             lambda **kwargs: create_calls.append(("team", kwargs)),
         )
 
@@ -1310,7 +1310,7 @@ class TestCoordinatorManager:
         monkeypatch,
     ):
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.list_assistants",
+            "unity.coordinator_manager.coordinator_manager.unisdk.list_assistants",
             lambda **_: [
                 {
                     "agent_id": 42,
@@ -1345,20 +1345,20 @@ class TestCoordinatorManager:
         SESSION_DETAILS.assistant.nationality = "United States"
         create_calls = []
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.list_assistants",
+            "unity.coordinator_manager.coordinator_manager.unisdk.list_assistants",
             lambda **_: [],
         )
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.create_assistant",
+            "unity.coordinator_manager.coordinator_manager.unisdk.create_assistant",
             lambda **kwargs: create_calls.append(kwargs)
             or {"agent_id": 42, "first_name": "Sarah Chen", "surname": "Recruiter"},
         )
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.list_teams",
+            "unity.coordinator_manager.coordinator_manager.unisdk.list_teams",
             lambda *_, **__: [{"team_id": 11, "name": "Hiring Desk"}],
         )
         monkeypatch.setattr(
-            "unity.coordinator_manager.coordinator_manager.unify.list_team_members",
+            "unity.coordinator_manager.coordinator_manager.unisdk.list_team_members",
             lambda *_, **__: [{"assistant_id": 42}],
         )
 

--- a/tests/conversation_manager/core/test_event_handlers.py
+++ b/tests/conversation_manager/core/test_event_handlers.py
@@ -2428,7 +2428,7 @@ class TestTaskDueEventHandlers:
         # The real scheduler resolves the activation's source task by its
         # log id (the delegate contract this test exercises), so use the
         # actual scheduled instance's log id rather than a fabricated value.
-        # The log id lives on the store row (``unify.Log.id``), not on the
+        # The log id lives on the store row (``unisdk.Log.id``), not on the
         # sanitized ``Task`` returned by ``_filter_tasks``.
         source_task_log_id = None
         for _ctx in scheduler._read_task_contexts():

--- a/tests/conversation_manager/core/test_event_logging.py
+++ b/tests/conversation_manager/core/test_event_logging.py
@@ -443,7 +443,7 @@ async def test_inbound_email_transcript_includes_all_recipients(cm_with_eventbus
     not just [0] (the assistant).
     """
     from unity.conversation_manager.domains.event_handlers import EventHandler
-    import unify
+    import unisdk
 
     cm = cm_with_eventbus
     assert cm.contact_manager is not None, "ContactManager not initialized"
@@ -495,7 +495,7 @@ async def test_inbound_email_transcript_includes_all_recipients(cm_with_eventbus
     ctx = getattr(tm, "_transcripts_ctx", None)
     assert ctx, "TranscriptManager missing _transcripts_ctx"
 
-    logs = unify.get_logs(
+    logs = unisdk.get_logs(
         context=ctx,
         limit=10,
         sorting={"timestamp": "descending"},
@@ -542,7 +542,7 @@ async def test_outbound_email_transcript_includes_all_recipients(cm_with_eventbu
     not just the single contact from event.contact.
     """
     from unity.conversation_manager.domains.event_handlers import EventHandler
-    import unify
+    import unisdk
 
     cm = cm_with_eventbus
     assert cm.contact_manager is not None, "ContactManager not initialized"
@@ -586,7 +586,7 @@ async def test_outbound_email_transcript_includes_all_recipients(cm_with_eventbu
     ctx = getattr(tm, "_transcripts_ctx", None)
     assert ctx, "TranscriptManager missing _transcripts_ctx"
 
-    logs = unify.get_logs(
+    logs = unisdk.get_logs(
         context=ctx,
         limit=10,
         sorting={"timestamp": "descending"},

--- a/tests/conversation_manager/core/test_inactivity_followup.py
+++ b/tests/conversation_manager/core/test_inactivity_followup.py
@@ -212,7 +212,7 @@ class TestTouchAssistantActivity:
                 "unity.transcript_manager.activity_sync._admin_key",
                 return_value="test-admin-key",
             ),
-            patch.dict("sys.modules", {"unify.utils": MagicMock(http=fake_http)}),
+            patch.dict("sys.modules", {"unisdk.utils": MagicMock(http=fake_http)}),
         ):
             assert touch_assistant_activity(42) is True
 
@@ -240,7 +240,7 @@ class TestTouchAssistantActivity:
                 "unity.transcript_manager.activity_sync._admin_key",
                 return_value="key",
             ),
-            patch.dict("sys.modules", {"unify.utils": MagicMock(http=fake_http)}),
+            patch.dict("sys.modules", {"unisdk.utils": MagicMock(http=fake_http)}),
         ):
             assert touch_assistant_activity(42) is False
 
@@ -260,7 +260,7 @@ class TestTouchAssistantActivity:
                 "unity.transcript_manager.activity_sync._admin_key",
                 return_value="key",
             ),
-            patch.dict("sys.modules", {"unify.utils": MagicMock(http=fake_http)}),
+            patch.dict("sys.modules", {"unisdk.utils": MagicMock(http=fake_http)}),
         ):
             # Should not raise
             assert touch_assistant_activity(42) is False
@@ -300,7 +300,7 @@ class TestFollowupOptOutHelpers:
                 "unity.transcript_manager.activity_sync._admin_key",
                 return_value="test-admin-key",
             ),
-            patch.dict("sys.modules", {"unify.utils": MagicMock(http=http_module)}),
+            patch.dict("sys.modules", {"unisdk.utils": MagicMock(http=http_module)}),
         ):
             assert opt_out_of_inactivity_followups_via_orchestra(42) is True
 
@@ -321,7 +321,7 @@ class TestFollowupOptOutHelpers:
                 "unity.transcript_manager.activity_sync._admin_key",
                 return_value="test-admin-key",
             ),
-            patch.dict("sys.modules", {"unify.utils": MagicMock(http=http_module)}),
+            patch.dict("sys.modules", {"unisdk.utils": MagicMock(http=http_module)}),
         ):
             assert opt_in_to_inactivity_followups_via_orchestra(42) is True
 
@@ -354,7 +354,7 @@ class TestFollowupOptOutHelpers:
                 "unity.transcript_manager.activity_sync._admin_key",
                 return_value="key",
             ),
-            patch.dict("sys.modules", {"unify.utils": MagicMock(http=http_module)}),
+            patch.dict("sys.modules", {"unisdk.utils": MagicMock(http=http_module)}),
         ):
             assert opt_out_of_inactivity_followups_via_orchestra(42) is False
 
@@ -374,7 +374,7 @@ class TestFollowupOptOutHelpers:
                 "unity.transcript_manager.activity_sync._admin_key",
                 return_value="key",
             ),
-            patch.dict("sys.modules", {"unify.utils": MagicMock(http=http_module)}),
+            patch.dict("sys.modules", {"unisdk.utils": MagicMock(http=http_module)}),
         ):
             assert opt_out_of_inactivity_followups_via_orchestra(42) is False
             assert opt_in_to_inactivity_followups_via_orchestra(42) is False

--- a/tests/conversation_manager/core/test_init_resilience.py
+++ b/tests/conversation_manager/core/test_init_resilience.py
@@ -172,7 +172,7 @@ class TestUserDetailsFetchResilience:
     async def test_user_details_fetch_failure_uses_fallback(self, resilience_cm):
         cm = resilience_cm
         with patch(
-            "unity.contact_manager.system_contacts.unify.get_user_basic_info",
+            "unity.contact_manager.system_contacts.unisdk.get_user_basic_info",
             side_effect=ConnectionError("Orchestra unreachable"),
         ):
             await _init(cm, "resilience_userinfo")

--- a/tests/conversation_manager/core/test_utils.py
+++ b/tests/conversation_manager/core/test_utils.py
@@ -1267,7 +1267,7 @@ class TestDispatchLivekitAgentCodeQuality:
     def test_uses_requests_post_not_http_post(self):
         """dispatch_livekit_agent must use requests.post directly, not http.post.
 
-        The http module from unify.utils has retry logic baked in. For this
+        The http module from unisdk.utils has retry logic baked in. For this
         fire-and-forget dispatch, we intentionally want NO retries - the timeout
         is expected and we should move on immediately. Using http.post would
         cause multiple retry attempts with backoff delays, defeating the purpose.

--- a/tests/conversation_manager/voice/test_fast_brain_context_window.py
+++ b/tests/conversation_manager/voice/test_fast_brain_context_window.py
@@ -6,10 +6,10 @@ Tests for the fast brain rolling context window and history hydration.
 
 Covers:
 - trim_fast_brain_context(): system prompt preservation, rolling window
-- hydrate_fast_brain_history(): backend query via unify.get_logs, event filtering, rendering
+- hydrate_fast_brain_history(): backend query via unisdk.get_logs, event filtering, rendering
 - _render_history_event(): per-event-type rendering and participant filtering
 
-All tests are symbolic — unify.get_logs is mocked to return synthetic log rows.
+All tests are symbolic — unisdk.get_logs is mocked to return synthetic log rows.
 """
 
 import json
@@ -74,7 +74,7 @@ ASSISTANT_NAME = "Alex"
 
 
 def _make_log_rows(cm_events):
-    """Convert CM events to unify.Log-shaped rows in descending order (newest first)."""
+    """Convert CM events to unisdk.Log-shaped rows in descending order (newest first)."""
     rows = []
     for ev in cm_events:
         payload = ev.to_dict()["payload"]
@@ -382,7 +382,7 @@ class TestRenderHistoryEvent:
 # hydrate_fast_brain_history — integration with backend mock
 # =============================================================================
 
-MOCK_GET_LOGS = "unify.get_logs"
+MOCK_GET_LOGS = "unisdk.get_logs"
 MOCK_SESSION = "unity.conversation_manager.medium_scripts.common.SESSION_DETAILS"
 
 
@@ -521,7 +521,7 @@ class TestHydrateFastBrainHistory:
 
     @pytest.mark.asyncio
     async def test_limit_passed_to_backend(self):
-        """The limit parameter is forwarded to unify.get_logs."""
+        """The limit parameter is forwarded to unisdk.get_logs."""
         with patch(MOCK_GET_LOGS, return_value=[]) as mock_get_logs:
             await hydrate_fast_brain_history({2}, False, ASSISTANT_NAME, limit=25)
 
@@ -617,7 +617,7 @@ class TestHydrateFastBrainHistory:
         an uninitialized proxy.  Before the direct-backend change, this
         function called EVENT_BUS.search() which raised RuntimeError, causing
         every call to return [].  Now it queries the backend directly via
-        unify.get_logs(), so history is available from the first turn.
+        unisdk.get_logs(), so history is available from the first turn.
         """
         events = [
             SMSReceived(contact=ALICE, content="Recent SMS", timestamp=BASE_TIME),

--- a/tests/coordinator_manager/integration/test_coordinator_shared_team_multi_coordinator_local_stack.py
+++ b/tests/coordinator_manager/integration/test_coordinator_shared_team_multi_coordinator_local_stack.py
@@ -11,7 +11,7 @@ from collections.abc import Iterator
 from typing import Any
 
 import pytest
-import unify
+import unisdk
 
 from tests.conversation_manager.core.test_coordinator_product_literacy_eval import (
     _PRIMARY_LLM_CONFIG,
@@ -88,7 +88,7 @@ def _reset_runtime() -> None:
     ManagerRegistry.clear()
     ContextRegistry.clear()
     try:
-        unify.unset_context()
+        unisdk.unset_context()
     except Exception:
         pass
 
@@ -107,7 +107,7 @@ def _organization_api_key(api_key: str) -> Iterator[None]:
 
 
 def _shared_guidance_rows(*, org_api_key: str, team_id: int, sentinel: str) -> list:
-    logs = unify.get_logs(
+    logs = unisdk.get_logs(
         project=_ASSISTANTS_PROJECT_NAME,
         context=f"Teams/{team_id}/Guidance",
         api_key=org_api_key,
@@ -139,16 +139,16 @@ def _configure_coordinator_session(
     SESSION_DETAILS.user.surname = coordinator.get("surname") or ""
     SESSION_DETAILS.team_ids = [summary.team_id for summary in team_summaries]
     SESSION_DETAILS.team_summaries = team_summaries
-    unify.BASE_URL = orchestra_url
+    unisdk.BASE_URL = orchestra_url
 
 
 def _activate_coordinator_context(*, org_api_key: str, coordinator: dict) -> None:
-    unify.activate(
+    unisdk.activate(
         _ASSISTANTS_PROJECT_NAME,
         overwrite=False,
         api_key=org_api_key,
     )
-    unify.set_context(
+    unisdk.set_context(
         f"{coordinator['user_id']}/{_assistant_id(coordinator)}",
         relative=False,
     )
@@ -193,7 +193,7 @@ async def test_shared_team_guidance_reaches_member_coordinators_local_stack(
     """Owner coordinator LLM-writes team guidance that member coordinators can read."""
 
     urls = require_local_stack
-    unify.BASE_URL = urls.orchestra_url
+    unisdk.BASE_URL = urls.orchestra_url
 
     suffix = uuid.uuid4().hex[:8]
     org = create_organization(

--- a/tests/coordinator_manager/integration/test_coordinator_team_crud_round_trip.py
+++ b/tests/coordinator_manager/integration/test_coordinator_team_crud_round_trip.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import pytest
-import unify
+import unisdk
 
 from tests.coordinator_manager.integration.local_stack_harness import (
     create_organization,
@@ -53,7 +53,7 @@ def _configure_coordinator_session(
     SESSION_DETAILS.is_coordinator = True
     SESSION_DETAILS.unify_key = org_api_key
     SESSION_DETAILS.org_id = org_id
-    unify.BASE_URL = orchestra_url
+    unisdk.BASE_URL = orchestra_url
 
 
 def test_coordinator_team_crud_round_trip_local_stack(require_local_stack):

--- a/tests/coordinator_manager/test_coordinator_manager.py
+++ b/tests/coordinator_manager/test_coordinator_manager.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 import pytest
 import requests
-from unify.utils.http import RequestError
+from unisdk.utils.http import RequestError
 
 from unity.coordinator_manager.coordinator_manager import CoordinatorManager
 from unity.manager_registry import ManagerRegistry
@@ -29,7 +29,7 @@ class TestCoordinatorManager:
         manager = CoordinatorManager()
 
         with patch(
-            "unity.coordinator_manager.coordinator_manager.unify.list_org_members",
+            "unity.coordinator_manager.coordinator_manager.unisdk.list_org_members",
         ) as list_members:
             assert manager.get_org_members() == []
 
@@ -42,7 +42,7 @@ class TestCoordinatorManager:
         manager = CoordinatorManager()
 
         with patch(
-            "unity.coordinator_manager.coordinator_manager.unify.list_org_members",
+            "unity.coordinator_manager.coordinator_manager.unisdk.list_org_members",
             return_value=[{"email": "dana@acme.com"}],
         ) as list_members:
             assert manager.get_org_members() == [{"email": "dana@acme.com"}]
@@ -63,7 +63,7 @@ class TestCoordinatorManager:
         response.status_code = 500
         response._content = b"temporary"
         with patch(
-            "unity.coordinator_manager.coordinator_manager.unify.list_org_members",
+            "unity.coordinator_manager.coordinator_manager.unisdk.list_org_members",
             side_effect=[
                 RequestError("https://api.unify.ai", "GET", response),
                 [{"email": "dana@acme.com"}],
@@ -81,7 +81,7 @@ class TestCoordinatorManager:
         manager = CoordinatorManager()
 
         with patch(
-            "unity.coordinator_manager.coordinator_manager.unify.list_org_members",
+            "unity.coordinator_manager.coordinator_manager.unisdk.list_org_members",
             side_effect=[
                 [{"email": "owner@acme.com"}],
                 [{"email": "admin@beta.com"}],

--- a/tests/coordinator_manager/test_coordinator_manager_tools.py
+++ b/tests/coordinator_manager/test_coordinator_manager_tools.py
@@ -34,7 +34,7 @@ def test_coordinator_manager_delegates_reads_for_coordinator(monkeypatch):
     SESSION_DETAILS.org_id = 7
 
     monkeypatch.setattr(
-        "unity.coordinator_manager.coordinator_manager.unify.list_assistants",
+        "unity.coordinator_manager.coordinator_manager.unisdk.list_assistants",
         lambda **_: [{"agent_id": 42, "first_name": "Ops", "organization_id": 7}],
     )
 
@@ -53,7 +53,7 @@ def test_coordinator_manager_blocks_mutations_when_role_is_not_coordinator(monke
         return {"team_id": 99}
 
     monkeypatch.setattr(
-        "unity.coordinator_manager.coordinator_manager.unify.create_team",
+        "unity.coordinator_manager.coordinator_manager.unisdk.create_team",
         _fake_create_team,
     )
 

--- a/tests/dashboard_manager/helpers.py
+++ b/tests/dashboard_manager/helpers.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 
-import unify
+import unisdk
 
 from unity.dashboard_manager.dashboard_manager import DashboardManager
 from unity.manager_registry import ManagerRegistry
@@ -18,7 +18,7 @@ def fresh_dashboard_manager() -> DashboardManager:
 
 def context_rows(context: str) -> list[dict]:
     """Return raw row entries for a Unify context."""
-    return [log.entries for log in unify.get_logs(context=context)]
+    return [log.entries for log in unisdk.get_logs(context=context)]
 
 
 def context_titles(context: str) -> set[str]:
@@ -28,12 +28,12 @@ def context_titles(context: str) -> set[str]:
 
 def create_context_if_missing(context: str) -> None:
     """Create a Unify context, ignoring the already-exists case."""
-    unify.create_context(context)
+    unisdk.create_context(context)
 
 
 def active_read_root() -> str:
     """Return the current project's active read root."""
-    return unify.get_active_context()["read"]
+    return unisdk.get_active_context()["read"]
 
 
 def serialized_binding_context(tile) -> str:

--- a/tests/dashboard_manager/test_types.py
+++ b/tests/dashboard_manager/test_types.py
@@ -609,13 +609,13 @@ class TestResolveBindingContexts:
     """Tests for resolve_binding_contexts with mocked unify API."""
 
     def _patch(self):
-        """Return a context manager that patches ContextRegistry and unify."""
+        """Return a context manager that patches ContextRegistry and unisdk."""
         patches = {}
         patches["registry"] = patch(
             "unity.dashboard_manager.ops.tile_ops.ContextRegistry",
         )
         patches["unify"] = patch(
-            "unity.dashboard_manager.ops.tile_ops.unify",
+            "unity.dashboard_manager.ops.tile_ops.unisdk",
         )
         return patches
 
@@ -625,7 +625,7 @@ class TestResolveBindingContexts:
                 "unity.dashboard_manager.ops.tile_ops.ContextRegistry",
             ) as mock_reg,
             patch(
-                "unity.dashboard_manager.ops.tile_ops.unify",
+                "unity.dashboard_manager.ops.tile_ops.unisdk",
             ) as mock_unify,
         ):
             mock_reg._base_context = BASE
@@ -649,7 +649,7 @@ class TestResolveBindingContexts:
                 "unity.dashboard_manager.ops.tile_ops.ContextRegistry",
             ) as mock_reg,
             patch(
-                "unity.dashboard_manager.ops.tile_ops.unify",
+                "unity.dashboard_manager.ops.tile_ops.unisdk",
             ) as mock_unify,
         ):
             mock_reg._base_context = BASE
@@ -667,7 +667,7 @@ class TestResolveBindingContexts:
                 "unity.dashboard_manager.ops.tile_ops.ContextRegistry",
             ) as mock_reg,
             patch(
-                "unity.dashboard_manager.ops.tile_ops.unify",
+                "unity.dashboard_manager.ops.tile_ops.unisdk",
             ) as mock_unify,
         ):
             mock_reg._base_context = BASE
@@ -686,7 +686,7 @@ class TestResolveBindingContexts:
                 "unity.dashboard_manager.ops.tile_ops.ContextRegistry",
             ) as mock_reg,
             patch(
-                "unity.dashboard_manager.ops.tile_ops.unify",
+                "unity.dashboard_manager.ops.tile_ops.unisdk",
             ) as mock_unify,
         ):
             mock_reg._base_context = BASE
@@ -726,7 +726,7 @@ class TestResolveBindingContexts:
                 "unity.dashboard_manager.ops.tile_ops.ContextRegistry",
             ) as mock_reg,
             patch(
-                "unity.dashboard_manager.ops.tile_ops.unify",
+                "unity.dashboard_manager.ops.tile_ops.unisdk",
             ) as mock_unify,
         ):
             mock_reg._base_context = BASE
@@ -762,7 +762,7 @@ class TestResolveBindingContexts:
                 "unity.dashboard_manager.ops.tile_ops.ContextRegistry",
             ) as mock_reg,
             patch(
-                "unity.dashboard_manager.ops.tile_ops.unify",
+                "unity.dashboard_manager.ops.tile_ops.unisdk",
             ) as mock_unify,
         ):
             mock_reg._base_context = None
@@ -779,7 +779,7 @@ class TestResolveBindingContexts:
                 "unity.dashboard_manager.ops.tile_ops.ContextRegistry",
             ) as mock_reg,
             patch(
-                "unity.dashboard_manager.ops.tile_ops.unify",
+                "unity.dashboard_manager.ops.tile_ops.unisdk",
             ) as mock_unify,
         ):
             mock_reg._base_context = BASE
@@ -796,7 +796,7 @@ class TestResolveBindingContexts:
                 "unity.dashboard_manager.ops.tile_ops.ContextRegistry",
             ) as mock_reg,
             patch(
-                "unity.dashboard_manager.ops.tile_ops.unify",
+                "unity.dashboard_manager.ops.tile_ops.unisdk",
             ) as mock_unify,
         ):
             mock_reg._base_context = BASE
@@ -814,7 +814,7 @@ class TestResolveBindingContexts:
                 "unity.dashboard_manager.ops.tile_ops.ContextRegistry",
             ) as mock_reg,
             patch(
-                "unity.dashboard_manager.ops.tile_ops.unify",
+                "unity.dashboard_manager.ops.tile_ops.unisdk",
             ) as mock_unify,
         ):
             mock_reg._base_context = BASE

--- a/tests/data_manager/test_context_resolution.py
+++ b/tests/data_manager/test_context_resolution.py
@@ -217,7 +217,7 @@ def test_get_context_with_empty_contextvar_raises():
     then turned into "user/68/Data//FileRecords/Local" (double slash, 404).
     """
     from unittest.mock import patch
-    from unify.logs import CONTEXT_READ, CONTEXT_WRITE
+    from unisdk.logs import CONTEXT_READ, CONTEXT_WRITE
     from unity.file_manager.managers.file_manager import FileManager
 
     ContextRegistry.clear()
@@ -239,7 +239,7 @@ def test_get_context_uses_stashed_base_after_clear():
     polluted ContextVar.
     """
     from unittest.mock import patch
-    from unify.logs import CONTEXT_READ, CONTEXT_WRITE
+    from unisdk.logs import CONTEXT_READ, CONTEXT_WRITE
     from unity.file_manager.managers.file_manager import FileManager
 
     ContextRegistry.clear()

--- a/tests/data_manager/test_destination_routing.py
+++ b/tests/data_manager/test_destination_routing.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import uuid
 
 import pytest
-import unify
+import unisdk
 
 from tests.helpers import _handle_project
 from unity.common.context_registry import ContextRegistry
@@ -40,7 +40,7 @@ def _configure_teams() -> tuple[int, int]:
 def _reset_teams(team_ids: tuple[int, int], suffix: str) -> None:
     for team_id in team_ids:
         try:
-            unify.delete_context(f"Teams/{team_id}/Data/{suffix}")
+            unisdk.delete_context(f"Teams/{team_id}/Data/{suffix}")
         except Exception:
             pass
     SESSION_DETAILS.team_ids = []

--- a/tests/data_manager/test_ops.py
+++ b/tests/data_manager/test_ops.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import pytest
 import requests
-from unify.utils.http import RequestError
+from unisdk.utils.http import RequestError
 
 from unity.data_manager.ops import ingest_ops, mutation_ops
 

--- a/tests/data_manager/test_post_ingest.py
+++ b/tests/data_manager/test_post_ingest.py
@@ -5,7 +5,7 @@ Covers:
 - ``_derive_target_name``: separator-aware target name construction
 - ``_run_post_ingest_rules``: config-driven rule execution with mocks
 - ``run_ingest`` post_ingest integration
-- Field description passthrough: widened ``fields`` type flows through to ``unify.create_fields``
+- Field description passthrough: widened ``fields`` type flows through to ``unisdk.create_fields``
 """
 
 from __future__ import annotations
@@ -355,9 +355,9 @@ class TestRunIngestPostIngestIntegration:
 
 class TestFieldsDescriptionPassthrough:
 
-    @patch("unity.data_manager.ops.table_ops.unify")
+    @patch("unity.data_manager.ops.table_ops.unisdk")
     def test_rich_fields_payload_reaches_create_fields(self, mock_unify):
-        """Verify that fields with descriptions pass through to unify.create_fields."""
+        """Verify that fields with descriptions pass through to unisdk.create_fields."""
         from unity.data_manager.ops.table_ops import create_table_impl
 
         rich_fields = {
@@ -382,7 +382,7 @@ class TestFieldsDescriptionPassthrough:
             context="test/ctx",
         )
 
-    @patch("unity.data_manager.ops.table_ops.unify")
+    @patch("unity.data_manager.ops.table_ops.unisdk")
     def test_simple_fields_still_work(self, mock_unify):
         """Backward compatibility: plain {name: type_str} still works."""
         from unity.data_manager.ops.table_ops import create_table_impl
@@ -396,7 +396,7 @@ class TestFieldsDescriptionPassthrough:
             context="test/ctx",
         )
 
-    @patch("unity.data_manager.ops.table_ops.unify")
+    @patch("unity.data_manager.ops.table_ops.unisdk")
     def test_none_fields_skips_create_fields(self, mock_unify):
         """When fields is None, create_fields should not be called."""
         from unity.data_manager.ops.table_ops import create_table_impl

--- a/tests/data_manager/test_real.py
+++ b/tests/data_manager/test_real.py
@@ -11,7 +11,7 @@ Each test gets a fresh, isolated Unify context that is cleaned up after the test
 from __future__ import annotations
 
 import pytest
-from unify.utils.http import RequestError
+from unisdk.utils.http import RequestError
 
 from unity.data_manager.data_manager import DataManager
 from unity.data_manager.types import TableDescription

--- a/tests/destination_routing_helpers.py
+++ b/tests/destination_routing_helpers.py
@@ -9,9 +9,9 @@ from collections.abc import Iterable
 from typing import Any
 
 import pytest
-import unify
+import unisdk
 from pydantic import BaseModel, Field
-from unify.utils.http import RequestError
+from unisdk.utils.http import RequestError
 
 from tests.async_tool_loop.conftest import LLM_CONFIGS
 from unity.blacklist_manager.base import BaseBlackListManager
@@ -64,7 +64,7 @@ def manager_routing_context(request):
     team_id = 20_000_000 + uuid.uuid4().int % 1_000_000_000
     ContextRegistry.clear()
     SESSION_DETAILS.reset()
-    unify.set_context(context, relative=False)
+    unisdk.set_context(context, relative=False)
     SESSION_DETAILS.team_ids = [team_id]
     SESSION_DETAILS.team_summaries = [
         {
@@ -76,7 +76,7 @@ def manager_routing_context(request):
     yield context, team_id
     for root in (context, f"Teams/{team_id}"):
         delete_context_tree(root)
-    unify.unset_context()
+    unisdk.unset_context()
     SESSION_DETAILS.reset()
     ContextRegistry.clear()
 
@@ -120,7 +120,7 @@ class RoutingScenario:
     def setup(self) -> None:
         ContextRegistry.clear()
         SESSION_DETAILS.reset()
-        unify.set_context(self.context, relative=False)
+        unisdk.set_context(self.context, relative=False)
         SESSION_DETAILS.team_ids = [self.patch_team_id, self.research_team_id]
         SESSION_DETAILS.team_summaries = self.team_summaries
 
@@ -131,7 +131,7 @@ class RoutingScenario:
             f"Teams/{self.research_team_id}",
         ):
             delete_context_tree(root)
-        unify.unset_context()
+        unisdk.unset_context()
         SESSION_DETAILS.reset()
         ContextRegistry.clear()
 
@@ -200,16 +200,16 @@ def delete_context_tree(root: str) -> None:
     """Delete a context and all currently listed descendants."""
 
     try:
-        children = list(unify.get_contexts(prefix=f"{root}/").keys())
+        children = list(unisdk.get_contexts(prefix=f"{root}/").keys())
     except Exception:
         children = []
     for context in sorted(children, key=len, reverse=True):
         try:
-            unify.delete_context(context)
+            unisdk.delete_context(context)
         except Exception:
             pass
     try:
-        unify.delete_context(root)
+        unisdk.delete_context(root)
     except Exception:
         pass
 
@@ -218,7 +218,7 @@ def rows_containing(context: str, sentinel: str) -> list[dict[str, Any]]:
     """Return rows containing a sentinel, treating missing contexts as empty."""
 
     try:
-        logs = unify.get_logs(context=context, limit=100)
+        logs = unisdk.get_logs(context=context, limit=100)
     except RequestError as exc:
         if "context" in str(exc).lower() and "not found" in str(exc).lower():
             return []

--- a/tests/docs/grid-search.md
+++ b/tests/docs/grid-search.md
@@ -161,10 +161,10 @@ Dry run - commands that would be executed:
 After a grid search, query the `Combined` context to compare results:
 
 ```python
-import unify
+import unisdk
 
-unify.activate("UnityTests")
-logs = unify.get_logs(context="Combined")
+unisdk.activate("UnityTests")
+logs = unisdk.get_logs(context="Combined")
 
 # Filter by tags (contains the exact --env values from the grid search)
 for log in logs:

--- a/tests/event_bus/test_global_vs_specific_schema.py
+++ b/tests/event_bus/test_global_vs_specific_schema.py
@@ -12,7 +12,7 @@ import json
 import pytest
 import datetime as dt
 
-import unify
+import unisdk
 
 from unity.events.event_bus import EventBus, Event
 from unity.events.types.manager_method import ManagerMethodPayload
@@ -45,8 +45,8 @@ async def test_global_context_stores_payload_json():
 
     # Query the global context directly to inspect raw schema
     global_ctx = bus._global_ctx
-    logs = unify.get_logs(
-        project=unify.active_project(),
+    logs = unisdk.get_logs(
+        project=unisdk.active_project(),
         context=global_ctx,
         filter=f"event_id == '{event.event_id}'",
     )
@@ -88,8 +88,8 @@ async def test_specific_context_spreads_payload():
 
     # Query the type-specific context directly
     specific_ctx = bus._specific_ctxs["ManagerMethod"]
-    logs = unify.get_logs(
-        project=unify.active_project(),
+    logs = unisdk.get_logs(
+        project=unisdk.active_project(),
         context=specific_ctx,
         filter=f"event_id == '{event.event_id}'",
     )

--- a/tests/event_bus/test_limit_check_connect_timeout.py
+++ b/tests/event_bus/test_limit_check_connect_timeout.py
@@ -1,6 +1,6 @@
 """Tests for shared spend client in spending limit checks.
 
-Verifies that limit checks use a shared ``unify.AsyncSpendClient`` with
+Verifies that limit checks use a shared ``unisdk.AsyncSpendClient`` with
 connection pooling and retries, so that connections are reused across checks.
 """
 
@@ -193,7 +193,7 @@ class TestSharedSpendClient:
 
         with _patch_context():
             with patch.object(sl, "_get_spend_client", return_value=mock_client):
-                with patch("unify.async_admin.AsyncSpendClient") as mock_cls:
+                with patch("unisdk.async_admin.AsyncSpendClient") as mock_cls:
                     await sl.check_spending_limits_callback(
                         LimitCheckRequest(model="gpt-4", endpoint="test"),
                     )

--- a/tests/event_bus/test_spending.py
+++ b/tests/event_bus/test_spending.py
@@ -17,7 +17,7 @@ import pytest
 from unillm import LLMEvent
 from unillm.limit_hooks import LimitCheckRequest, LimitType
 
-from unify.async_admin import SpendRequestError
+from unisdk.async_admin import SpendRequestError
 
 from unity.common.log_utils import AtomicUpsertResult, atomic_upsert
 from unity.events.llm_event_hook import (
@@ -89,7 +89,7 @@ class TestAtomicUpsert:
                 with patch("unity.common.log_utils.SETTINGS") as mock_settings:
                     mock_settings.ORCHESTRA_URL = "https://api.test.com/v0"
 
-                    with patch("unity.common.log_utils.unify") as mock_unify:
+                    with patch("unity.common.log_utils.unisdk") as mock_unify:
                         mock_unify.active_project.return_value = "Assistants"
 
                         result = await atomic_upsert(
@@ -148,7 +148,7 @@ class TestAtomicUpsert:
                 with patch("unity.common.log_utils.SETTINGS") as mock_settings:
                     mock_settings.ORCHESTRA_URL = "https://api.test.com/v0"
 
-                    with patch("unity.common.log_utils.unify") as mock_unify:
+                    with patch("unity.common.log_utils.unisdk") as mock_unify:
                         mock_unify.active_project.return_value = "Assistants"
 
                         await atomic_upsert(
@@ -206,7 +206,7 @@ class TestAtomicUpsert:
                 with patch("unity.common.log_utils.SETTINGS") as mock_settings:
                     mock_settings.ORCHESTRA_URL = "https://api.test.com/v0"
 
-                    with patch("unity.common.log_utils.unify") as mock_unify:
+                    with patch("unity.common.log_utils.unisdk") as mock_unify:
                         mock_unify.active_project.return_value = "Assistants"
 
                         await atomic_upsert(
@@ -253,7 +253,7 @@ class TestAtomicUpsert:
                 with patch("unity.common.log_utils.SETTINGS") as mock_settings:
                     mock_settings.ORCHESTRA_URL = "https://api.test.com/v0"
 
-                    with patch("unity.common.log_utils.unify") as mock_unify:
+                    with patch("unity.common.log_utils.unisdk") as mock_unify:
                         mock_unify.active_project.return_value = "Assistants"
 
                         with pytest.raises(httpx.HTTPStatusError):
@@ -530,7 +530,7 @@ class TestConcurrentSpendUpdates:
                 with patch("unity.common.log_utils.SETTINGS") as mock_settings:
                     mock_settings.ORCHESTRA_URL = "https://api.test.com/v0"
 
-                    with patch("unity.common.log_utils.unify") as mock_unify:
+                    with patch("unity.common.log_utils.unisdk") as mock_unify:
                         mock_unify.active_project.return_value = "Assistants"
 
                         # Launch 5 concurrent upserts

--- a/tests/event_bus/test_windows.py
+++ b/tests/event_bus/test_windows.py
@@ -42,10 +42,10 @@ async def test_cache_only_skips_backend():
         await bus.publish(evt, blocking=True)
 
     # Use a spy to track get_logs calls
-    original_get_logs = __import__("unify").get_logs
+    original_get_logs = __import__("unisdk").get_logs
     spy = MagicMock(side_effect=original_get_logs)
 
-    with patch("unify.get_logs", spy):
+    with patch("unisdk.get_logs", spy):
         # Search for fewer events than cache holds
         results = await bus.search(filter="type == 'Message'", limit=3)
 

--- a/tests/file_manager/managers/test_embed_modes_private.py
+++ b/tests/file_manager/managers/test_embed_modes_private.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import Any, Dict, List
 
 import pytest
-import unify
+import unisdk
 
 from tests.helpers import _handle_project
 from unity.common.pipeline.instrumentation import PipelineInstrumentation
@@ -162,7 +162,7 @@ def test_embed_off_no_columns(file_manager, tmp_path: Path):
     )
     assert file_id is not None, f"File record not found for {file_path}"
     ctx = fm._ctx_for_file_content(str(file_id))
-    fields = unify.get_fields(context=ctx)
+    fields = unisdk.get_fields(context=ctx)
     assert "_summary_emb" not in fields
 
 
@@ -259,7 +259,7 @@ def test_embed_after_creates_columns(file_manager, tmp_path: Path):
     )
     assert file_id is not None, f"File record not found for {file_path}"
     ctx = fm._ctx_for_file_content(str(file_id))
-    fields = unify.get_fields(context=ctx)
+    fields = unisdk.get_fields(context=ctx)
     assert "_summary_emb" in fields
 
 
@@ -366,7 +366,7 @@ def test_embed_along_content(file_manager, tmp_path: Path):
     )
     assert file_id is not None, f"File record not found for {file_path}"
     ctx = fm._ctx_for_file_content(str(file_id))
-    fields = unify.get_fields(context=ctx)
+    fields = unisdk.get_fields(context=ctx)
     assert "_summary_emb" in fields
 
 

--- a/tests/file_manager/managers/test_parse_tables.py
+++ b/tests/file_manager/managers/test_parse_tables.py
@@ -84,9 +84,9 @@ async def test_csv_per_table_context(file_manager, tmp_path: Path):
     assert item.status == "success"
 
     # Verify `/Content/` contains sheet + table catalog rows (RAG navigation surface)
-    import unify
+    import unisdk
 
-    content_rows = unify.get_logs(context=item.content_ref.context, limit=50)
+    content_rows = unisdk.get_logs(context=item.content_ref.context, limit=50)
     assert content_rows, "Expected at least one /Content/ row"
     entries = [r.entries for r in content_rows]
     sheet_rows = [e for e in entries if e.get("content_type") == "sheet"]
@@ -100,8 +100,8 @@ async def test_csv_per_table_context(file_manager, tmp_path: Path):
     assert table_rows[0].get("summary") == "stub table summary"
 
     # Verify a per-table context exists
-    ctxs = unify.get_contexts()
-    # unify.get_contexts() returns a list of dicts with 'name' field
+    ctxs = unisdk.get_contexts()
+    # unisdk.get_contexts() returns a list of dicts with 'name' field
     ctx_names = (
         [ctx.get("name", "") for ctx in ctxs]
         if isinstance(ctxs, list)
@@ -114,7 +114,7 @@ async def test_csv_per_table_context(file_manager, tmp_path: Path):
 
     # Optionally, fetch a few rows from one table context
     sample_ctx = table_ctx_candidates[0]
-    rows = unify.get_logs(context=sample_ctx, limit=10)
+    rows = unisdk.get_logs(context=sample_ctx, limit=10)
     # Should have header-derived columns
     assert rows, "No rows found"
     assert set(["Name", "Age", "City"]).issubset(
@@ -211,9 +211,9 @@ async def test_xlsx_multi_tab_per_table_context(file_manager, tmp_path: Path):
     #   .../Files/Local/<storage_id>/Tables/<SheetName>
     # retail_data.xlsx  -> Local/0/Tables/{Stores,Sales,Inventory,Returns}
     # workforce_data.xlsx -> Local/1/Tables/{Employees,Attendance,Salaries}
-    import unify
+    import unisdk
 
-    ctxs = unify.get_contexts()
+    ctxs = unisdk.get_contexts()
     ctx_names = (
         [ctx.get("name", "") for ctx in ctxs]
         if isinstance(ctxs, list)

--- a/tests/file_manager/sync/test_manager.py
+++ b/tests/file_manager/sync/test_manager.py
@@ -223,7 +223,7 @@ class TestSyncManagerSSHKeyRetrieval:
                 "unity.settings.SETTINGS",
             ) as mock_settings,
             patch(
-                "unify.utils.http.get",
+                "unisdk.utils.http.get",
                 return_value=mock_response,
             ) as mock_get,
         ):
@@ -263,7 +263,7 @@ class TestSyncManagerSSHKeyRetrieval:
                 "unity.settings.SETTINGS",
             ) as mock_settings,
             patch(
-                "unify.utils.http.get",
+                "unisdk.utils.http.get",
                 return_value=mock_response,
             ),
         ):

--- a/tests/file_manager/test_destination_routing.py
+++ b/tests/file_manager/test_destination_routing.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import uuid
 
 import pytest
-import unify
+import unisdk
 
 from tests.helpers import _handle_project
 from unity.common.context_registry import ContextRegistry
@@ -42,7 +42,7 @@ def _reset_teams(team_ids: tuple[int, int], alias: str) -> None:
             f"Teams/{team_id}/Files/{alias}",
         ):
             try:
-                unify.delete_context(context)
+                unisdk.delete_context(context)
             except Exception:
                 pass
     SESSION_DETAILS.team_ids = []

--- a/tests/file_manager/test_tool_docstrings.py
+++ b/tests/file_manager/test_tool_docstrings.py
@@ -63,14 +63,14 @@ def _build_tools_schema_in_subprocess(method: str, test_context: str) -> str:
         f"""
 		import os, sys, json
 		sys.path.insert(0, os.getcwd())
-		import unify
+		import unisdk
 		# Activate the test project before setting context
 		project_name = os.environ.get("UNITY_TEST_PROJECT_NAME", "UnityTests")
-		unify.activate(project_name, overwrite=False)
+		unisdk.activate(project_name, overwrite=False)
 		# Set test-specific context before creating FileManager to avoid races
 		test_ctx = os.environ.get("_TEST_CONTEXT")
 		if test_ctx:
-			unify.set_context(test_ctx, relative=False)
+			unisdk.set_context(test_ctx, relative=False)
 		from unity.common.llm_helpers import method_to_schema
 		def _unwrap_callable(tool):
 			return getattr(tool, "fn", tool)

--- a/tests/flows/harness.py
+++ b/tests/flows/harness.py
@@ -523,12 +523,12 @@ class FlowHarness:
         if not self.context_path:
             return
         try:
-            import unify
+            import unisdk
             from unity.common.context_registry import ContextRegistry
             from unity.knowledge_manager.knowledge_manager import KNOWLEDGE_TABLE
 
             try:
-                unify.set_context(self.context_path, relative=False, skip_create=True)
+                unisdk.set_context(self.context_path, relative=False, skip_create=True)
             except Exception:
                 pass
             ContextRegistry.set_base_context(self.context_path)
@@ -595,7 +595,7 @@ async def build_flow_harness(
 ) -> FlowHarness:
     """Start a real CM + CodeAct actor for flow tests."""
 
-    import unify
+    import unisdk
     from unity.settings import SETTINGS
 
     await _reset_operations_queue()
@@ -603,7 +603,7 @@ async def build_flow_harness(
     isolation_user = hashlib.sha256(context_path.encode()).hexdigest()[:16]
     os.environ["USER_ID"] = isolation_user
 
-    unify.activate(project_name, overwrite=False)
+    unisdk.activate(project_name, overwrite=False)
     try:
         from unity.common.context_registry import ContextRegistry
         from unity.events.event_bus import EVENT_BUS
@@ -613,9 +613,9 @@ async def build_flow_harness(
     except Exception:
         pass
     try:
-        unify.set_context(context_path, relative=False, skip_create=False)
+        unisdk.set_context(context_path, relative=False, skip_create=False)
     except Exception:
-        unify.set_context(context_path, relative=False, skip_create=True)
+        unisdk.set_context(context_path, relative=False, skip_create=True)
 
     ActorFactory._apply_manager_impl_env("real")
     ManagerRegistry.clear()

--- a/tests/flows/test_task_schedule.py
+++ b/tests/flows/test_task_schedule.py
@@ -30,7 +30,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Any
 
 import pytest
-import unify
+import unisdk
 
 from unity.common.context_registry import ContextRegistry
 from unity.manager_registry import ManagerRegistry
@@ -122,7 +122,7 @@ def _resolve_coordinator() -> dict[str, Any] | None:
     hardcoded id.
     """
 
-    for assistant in unify.list_assistants():
+    for assistant in unisdk.list_assistants():
         if assistant.get("is_coordinator") and assistant.get("agent_id") is not None:
             return assistant
     return None
@@ -152,16 +152,16 @@ def coordinator_task_env():
     user_id = str(coordinator["user_id"])
     base_context = f"{user_id}/{agent_id}"
 
-    prev_project = unify.active_project()
-    prev_ctx = unify.get_active_context()
+    prev_project = unisdk.active_project()
+    prev_ctx = unisdk.get_active_context()
     prev_user_id = SESSION_DETAILS.user.id
     prev_agent_id = SESSION_DETAILS.assistant.agent_id
     prev_base_context = ContextRegistry._base_context
 
     SESSION_DETAILS.user.id = user_id
     SESSION_DETAILS.assistant.agent_id = agent_id
-    unify.activate(TASK_MACHINE_STATE_PROJECT)
-    unify.set_context(base_context, relative=False, skip_create=False)
+    unisdk.activate(TASK_MACHINE_STATE_PROJECT)
+    unisdk.set_context(base_context, relative=False, skip_create=False)
     ContextRegistry.clear()
     ContextRegistry.set_base_context(base_context)
     # Drop any cached singleton built under a previous flow test's context so
@@ -184,21 +184,21 @@ def coordinator_task_env():
             ContextRegistry.set_base_context(prev_base_context)
         ManagerRegistry.clear()
         if prev_project:
-            unify.activate(prev_project)
+            unisdk.activate(prev_project)
         prev_read = (prev_ctx or {}).get("read") or ""
         prev_write = (prev_ctx or {}).get("write") or ""
         if prev_read or prev_write:
             # Restore read/write independently so a prior context whose read and
             # write halves differ is not silently collapsed to one value.
-            unify.set_context(
+            unisdk.set_context(
                 prev_write,
                 mode="write",
                 relative=False,
                 skip_create=True,
             )
-            unify.set_context(prev_read, mode="read", relative=False, skip_create=True)
+            unisdk.set_context(prev_read, mode="read", relative=False, skip_create=True)
         else:
-            unify.unset_context()
+            unisdk.unset_context()
 
 
 async def _wait_for_activation(

--- a/tests/function_manager/core/test_embeddings.py
+++ b/tests/function_manager/core/test_embeddings.py
@@ -1,7 +1,7 @@
 import json
 
 import pytest
-import unify
+import unisdk
 
 from unity.function_manager.function_manager import FunctionManager
 from tests.helpers import _handle_project
@@ -56,7 +56,7 @@ def send_plain_text_email(recipient: str, subject: str, body: str):
 
 def _get_embedding(fm: FunctionManager, name: str):
     """Fetch the raw _embedding_text_emb for a function by name."""
-    logs = unify.get_logs(
+    logs = unisdk.get_logs(
         context=fm._compositional_ctx,
         filter=f"name == {json.dumps(name)}",
         limit=1,

--- a/tests/function_manager/core/test_foreign_keys.py
+++ b/tests/function_manager/core/test_foreign_keys.py
@@ -12,7 +12,7 @@ Coverage
 
 from __future__ import annotations
 
-import unify
+import unisdk
 from tests.helpers import _handle_project
 from unity.function_manager.function_manager import FunctionManager
 from unity.guidance_manager.guidance_manager import GuidanceManager
@@ -33,7 +33,7 @@ def test_fk_guidance_ids_valid_reference():
     gm.add_guidance(title="Usage Guide", content="How to use the system")
 
     # Get guidance IDs
-    guidance_list = unify.get_logs(context=gm._ctx, from_fields=["guidance_id"])
+    guidance_list = unisdk.get_logs(context=gm._ctx, from_fields=["guidance_id"])
     g_ids = sorted([int(g.entries["guidance_id"]) for g in guidance_list])
     assert len(g_ids) == 2
 
@@ -42,7 +42,7 @@ def test_fk_guidance_ids_valid_reference():
     fm.add_functions(implementations=src)
 
     # Get the function log
-    func_logs = unify.get_logs(
+    func_logs = unisdk.get_logs(
         context=fm._compositional_ctx,
         filter="name == 'setup_demo'",
         return_ids_only=True,
@@ -50,7 +50,7 @@ def test_fk_guidance_ids_valid_reference():
     assert func_logs, "Function not created"
 
     # Update with guidance_ids
-    unify.update_logs(
+    unisdk.update_logs(
         context=fm._compositional_ctx,
         logs=func_logs[0],
         entries={"guidance_ids": g_ids},
@@ -58,7 +58,7 @@ def test_fk_guidance_ids_valid_reference():
     )
 
     # Verify function was created with guidance_ids
-    funcs = unify.get_logs(
+    funcs = unisdk.get_logs(
         context=fm._compositional_ctx,
         from_fields=["function_id", "guidance_ids"],
     )
@@ -79,7 +79,7 @@ def test_fk_guidance_ids_cascade_on_delete():
     gm.add_guidance(title="Guide 3", content="Content 3")
 
     # Get guidance IDs
-    guidance_list = unify.get_logs(context=gm._ctx, from_fields=["guidance_id"])
+    guidance_list = unisdk.get_logs(context=gm._ctx, from_fields=["guidance_id"])
     g_ids = sorted([int(g.entries["guidance_id"]) for g in guidance_list])
     assert len(g_ids) == 3
     g1, g2, g3 = g_ids
@@ -89,7 +89,7 @@ def test_fk_guidance_ids_cascade_on_delete():
     fm.add_functions(implementations=src)
 
     # Get the function log
-    func_logs = unify.get_logs(
+    func_logs = unisdk.get_logs(
         context=fm._compositional_ctx,
         filter="name == 'complex_setup'",
         return_ids_only=True,
@@ -97,7 +97,7 @@ def test_fk_guidance_ids_cascade_on_delete():
     assert func_logs, "Function not created"
 
     # Update with guidance_ids
-    unify.update_logs(
+    unisdk.update_logs(
         context=fm._compositional_ctx,
         logs=func_logs[0],
         entries={"guidance_ids": [g1, g2, g3]},
@@ -105,7 +105,7 @@ def test_fk_guidance_ids_cascade_on_delete():
     )
 
     # Verify function has all three guidance_ids
-    funcs = unify.get_logs(
+    funcs = unisdk.get_logs(
         context=fm._compositional_ctx,
         from_fields=["function_id", "guidance_ids"],
     )
@@ -116,7 +116,7 @@ def test_fk_guidance_ids_cascade_on_delete():
     gm.delete_guidance(guidance_id=g2)
 
     # Verify g2 was removed from function.guidance_ids (CASCADE behavior)
-    funcs_after = unify.get_logs(
+    funcs_after = unisdk.get_logs(
         context=fm._compositional_ctx,
         from_fields=["function_id", "guidance_ids"],
     )
@@ -136,7 +136,7 @@ def test_fk_guidance_ids_empty_array():
     fm.add_functions(implementations=src)
 
     # Verify function was created with empty guidance_ids
-    funcs = unify.get_logs(
+    funcs = unisdk.get_logs(
         context=fm._compositional_ctx,
         from_fields=["function_id", "guidance_ids"],
     )
@@ -155,7 +155,7 @@ def test_fk_guidance_ids_multiple_deletes():
         gm.add_guidance(title=f"Guide {i}", content=f"Content {i}")
 
     # Get all guidance IDs
-    guidance_list = unify.get_logs(context=gm._ctx, from_fields=["guidance_id"])
+    guidance_list = unisdk.get_logs(context=gm._ctx, from_fields=["guidance_id"])
     g_ids = sorted([int(g.entries["guidance_id"]) for g in guidance_list])
     assert len(g_ids) == 5
 
@@ -164,7 +164,7 @@ def test_fk_guidance_ids_multiple_deletes():
     fm.add_functions(implementations=src)
 
     # Get the function log
-    func_logs = unify.get_logs(
+    func_logs = unisdk.get_logs(
         context=fm._compositional_ctx,
         filter="name == 'mega_func'",
         return_ids_only=True,
@@ -172,7 +172,7 @@ def test_fk_guidance_ids_multiple_deletes():
     assert func_logs, "Function not created"
 
     # Update with guidance_ids
-    unify.update_logs(
+    unisdk.update_logs(
         context=fm._compositional_ctx,
         logs=func_logs[0],
         entries={"guidance_ids": g_ids},
@@ -184,7 +184,7 @@ def test_fk_guidance_ids_multiple_deletes():
         gm.delete_guidance(guidance_id=gid)
 
     # Verify only last 2 remain in function.guidance_ids
-    funcs = unify.get_logs(
+    funcs = unisdk.get_logs(
         context=fm._compositional_ctx,
         from_fields=["function_id", "guidance_ids"],
     )

--- a/tests/function_manager/test_destination_routing.py
+++ b/tests/function_manager/test_destination_routing.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import uuid
 
-import unify
+import unisdk
 
 from tests.destination_routing_helpers import (
     manager_routing_context as manager_routing_context,  # noqa: F401
@@ -30,8 +30,8 @@ def test_function_writes_route_to_destination_and_reads_merge_roots(
         destination=f"team:{team_id}",
     )
 
-    personal_rows = unify.get_logs(context=manager._compositional_ctx)
-    shared_rows = unify.get_logs(
+    personal_rows = unisdk.get_logs(context=manager._compositional_ctx)
+    shared_rows = unisdk.get_logs(
         context=f"Teams/{team_id}/Functions/Compositional",
     )
 
@@ -101,11 +101,11 @@ def test_sync_custom_venvs_routes_each_destination_independently(
     )
     personal_ids = manager.sync_custom_venvs(source_venvs=source_venvs)
 
-    personal_rows = unify.get_logs(
+    personal_rows = unisdk.get_logs(
         context=manager._venvs_ctx,
         filter=f"name == '{venv_name}'",
     )
-    shared_rows = unify.get_logs(
+    shared_rows = unisdk.get_logs(
         context=f"Teams/{team_id}/Functions/VirtualEnvs",
         filter=f"name == '{venv_name}'",
     )
@@ -128,7 +128,7 @@ def test_sync_custom_venvs_routes_each_destination_independently(
         source_venvs=source_venvs,
         destination=f"team:{team_id}",
     )
-    refreshed_shared_rows = unify.get_logs(
+    refreshed_shared_rows = unisdk.get_logs(
         context=f"Teams/{team_id}/Functions/VirtualEnvs",
         filter=f"name == '{venv_name}'",
     )
@@ -167,11 +167,11 @@ def test_sync_custom_functions_routes_each_destination_independently(
     )
     assert manager.sync_custom_functions(source_functions=source_functions) is True
 
-    personal_rows = unify.get_logs(
+    personal_rows = unisdk.get_logs(
         context=manager._compositional_ctx,
         filter=f"name == '{function_name}'",
     )
-    shared_rows = unify.get_logs(
+    shared_rows = unisdk.get_logs(
         context=f"Teams/{team_id}/Functions/Compositional",
         filter=f"name == '{function_name}'",
     )
@@ -195,7 +195,7 @@ def test_sync_custom_functions_routes_each_destination_independently(
         )
         is True
     )
-    refreshed_shared_rows = unify.get_logs(
+    refreshed_shared_rows = unisdk.get_logs(
         context=f"Teams/{team_id}/Functions/Compositional",
         filter=f"name == '{function_name}'",
     )

--- a/tests/function_manager/test_destination_routing_eval.py
+++ b/tests/function_manager/test_destination_routing_eval.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import uuid
 
 import pytest
-import unify
+import unisdk
 
 from tests.destination_routing_helpers import (
     RoutingScenario,
@@ -44,14 +44,14 @@ async def test_team_function_routes_to_the_matching_shared_team(llm_config):
         assert_tool_destination(messages, "add_functions", scenario.patch_destination)
         assert [
             row
-            for row in unify.get_logs(
+            for row in unisdk.get_logs(
                 context=f"Teams/{scenario.patch_team_id}/Functions/Compositional",
                 filter=f"name == '{function_name}'",
                 limit=10,
             )
         ]
         assert (
-            unify.get_logs(
+            unisdk.get_logs(
                 context=manager._compositional_ctx,
                 filter=f"name == '{function_name}'",
                 limit=10,

--- a/tests/function_manager/test_provider_integration_materialization.py
+++ b/tests/function_manager/test_provider_integration_materialization.py
@@ -442,7 +442,7 @@ def test_staging_sync_logs_insert_mismatch(monkeypatch, caplog) -> None:
         "unity.function_manager.function_manager.list_private_fields",
         lambda _context: [],
     )
-    monkeypatch.setattr("unify.get_logs", lambda **_kwargs: [])
+    monkeypatch.setattr("unisdk.get_logs", lambda **_kwargs: [])
     fm = _fake_function_manager()
     fm._primitives_ctx = "Functions/Primitives"
     fm._insert_primitives = lambda _rows: None
@@ -707,7 +707,7 @@ def test_function_manager_queries_do_not_call_integration_ops(monkeypatch) -> No
 
     monkeypatch.setattr("unity.integrations.ops.list_connections", fail_ops)
     monkeypatch.setattr(
-        "unify.get_logs",
+        "unisdk.get_logs",
         lambda **kwargs: (
             [SimpleNamespace(entries=primitive_row)]
             if kwargs.get("context") == "Functions/Primitives"
@@ -831,8 +831,8 @@ def test_disconnect_cleanup_deletes_only_metadata_provider_rows(
     def fake_delete_logs(**kwargs):
         deleted.extend(kwargs["logs"])
 
-    monkeypatch.setattr("unify.get_logs", fake_get_logs)
-    monkeypatch.setattr("unify.delete_logs", fake_delete_logs)
+    monkeypatch.setattr("unisdk.get_logs", fake_get_logs)
+    monkeypatch.setattr("unisdk.delete_logs", fake_delete_logs)
     monkeypatch.setattr(fm_module, "list_private_fields", lambda *_args, **_kwargs: [])
     fm = FunctionManager.__new__(FunctionManager)
     fm._primitives_ctx = "Functions/Primitives"

--- a/tests/guidance_manager/test_builtins_guidance.py
+++ b/tests/guidance_manager/test_builtins_guidance.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import uuid
 
 import pytest
-import unify
+import unisdk
 
 from tests.helpers import _handle_project
 from unity.guidance_manager.builtins_catalog import (
@@ -49,13 +49,13 @@ def builtins_test_project(monkeypatch):
     monkeypatch.setattr(SETTINGS, "UNITY_BUILTINS_PROJECT", name)
     yield name
     try:
-        unify.delete_project(name)
+        unisdk.delete_project(name)
     except Exception:
         pass
 
 
 def _builtin_rows(project: str) -> dict[str, dict]:
-    logs = unify.get_logs(
+    logs = unisdk.get_logs(
         project=project,
         context=BUILTINS_GUIDANCE_CONTEXT,
         from_fields=["guidance_id", "title", "content", "is_builtin"],

--- a/tests/guidance_manager/test_destination_routing.py
+++ b/tests/guidance_manager/test_destination_routing.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import unify
+import unisdk
 
 from tests.destination_routing_helpers import (
     manager_routing_context as manager_routing_context,  # noqa: F401
@@ -23,12 +23,12 @@ def test_guidance_writes_route_to_destination_and_reads_merge_roots(
         destination=f"team:{team_id}",
     )
 
-    assert [row.entries["title"] for row in unify.get_logs(context=manager._ctx)] == [
+    assert [row.entries["title"] for row in unisdk.get_logs(context=manager._ctx)] == [
         "Private rule",
     ]
     assert [
         row.entries["title"]
-        for row in unify.get_logs(context=f"Teams/{team_id}/Guidance")
+        for row in unisdk.get_logs(context=f"Teams/{team_id}/Guidance")
     ] == ["Team rule"]
     # Reads also federate over the read-only builtins library; tenant rows
     # are isolated with the provenance flag.

--- a/tests/guidance_manager/test_foreign_keys.py
+++ b/tests/guidance_manager/test_foreign_keys.py
@@ -17,7 +17,7 @@ Coverage
 
 from __future__ import annotations
 
-import unify
+import unisdk
 from tests.helpers import _handle_project
 from unity.function_manager.function_manager import FunctionManager
 from unity.guidance_manager.guidance_manager import GuidanceManager
@@ -68,7 +68,7 @@ def test_fk_images_valid_reference():
     )
 
     # Verify guidance created with nested image references
-    guidance_list = unify.get_logs(
+    guidance_list = unisdk.get_logs(
         context=gm._ctx,
         from_fields=["guidance_id", "images"],
     )
@@ -109,23 +109,23 @@ def test_fk_images_set_null_on_delete():
     )
 
     # Verify all 3 images
-    guidance_list = unify.get_logs(
+    guidance_list = unisdk.get_logs(
         context=gm._ctx,
         from_fields=["guidance_id", "images"],
     )
     assert len(guidance_list[0].entries["images"]) == 3
 
     # Delete middle image (img2)
-    img2_logs = unify.get_logs(
+    img2_logs = unisdk.get_logs(
         context=im._ctx,
         filter=f"image_id == {img2_id}",
         return_ids_only=True,
     )
     assert img2_logs, "Image not found"
-    unify.delete_logs(context=im._ctx, logs=img2_logs[0])
+    unisdk.delete_logs(context=im._ctx, logs=img2_logs[0])
 
     # Verify SET NULL behavior: img2 replaced with None in-place
-    guidance_after = unify.get_logs(context=gm._ctx, from_fields=["images"])
+    guidance_after = unisdk.get_logs(context=gm._ctx, from_fields=["images"])
     remaining_images = guidance_after[0].entries.get("images", [])
     assert len(remaining_images) == 3  # Still 3 entries, one has None
 
@@ -178,21 +178,21 @@ def test_fk_images_multiple_deletes():
     )
 
     # Verify all 5 images
-    guidance = unify.get_logs(context=gm._ctx, from_fields=["images"])
+    guidance = unisdk.get_logs(context=gm._ctx, from_fields=["images"])
     assert len(guidance[0].entries["images"]) == 5
 
     # Delete first 3 images
     for img_id in image_ids[:3]:
-        img_logs = unify.get_logs(
+        img_logs = unisdk.get_logs(
             context=im._ctx,
             filter=f"image_id == {img_id}",
             return_ids_only=True,
         )
         assert img_logs, f"Image {img_id} not found"
-        unify.delete_logs(context=im._ctx, logs=img_logs[0])
+        unisdk.delete_logs(context=im._ctx, logs=img_logs[0])
 
     # Verify SET NULL behavior: still 5 entries, 3 with None
-    guidance_after = unify.get_logs(context=gm._ctx, from_fields=["images"])
+    guidance_after = unisdk.get_logs(context=gm._ctx, from_fields=["images"])
     remaining_images = guidance_after[0].entries.get("images", [])
     assert len(remaining_images) == 5  # Still 5 entries
 
@@ -234,24 +234,24 @@ def test_fk_images_null_tolerance():
     )
 
     # Get guidance_id
-    guidance_list = unify.get_logs(context=gm._ctx, from_fields=["guidance_id"])
+    guidance_list = unisdk.get_logs(context=gm._ctx, from_fields=["guidance_id"])
     assert len(guidance_list) == 1
     guidance_id = int(guidance_list[0].entries["guidance_id"])
 
     # Delete image (SET NULL will replace image_id with None)
-    img_logs = unify.get_logs(
+    img_logs = unisdk.get_logs(
         context=im._ctx,
         filter=f"image_id == {img_id}",
         return_ids_only=True,
     )
     assert img_logs, "Image not found"
-    unify.delete_logs(context=im._ctx, logs=img_logs[0])
+    unisdk.delete_logs(context=im._ctx, logs=img_logs[0])
 
     # Reinitialize GuidanceManager and verify it doesn't crash
     gm2 = GuidanceManager()
 
     # Verify guidance still exists and can be read
-    guidance_after = unify.get_logs(
+    guidance_after = unisdk.get_logs(
         context=gm2._ctx,
         from_fields=["guidance_id", "images"],
     )
@@ -294,7 +294,7 @@ def test_fk_function_ids_valid_reference():
     fm.add_functions(implementations=[src1, src2])
 
     # Get function IDs
-    funcs = unify.get_logs(context=fm._compositional_ctx, from_fields=["function_id"])
+    funcs = unisdk.get_logs(context=fm._compositional_ctx, from_fields=["function_id"])
     func_ids = sorted([int(f.entries["function_id"]) for f in funcs])
     assert len(func_ids) == 2
 
@@ -306,7 +306,7 @@ def test_fk_function_ids_valid_reference():
     )
 
     # Verify guidance created with function_ids
-    guidance_list = unify.get_logs(
+    guidance_list = unisdk.get_logs(
         context=gm._ctx,
         from_fields=["guidance_id", "function_ids"],
     )
@@ -326,7 +326,7 @@ def test_fk_function_ids_set_null_on_delete():
         fm.add_functions(implementations=src)
 
     # Get function IDs
-    funcs = unify.get_logs(context=fm._compositional_ctx, from_fields=["function_id"])
+    funcs = unisdk.get_logs(context=fm._compositional_ctx, from_fields=["function_id"])
     func_ids = sorted([int(f.entries["function_id"]) for f in funcs])
     assert len(func_ids) == 3
     f1, f2, f3 = func_ids
@@ -339,14 +339,14 @@ def test_fk_function_ids_set_null_on_delete():
     )
 
     # Verify all 3 function_ids
-    guidance = unify.get_logs(context=gm._ctx, from_fields=["function_ids"])
+    guidance = unisdk.get_logs(context=gm._ctx, from_fields=["function_ids"])
     assert sorted(guidance[0].entries["function_ids"]) == [f1, f2, f3]
 
     # Delete middle function (f2)
     fm.delete_function(function_id=f2)
 
     # Verify f2 removed from function_ids array
-    guidance_after = unify.get_logs(context=gm._ctx, from_fields=["function_ids"])
+    guidance_after = unisdk.get_logs(context=gm._ctx, from_fields=["function_ids"])
     remaining_ids = sorted(guidance_after[0].entries.get("function_ids", []))
     assert remaining_ids == [f1, f3]
     assert f2 not in remaining_ids
@@ -365,7 +365,7 @@ def test_fk_function_ids_empty_array():
     )
 
     # Verify guidance was created
-    guidance = unify.get_logs(
+    guidance = unisdk.get_logs(
         context=gm._ctx,
         from_fields=["guidance_id", "function_ids"],
     )
@@ -391,7 +391,7 @@ def test_fk_combined_images_and_functions():
     # Create function
     src = "def demo():\n    return 'demo'\n"
     fm.add_functions(implementations=src)
-    funcs = unify.get_logs(context=fm._compositional_ctx, from_fields=["function_id"])
+    funcs = unisdk.get_logs(context=fm._compositional_ctx, from_fields=["function_id"])
     func_id = int(funcs[0].entries["function_id"])
 
     # Create guidance with both
@@ -405,21 +405,21 @@ def test_fk_combined_images_and_functions():
     )
 
     # Verify both references
-    guidance = unify.get_logs(context=gm._ctx, from_fields=["images", "function_ids"])
+    guidance = unisdk.get_logs(context=gm._ctx, from_fields=["images", "function_ids"])
     assert guidance[0].entries["images"][0]["raw_image_ref"]["image_id"] == img_id
     assert guidance[0].entries["function_ids"] == [func_id]
 
     # Delete image
-    img_logs = unify.get_logs(
+    img_logs = unisdk.get_logs(
         context=im._ctx,
         filter=f"image_id == {img_id}",
         return_ids_only=True,
     )
     assert img_logs, "Image not found"
-    unify.delete_logs(context=im._ctx, logs=img_logs[0])
+    unisdk.delete_logs(context=im._ctx, logs=img_logs[0])
 
     # Verify SET NULL: image_id replaced with None, function_ids intact
-    guidance_after = unify.get_logs(
+    guidance_after = unisdk.get_logs(
         context=gm._ctx,
         from_fields=["images", "function_ids"],
     )
@@ -432,7 +432,7 @@ def test_fk_combined_images_and_functions():
     fm.delete_function(function_id=func_id)
 
     # Verify function_id removed (CASCADE), guidance still exists
-    guidance_final = unify.get_logs(
+    guidance_final = unisdk.get_logs(
         context=gm._ctx,
         from_fields=["guidance_id", "images", "function_ids"],
     )

--- a/tests/guidance_manager/test_images.py
+++ b/tests/guidance_manager/test_images.py
@@ -5,7 +5,7 @@ from datetime import datetime, timezone
 from unity.image_manager.utils import make_solid_png_base64
 
 import pytest
-import unify
+import unisdk
 
 from unity.image_manager.image_manager import ImageManager
 from unity.guidance_manager.guidance_manager import GuidanceManager
@@ -107,7 +107,7 @@ def test_images_field_schema_is_nested_and_enforced():
     gm = GuidanceManager()
 
     # 1) The Guidance context should expose a nested JSON schema for the images field
-    fields = unify.get_fields(context=gm._ctx)
+    fields = unisdk.get_fields(context=gm._ctx)
     assert "images" in fields
     dtype = str(fields["images"].get("data_type"))
     # Expect array/list with object items including raw_image_ref + annotation and nested image_id
@@ -121,7 +121,7 @@ def test_images_field_schema_is_nested_and_enforced():
             {"raw_image_ref": {"image_id": 101}, "annotation": "overview"},
         ],
     }
-    _ = unify.log(context=gm._ctx, **valid_payload, new=True, mutable=True)
+    _ = unisdk.log(context=gm._ctx, **valid_payload, new=True, mutable=True)
 
     # 3) Invalid nested payload – wrong key name for image id → must be rejected
     invalid_payload_bad_key = {
@@ -132,7 +132,7 @@ def test_images_field_schema_is_nested_and_enforced():
         ],
     }
     with pytest.raises(Exception):
-        unify.log(context=gm._ctx, **invalid_payload_bad_key, new=True, mutable=True)
+        unisdk.log(context=gm._ctx, **invalid_payload_bad_key, new=True, mutable=True)
 
     # 4) Invalid nested payload – wrong type for annotation → must be rejected
     invalid_payload_bad_type = {
@@ -143,7 +143,7 @@ def test_images_field_schema_is_nested_and_enforced():
         ],
     }
     with pytest.raises(Exception):
-        unify.log(context=gm._ctx, **invalid_payload_bad_type, new=True, mutable=True)
+        unisdk.log(context=gm._ctx, **invalid_payload_bad_type, new=True, mutable=True)
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,4 +1,4 @@
-import unify
+import unisdk
 import functools
 import inspect
 import sys
@@ -44,8 +44,8 @@ def restore_scenario_context(ctx: str) -> None:
     """Restore both Unify and ContextRegistry to a session scenario root."""
     from unity.common.context_registry import ContextRegistry
 
-    unify.create_context(ctx)
-    unify.set_context(ctx, relative=False)
+    unisdk.create_context(ctx)
+    unisdk.set_context(ctx, relative=False)
     ContextRegistry.set_base_context(ctx)
 
 
@@ -195,7 +195,7 @@ def _log_test_combined(
 ) -> None:
     """Log test duration, LLM I/O, and settings to the Combined context."""
     try:
-        unify.log(
+        unisdk.log(
             context="Combined",
             test_fpath=test_fpath,
             tags=get_session_tags(),
@@ -325,7 +325,7 @@ def _upload_trace_to_context(
             return  # No spans after filtering
 
         # Detach from trace context to avoid recursive span creation.
-        # Without this, each unify.log() call generates ~26 Orchestra spans,
+        # Without this, each unisdk.log() call generates ~26 Orchestra spans,
         # turning a 600-span upload into 15,000+ additional spans.
         try:
             from opentelemetry import context
@@ -338,13 +338,13 @@ def _upload_trace_to_context(
             # Create the Trace context with explicit field types
             trace_ctx = f"{test_ctx}/Trace"
             try:
-                unify.create_context(trace_ctx)
+                unisdk.create_context(trace_ctx)
             except Exception:
                 pass  # Context may already exist
 
             # Create fields with explicit types (idempotent)
             try:
-                unify.create_fields(context=trace_ctx, fields=_TRACE_FIELDS)
+                unisdk.create_fields(context=trace_ctx, fields=_TRACE_FIELDS)
             except Exception:
                 pass  # Fields may already exist
 
@@ -365,7 +365,7 @@ def _upload_trace_to_context(
                 for span in spans
             ]
             try:
-                unify.create_logs(context=trace_ctx, entries=entries)
+                unisdk.create_logs(context=trace_ctx, entries=entries)
             except Exception:
                 pass  # Best-effort logging
         finally:
@@ -435,7 +435,7 @@ class _TestContext:
         NOTE:
         Unify context management is handled centrally in tests/conftest.py
         (pytest_runtest_setup/teardown) so it wraps fixture setup + teardown.
-        Doing unify.set_context()/unset_context() here (inside the test call
+        Doing unisdk.set_context()/unset_context() here (inside the test call
         phase) can cause flaky cross-test interference when fixtures create
         or clear managers that delete contexts.
         """
@@ -755,7 +755,7 @@ def is_scenario_seeded(
 
     # Check for transcripts - scenario is only fully seeded if both exist
     try:
-        logs = unify.get_logs(context=transcript_context, limit=1)
+        logs = unisdk.get_logs(context=transcript_context, limit=1)
         return bool(logs)
     except Exception:
         # If we can't check transcripts, fall back to contacts-only check

--- a/tests/image_manager/test_data_store.py
+++ b/tests/image_manager/test_data_store.py
@@ -125,7 +125,7 @@ def test_get_images_prefers_cache_and_falls_back_backend(monkeypatch):
         calls["count"] += 1
         return orig_get_logs(*args, **kwargs)
 
-    monkeypatch.setattr(unify, "get_logs", _wrapped_get_logs)
+    monkeypatch.setattr(unisdk, "get_logs", _wrapped_get_logs)
     _ = im.get_images([ids[0]])
     assert calls["count"] == 0
 
@@ -175,7 +175,7 @@ def test_image_handle_raw_caches_gcs_download(monkeypatch):
         ret["image_id"] = eid
         return _FakeLog(ret)
 
-    monkeypatch.setattr(unify, "log", _fake_unify_log)
+    monkeypatch.setattr(unisdk, "log", _fake_unify_log)
 
     [img_id] = im.add_images(
         [
@@ -194,7 +194,7 @@ def test_image_handle_raw_caches_gcs_download(monkeypatch):
         download_count["count"] += 1
         return b"IMG_BYTES"
 
-    monkeypatch.setattr(unify, "download_object", _fake_download_object)
+    monkeypatch.setattr(unisdk, "download_object", _fake_download_object)
 
     # First raw() must download and then cache base64 in DataStore
     h1 = im.get_images([img_id])[0]

--- a/tests/image_manager/test_data_store.py
+++ b/tests/image_manager/test_data_store.py
@@ -4,7 +4,7 @@ import base64
 from datetime import datetime, timezone
 from typing import Any
 
-import unify
+import unisdk
 from unity.image_manager.image_manager import ImageManager
 from unity.common.data_store import DataStore
 from tests.helpers import _handle_project
@@ -119,7 +119,7 @@ def test_get_images_prefers_cache_and_falls_back_backend(monkeypatch):
 
     # 1) Cache-hit path: both ids present in DataStore → zero backend reads
     calls = {"count": 0}
-    orig_get_logs = unify.get_logs
+    orig_get_logs = unisdk.get_logs
 
     def _wrapped_get_logs(*args: Any, **kwargs: Any):
         calls["count"] += 1
@@ -154,7 +154,7 @@ def test_image_handle_raw_caches_gcs_download(monkeypatch):
     ds = DataStore.for_context(im._ctx, key_fields=("image_id",))
 
     # Seed a row that points to GCS so ImageHandle.raw() downloads once
-    # Avoid a real POST with a GCS URL by faking unify.log
+    # Avoid a real POST with a GCS URL by faking unisdk.log
     class _FakeLog:
         def __init__(self, entries: dict):
             self.entries = entries
@@ -187,7 +187,7 @@ def test_image_handle_raw_caches_gcs_download(monkeypatch):
         ],
     )
 
-    # Mock unify.download_object to count downloads
+    # Mock unisdk.download_object to count downloads
     download_count = {"count": 0}
 
     def _fake_download_object(gcs_uri, *, api_key=None):

--- a/tests/image_manager/test_destination_routing.py
+++ b/tests/image_manager/test_destination_routing.py
@@ -5,7 +5,7 @@ import time
 from datetime import UTC, datetime
 
 import pytest
-import unify
+import unisdk
 
 from tests.helpers import _handle_project
 from unity.image_manager.image_manager import ImageManager
@@ -18,7 +18,7 @@ def _team_id() -> int:
 
 
 def _image_logs(context: str, image_id: int):
-    return unify.get_logs(
+    return unisdk.get_logs(
         context=context,
         filter=f"image_id == {int(image_id)}",
         return_ids_only=False,
@@ -27,16 +27,16 @@ def _image_logs(context: str, image_id: int):
 
 def _delete_context_tree(root: str) -> None:
     try:
-        children = list(unify.get_contexts(prefix=f"{root}/").keys())
+        children = list(unisdk.get_contexts(prefix=f"{root}/").keys())
     except Exception:
         children = []
     for context in sorted(children, key=len, reverse=True):
         try:
-            unify.delete_context(context)
+            unisdk.delete_context(context)
         except Exception:
             pass
     try:
-        unify.delete_context(root)
+        unisdk.delete_context(root)
     except Exception:
         pass
 
@@ -75,7 +75,7 @@ def test_image_writes_route_to_space_and_reads_fan_out():
 
     space_context = f"Teams/{team_id}/Images"
     assert _image_logs(im._ctx, personal_id)
-    assert not unify.get_logs(
+    assert not unisdk.get_logs(
         context=im._ctx,
         filter=f"caption == '{space_caption}'",
     )
@@ -173,7 +173,7 @@ def test_image_handle_updates_persist_to_original_root():
 
     handle.update_metadata(caption="handle updated in team")
 
-    assert not unify.get_logs(
+    assert not unisdk.get_logs(
         context=im._ctx,
         filter="caption == 'handle updated in team'",
     )

--- a/tests/image_manager/test_pending.py
+++ b/tests/image_manager/test_pending.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import base64
 from datetime import datetime, timezone
 import asyncio
-import unify
+import unisdk
 
 import pytest
 
@@ -175,7 +175,7 @@ def test_get_images_for_pending_prefers_cache_no_backend(monkeypatch):
     )
 
     calls = {"count": 0}
-    orig_get_logs = unify.get_logs
+    orig_get_logs = unisdk.get_logs
 
     def _wrapped_get_logs(*args, **kwargs):
         calls["count"] += 1

--- a/tests/image_manager/test_pending.py
+++ b/tests/image_manager/test_pending.py
@@ -181,7 +181,7 @@ def test_get_images_for_pending_prefers_cache_no_backend(monkeypatch):
         calls["count"] += 1
         return orig_get_logs(*args, **kwargs)
 
-    monkeypatch.setattr(unify, "get_logs", _wrapped_get_logs)
+    monkeypatch.setattr(unisdk, "get_logs", _wrapped_get_logs)
 
     handles = im.get_images([h1.image_id, h2.image_id])
     assert [h.image_id for h in handles] == [h1.image_id, h2.image_id]

--- a/tests/image_manager/test_types.py
+++ b/tests/image_manager/test_types.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import pytest
-import unify
+import unisdk
 from datetime import datetime, UTC
 from pydantic import BaseModel, Field
 from unity.common.context_store import TableStore
@@ -151,7 +151,7 @@ def test_backend_schema_raw_ref_field_enforced():
 
     # Provision context with nested schema for RawImageRef
     try:
-        ctxs = unify.get_active_context()
+        ctxs = unisdk.get_active_context()
         base_ctx = ctxs.get("write") if isinstance(ctxs, dict) else None
     except Exception:
         base_ctx = None
@@ -165,17 +165,17 @@ def test_backend_schema_raw_ref_field_enforced():
     )
     store.ensure_context()
 
-    fields = unify.get_fields(context=ctx)
+    fields = unisdk.get_fields(context=ctx)
     assert "ref" in fields and "image_id" in str(fields["ref"].get("data_type"))
 
     # Valid payload
     valid = {"ref": {"image_id": 123}}
-    _ = unify.log(context=ctx, **valid, new=True, mutable=True)
+    _ = unisdk.log(context=ctx, **valid, new=True, mutable=True)
 
     # Invalid: wrong nested key
     invalid = {"ref": {"image_idx": 123}}
     with pytest.raises(Exception):
-        unify.log(context=ctx, **invalid, new=True, mutable=True)
+        unisdk.log(context=ctx, **invalid, new=True, mutable=True)
 
 
 @_handle_project
@@ -184,7 +184,7 @@ def test_backend_schema_annotated_ref_field_enforced():
         ref: AnnotatedImageRef
 
     try:
-        ctxs = unify.get_active_context()
+        ctxs = unisdk.get_active_context()
         base_ctx = ctxs.get("write") if isinstance(ctxs, dict) else None
     except Exception:
         base_ctx = None
@@ -200,23 +200,23 @@ def test_backend_schema_annotated_ref_field_enforced():
     )
     store.ensure_context()
 
-    fields = unify.get_fields(context=ctx)
+    fields = unisdk.get_fields(context=ctx)
     dtype = str(fields["ref"].get("data_type"))
     assert "raw_image_ref" in dtype and "annotation" in dtype and "image_id" in dtype
 
     # Valid
     valid = {"ref": {"raw_image_ref": {"image_id": 5}, "annotation": "note"}}
-    _ = unify.log(context=ctx, **valid, new=True, mutable=True)
+    _ = unisdk.log(context=ctx, **valid, new=True, mutable=True)
 
     # Invalid key
     bad_key = {"ref": {"raw_image_ref": {"image_idx": 5}, "annotation": "note"}}
     with pytest.raises(Exception):
-        unify.log(context=ctx, **bad_key, new=True, mutable=True)
+        unisdk.log(context=ctx, **bad_key, new=True, mutable=True)
 
     # Invalid type
     bad_type = {"ref": {"raw_image_ref": {"image_id": 6}, "annotation": 123}}
     with pytest.raises(Exception):
-        unify.log(context=ctx, **bad_type, new=True, mutable=True)
+        unisdk.log(context=ctx, **bad_type, new=True, mutable=True)
 
 
 @_handle_project
@@ -225,7 +225,7 @@ def test_backend_schema_refs_field_enforced():
         refs: ImageRefs
 
     try:
-        ctxs = unify.get_active_context()
+        ctxs = unisdk.get_active_context()
         base_ctx = ctxs.get("write") if isinstance(ctxs, dict) else None
     except Exception:
         base_ctx = None
@@ -239,7 +239,7 @@ def test_backend_schema_refs_field_enforced():
     )
     store.ensure_context()
 
-    fields = unify.get_fields(context=ctx)
+    fields = unisdk.get_fields(context=ctx)
     dtype = str(fields["refs"].get("data_type"))
     assert "raw_image_ref" in dtype and "annotation" in dtype and "image_id" in dtype
 
@@ -250,12 +250,12 @@ def test_backend_schema_refs_field_enforced():
             {"raw_image_ref": {"image_id": 2}, "annotation": "a"},
         ],
     }
-    _ = unify.log(context=ctx, **valid, new=True, mutable=True)
+    _ = unisdk.log(context=ctx, **valid, new=True, mutable=True)
 
     # Invalid element structure
     bad = {"refs": [{"raw_image_ref": {"image_idx": 3}, "annotation": "x"}]}
     with pytest.raises(Exception):
-        unify.log(context=ctx, **bad, new=True, mutable=True)
+        unisdk.log(context=ctx, **bad, new=True, mutable=True)
 
 
 @_handle_project
@@ -264,7 +264,7 @@ def test_backend_schema_raw_refs_field_enforced():
         refs: RawImageRefs
 
     try:
-        ctxs = unify.get_active_context()
+        ctxs = unisdk.get_active_context()
         base_ctx = ctxs.get("write") if isinstance(ctxs, dict) else None
     except Exception:
         base_ctx = None
@@ -278,18 +278,18 @@ def test_backend_schema_raw_refs_field_enforced():
     )
     store.ensure_context()
 
-    fields = unify.get_fields(context=ctx)
+    fields = unisdk.get_fields(context=ctx)
     dtype = str(fields["refs"].get("data_type"))
     assert "image_id" in dtype and "raw_image_ref" not in dtype  # raw-only entries
 
     # Valid raw-only list
     valid = {"refs": [{"image_id": 10}, {"image_id": 11}]}
-    _ = unify.log(context=ctx, **valid, new=True, mutable=True)
+    _ = unisdk.log(context=ctx, **valid, new=True, mutable=True)
 
     # Invalid: annotated entry inside raw-only list
     bad = {"refs": [{"raw_image_ref": {"image_id": 12}, "annotation": "x"}]}
     with pytest.raises(Exception):
-        unify.log(context=ctx, **bad, new=True, mutable=True)
+        unisdk.log(context=ctx, **bad, new=True, mutable=True)
 
 
 @_handle_project
@@ -298,7 +298,7 @@ def test_backend_schema_annotated_refs_field_enforced():
         refs: AnnotatedImageRefs
 
     try:
-        ctxs = unify.get_active_context()
+        ctxs = unisdk.get_active_context()
         base_ctx = ctxs.get("write") if isinstance(ctxs, dict) else None
     except Exception:
         base_ctx = None
@@ -316,18 +316,18 @@ def test_backend_schema_annotated_refs_field_enforced():
     )
     store.ensure_context()
 
-    fields = unify.get_fields(context=ctx)
+    fields = unisdk.get_fields(context=ctx)
     dtype = str(fields["refs"].get("data_type"))
     assert "raw_image_ref" in dtype and "annotation" in dtype and "image_id" in dtype
 
     # Valid annotated list
     valid = {"refs": [{"raw_image_ref": {"image_id": 20}, "annotation": "z"}]}
-    _ = unify.log(context=ctx, **valid, new=True, mutable=True)
+    _ = unisdk.log(context=ctx, **valid, new=True, mutable=True)
 
     # Invalid element type for annotation
     bad = {"refs": [{"raw_image_ref": {"image_id": 21}, "annotation": 7}]}
     with pytest.raises(Exception):
-        unify.log(context=ctx, **bad, new=True, mutable=True)
+        unisdk.log(context=ctx, **bad, new=True, mutable=True)
 
 
 @_handle_project
@@ -336,7 +336,7 @@ def test_backend_schema_image_field_enforced():
         entry: Image
 
     try:
-        ctxs = unify.get_active_context()
+        ctxs = unisdk.get_active_context()
         base_ctx = ctxs.get("write") if isinstance(ctxs, dict) else None
     except Exception:
         base_ctx = None
@@ -350,7 +350,7 @@ def test_backend_schema_image_field_enforced():
     )
     store.ensure_context()
 
-    fields = unify.get_fields(context=ctx)
+    fields = unisdk.get_fields(context=ctx)
     dtype = str(fields["entry"].get("data_type"))
     assert "timestamp" in dtype and "data" in dtype
 
@@ -363,7 +363,7 @@ def test_backend_schema_image_field_enforced():
             "data": png_b64,
         },
     }
-    _ = unify.log(context=ctx, **valid, new=True, mutable=True)
+    _ = unisdk.log(context=ctx, **valid, new=True, mutable=True)
 
     # Invalid: missing required key 'data'
     bad_missing = {
@@ -373,4 +373,4 @@ def test_backend_schema_image_field_enforced():
         },
     }
     with pytest.raises(Exception):
-        unify.log(context=ctx, **bad_missing, new=True, mutable=True)
+        unisdk.log(context=ctx, **bad_missing, new=True, mutable=True)

--- a/tests/integrations/test_builtins_catalog.py
+++ b/tests/integrations/test_builtins_catalog.py
@@ -72,7 +72,7 @@ def test_seed_builtin_integrations_hash_guards_app_and_tool_units(monkeypatch) -
     }
 
     monkeypatch.setattr(
-        builtins_catalog.unify,
+        builtins_catalog.unisdk,
         "create_project",
         lambda *args, **kwargs: calls.append(("create_project", kwargs)),
     )
@@ -82,7 +82,7 @@ def test_seed_builtin_integrations_hash_guards_app_and_tool_units(monkeypatch) -
         lambda project: calls.append(("ensure_builtins_project", {"project": project})),
     )
     monkeypatch.setattr(
-        builtins_catalog.unify,
+        builtins_catalog.unisdk,
         "create_context",
         lambda *args, **kwargs: calls.append(("create_context", kwargs)),
     )
@@ -107,14 +107,14 @@ def test_seed_builtin_integrations_hash_guards_app_and_tool_units(monkeypatch) -
         seen_filters.add(filter_expr)
         return [17]
 
-    monkeypatch.setattr(builtins_catalog.unify, "get_logs", fake_get_logs)
+    monkeypatch.setattr(builtins_catalog.unisdk, "get_logs", fake_get_logs)
     monkeypatch.setattr(
-        builtins_catalog.unify,
+        builtins_catalog.unisdk,
         "delete_logs",
         lambda **kwargs: deleted.append((kwargs["context"], list(kwargs["logs"]))),
     )
     monkeypatch.setattr(
-        builtins_catalog.unify,
+        builtins_catalog.unisdk,
         "create_logs",
         lambda **kwargs: inserted.append((kwargs["context"], list(kwargs["entries"]))),
     )
@@ -176,7 +176,11 @@ def test_seed_builtin_integrations_preserves_unlisted_app_scope(monkeypatch) -> 
     seen_filters: set[str] = set()
 
     monkeypatch.setattr(builtins_catalog, "ensure_builtins_project", lambda *_: None)
-    monkeypatch.setattr(builtins_catalog.unify, "create_context", lambda *_, **__: None)
+    monkeypatch.setattr(
+        builtins_catalog.unisdk,
+        "create_context",
+        lambda *_, **__: None,
+    )
     monkeypatch.setattr(builtins_catalog, "ensure_vector_column", lambda *_, **__: None)
     monkeypatch.setattr(
         builtins_catalog,
@@ -193,7 +197,7 @@ def test_seed_builtin_integrations_preserves_unlisted_app_scope(monkeypatch) -> 
         "write_seed_hashes",
         lambda *_args, **_kwargs: None,
     )
-    monkeypatch.setattr(builtins_catalog.unify, "create_logs", lambda **_kwargs: None)
+    monkeypatch.setattr(builtins_catalog.unisdk, "create_logs", lambda **_kwargs: None)
 
     def fake_get_logs(**kwargs):
         if kwargs.get("context") == builtins_catalog.BUILTINS_INTEGRATION_META_CONTEXT:
@@ -206,8 +210,8 @@ def test_seed_builtin_integrations_preserves_unlisted_app_scope(monkeypatch) -> 
         seen_filters.add(filter_expr)
         return [17]
 
-    monkeypatch.setattr(builtins_catalog.unify, "get_logs", fake_get_logs)
-    monkeypatch.setattr(builtins_catalog.unify, "delete_logs", lambda **_kwargs: None)
+    monkeypatch.setattr(builtins_catalog.unisdk, "get_logs", fake_get_logs)
+    monkeypatch.setattr(builtins_catalog.unisdk, "delete_logs", lambda **_kwargs: None)
 
     assert builtins_catalog.seed_builtin_integrations(
         apps=[_app("gmail")],
@@ -236,7 +240,11 @@ def test_seed_builtin_integrations_prunes_unlisted_app_scope(monkeypatch) -> Non
     seen_filters: set[str] = set()
 
     monkeypatch.setattr(builtins_catalog, "ensure_builtins_project", lambda *_: None)
-    monkeypatch.setattr(builtins_catalog.unify, "create_context", lambda *_, **__: None)
+    monkeypatch.setattr(
+        builtins_catalog.unisdk,
+        "create_context",
+        lambda *_, **__: None,
+    )
     monkeypatch.setattr(builtins_catalog, "ensure_vector_column", lambda *_, **__: None)
     monkeypatch.setattr(
         builtins_catalog,
@@ -253,7 +261,7 @@ def test_seed_builtin_integrations_prunes_unlisted_app_scope(monkeypatch) -> Non
         "write_seed_hashes",
         lambda *_args, **_kwargs: None,
     )
-    monkeypatch.setattr(builtins_catalog.unify, "create_logs", lambda **_kwargs: None)
+    monkeypatch.setattr(builtins_catalog.unisdk, "create_logs", lambda **_kwargs: None)
 
     def fake_get_logs(**kwargs):
         if kwargs.get("context") == builtins_catalog.BUILTINS_INTEGRATION_META_CONTEXT:
@@ -266,8 +274,8 @@ def test_seed_builtin_integrations_prunes_unlisted_app_scope(monkeypatch) -> Non
         seen_filters.add(filter_expr)
         return [17]
 
-    monkeypatch.setattr(builtins_catalog.unify, "get_logs", fake_get_logs)
-    monkeypatch.setattr(builtins_catalog.unify, "delete_logs", lambda **_kwargs: None)
+    monkeypatch.setattr(builtins_catalog.unisdk, "get_logs", fake_get_logs)
+    monkeypatch.setattr(builtins_catalog.unisdk, "delete_logs", lambda **_kwargs: None)
 
     assert builtins_catalog.seed_builtin_integrations(
         apps=[_app("gmail")],
@@ -299,7 +307,11 @@ def test_seed_builtin_integrations_app_only_prune_preserves_tool_units(
     builtins_catalog._ENSURED_STORAGE_PROJECTS.clear()
     builtins_catalog._ENSURED_EMBEDDING_PROJECTS.clear()
     monkeypatch.setattr(builtins_catalog, "ensure_builtins_project", lambda *_: None)
-    monkeypatch.setattr(builtins_catalog.unify, "create_context", lambda *_, **__: None)
+    monkeypatch.setattr(
+        builtins_catalog.unisdk,
+        "create_context",
+        lambda *_, **__: None,
+    )
     monkeypatch.setattr(builtins_catalog, "ensure_vector_column", lambda *_, **__: None)
     monkeypatch.setattr(
         builtins_catalog,
@@ -332,14 +344,14 @@ def test_seed_builtin_integrations_app_only_prune_preserves_tool_units(
         seen_filters.add(filter_expr)
         return [17]
 
-    monkeypatch.setattr(builtins_catalog.unify, "get_logs", fake_get_logs)
+    monkeypatch.setattr(builtins_catalog.unisdk, "get_logs", fake_get_logs)
     monkeypatch.setattr(
-        builtins_catalog.unify,
+        builtins_catalog.unisdk,
         "delete_logs",
         lambda **kwargs: deleted.append((kwargs["context"], list(kwargs["logs"]))),
     )
     monkeypatch.setattr(
-        builtins_catalog.unify,
+        builtins_catalog.unisdk,
         "create_logs",
         lambda **kwargs: inserted.append((kwargs["context"], list(kwargs["entries"]))),
     )
@@ -763,7 +775,11 @@ def test_seed_builtin_integrations_dedupes_and_deletes_tools_by_function_id(
     seen_filters: set[str] = set()
 
     monkeypatch.setattr(builtins_catalog, "ensure_builtins_project", lambda *_: None)
-    monkeypatch.setattr(builtins_catalog.unify, "create_context", lambda *_, **__: None)
+    monkeypatch.setattr(
+        builtins_catalog.unisdk,
+        "create_context",
+        lambda *_, **__: None,
+    )
     monkeypatch.setattr(builtins_catalog, "ensure_vector_column", lambda *_, **__: None)
     monkeypatch.setattr(
         builtins_catalog,
@@ -792,14 +808,14 @@ def test_seed_builtin_integrations_dedupes_and_deletes_tools_by_function_id(
         seen_filters.add(filter_expr)
         return [17]
 
-    monkeypatch.setattr(builtins_catalog.unify, "get_logs", fake_get_logs)
+    monkeypatch.setattr(builtins_catalog.unisdk, "get_logs", fake_get_logs)
     monkeypatch.setattr(
-        builtins_catalog.unify,
+        builtins_catalog.unisdk,
         "delete_logs",
         lambda **kwargs: deleted.append((kwargs["context"], list(kwargs["logs"]))),
     )
     monkeypatch.setattr(
-        builtins_catalog.unify,
+        builtins_catalog.unisdk,
         "create_logs",
         lambda **kwargs: inserted.append((kwargs["context"], list(kwargs["entries"]))),
     )

--- a/tests/integrations/test_integration_primitives.py
+++ b/tests/integrations/test_integration_primitives.py
@@ -125,7 +125,7 @@ def patch_ops_from_client(monkeypatch, client: FakeIntegrationClient) -> None:
 
 
 def stub_materialized_tool(monkeypatch, *, name: str, tool_id: str) -> None:
-    monkeypatch.setattr("unify.get_active_context", lambda: {"read": "user-1/42"})
+    monkeypatch.setattr("unisdk.get_active_context", lambda: {"read": "user-1/42"})
 
     def fake_get_logs(**kwargs):
         if kwargs.get("filter") == (
@@ -146,11 +146,11 @@ def stub_materialized_tool(monkeypatch, *, name: str, tool_id: str) -> None:
             ]
         return []
 
-    monkeypatch.setattr("unify.get_logs", fake_get_logs)
+    monkeypatch.setattr("unisdk.get_logs", fake_get_logs)
 
 
 def stub_materialized_app(monkeypatch, *, app_slug: str, names: list[str]) -> None:
-    monkeypatch.setattr("unify.get_active_context", lambda: {"read": "user-1/42"})
+    monkeypatch.setattr("unisdk.get_active_context", lambda: {"read": "user-1/42"})
 
     def fake_get_logs(**kwargs):
         if kwargs.get("filter") == (
@@ -176,11 +176,11 @@ def stub_materialized_app(monkeypatch, *, app_slug: str, names: list[str]) -> No
             ]
         return []
 
-    monkeypatch.setattr("unify.get_logs", fake_get_logs)
+    monkeypatch.setattr("unisdk.get_logs", fake_get_logs)
 
 
 def stub_native_app(monkeypatch, *, app_slug: str, function_names: list[str]) -> None:
-    monkeypatch.setattr("unify.get_active_context", lambda: {"read": "user-1/42"})
+    monkeypatch.setattr("unisdk.get_active_context", lambda: {"read": "user-1/42"})
 
     def fake_get_logs(**kwargs):
         filter_text = kwargs.get("filter")
@@ -215,7 +215,7 @@ def stub_native_app(monkeypatch, *, app_slug: str, function_names: list[str]) ->
                 ]
         return []
 
-    monkeypatch.setattr("unify.get_logs", fake_get_logs)
+    monkeypatch.setattr("unisdk.get_logs", fake_get_logs)
 
 
 def test_ops_functions_delegate_to_unify_integration_helpers(monkeypatch) -> None:
@@ -229,37 +229,37 @@ def test_ops_functions_delegate_to_unify_integration_helpers(monkeypatch) -> Non
         return _fake
 
     monkeypatch.setattr(
-        "unity.integrations.ops.unify.list_integration_connections",
+        "unity.integrations.ops.unisdk.list_integration_connections",
         helper("list_connections"),
         raising=False,
     )
     monkeypatch.setattr(
-        "unity.integrations.ops.unify.run_integration_tool",
+        "unity.integrations.ops.unisdk.run_integration_tool",
         helper("run_tool"),
         raising=False,
     )
     monkeypatch.setattr(
-        "unity.integrations.ops.unify.get_integration_tool_policy",
+        "unity.integrations.ops.unisdk.get_integration_tool_policy",
         helper("get_tool_policy"),
         raising=False,
     )
     monkeypatch.setattr(
-        "unity.integrations.ops.unify.patch_integration_tool_policy",
+        "unity.integrations.ops.unisdk.patch_integration_tool_policy",
         helper("patch_tool_policy"),
         raising=False,
     )
     monkeypatch.setattr(
-        "unity.integrations.ops.unify.approve_integration_tool_execution",
+        "unity.integrations.ops.unisdk.approve_integration_tool_execution",
         helper("approve_tool_execution"),
         raising=False,
     )
     monkeypatch.setattr(
-        "unity.integrations.ops.unify.deny_integration_tool_execution",
+        "unity.integrations.ops.unisdk.deny_integration_tool_execution",
         helper("deny_tool_execution"),
         raising=False,
     )
     monkeypatch.setattr(
-        "unity.integrations.ops.unify.test_integration_connection",
+        "unity.integrations.ops.unisdk.test_integration_connection",
         helper("test_connection"),
         raising=False,
     )
@@ -379,7 +379,7 @@ def test_ops_functions_re_raise_unify_keyerror_like_unify_logging(monkeypatch) -
         raise KeyError("UNIFY_KEY is missing. Please make sure it is set correctly!")
 
     monkeypatch.setattr(
-        "unity.integrations.ops.unify.list_integration_connections",
+        "unity.integrations.ops.unisdk.list_integration_connections",
         raise_missing_key,
         raising=False,
     )
@@ -1002,8 +1002,8 @@ async def test_namespace_execution_uses_function_manager_provider_row(
         "unity.manager_registry.ManagerRegistry.get_function_manager",
         lambda: FakeFunctionManager(),
     )
-    monkeypatch.setattr("unify.get_active_context", lambda: {})
-    monkeypatch.setattr("unify.get_logs", lambda **_kwargs: [])
+    monkeypatch.setattr("unisdk.get_active_context", lambda: {})
+    monkeypatch.setattr("unisdk.get_logs", lambda **_kwargs: [])
 
     primitives = IntegrationPrimitives(owner_scope={"assistant_id": 42})
     callable_tool = primitives.gmail.fetch_emails

--- a/tests/knowledge_manager/conftest.py
+++ b/tests/knowledge_manager/conftest.py
@@ -5,7 +5,7 @@ import pytest_asyncio
 from typing import List, Dict, Tuple, Any
 import os
 
-import unify
+import unisdk
 from unity.knowledge_manager.knowledge_manager import KnowledgeManager
 from unity.manager_registry import ManagerRegistry
 from unity.common.context_registry import ContextRegistry
@@ -111,7 +111,7 @@ class ScenarioBuilderKnowledge:
             (knowledge_data,) for knowledge_data in _KNOWLEDGE_DATA
         ]
 
-        results = unify.map(
+        results = unisdk.map(
             search_and_map_knowledge,
             knowledge_data_tuples,
             mode="asyncio",
@@ -171,8 +171,8 @@ async def knowledge_scenario(
     os.environ["TQDM_DISABLE"] = "1"
 
     ctx = "tests/knowledge/Scenario"
-    unify.set_context(ctx, relative=False)
-    existing_contexts = unify.get_contexts(prefix=ctx)
+    unisdk.set_context(ctx, relative=False)
+    existing_contexts = unisdk.get_contexts(prefix=ctx)
     overwrite_scenarios = request.config.getoption("--overwrite-scenarios")
 
     # If --overwrite-scenarios is set, delete and recreate scenarios
@@ -184,12 +184,12 @@ async def knowledge_scenario(
     if not reuse_scenario:
         # delete all contexts to freshly create the new scenario
         def recreate_contexts(ctx):
-            unify.delete_context(ctx)
-            unify.create_context(ctx)
+            unisdk.delete_context(ctx)
+            unisdk.create_context(ctx)
 
         existing_ctx_names = list(existing_contexts.keys())
         if existing_ctx_names:
-            unify.map(
+            unisdk.map(
                 recreate_contexts,
                 existing_ctx_names,
                 mode="asyncio",
@@ -198,9 +198,9 @@ async def knowledge_scenario(
     if reuse_scenario and not SCENARIO_COMMIT_HASHES:
 
         def get_context_commits_and_rollback(ctx):
-            history = unify.get_context_commits(ctx)
+            history = unisdk.get_context_commits(ctx)
             if history:
-                unify.rollback_context(
+                unisdk.rollback_context(
                     name=ctx,
                     commit_hash=history[0]["commit_hash"],
                 )
@@ -208,7 +208,7 @@ async def knowledge_scenario(
 
         existing_ctx_names = list(existing_contexts.keys())
         if existing_ctx_names:
-            unify.map(
+            unisdk.map(
                 get_context_commits_and_rollback,
                 existing_ctx_names,
                 mode="asyncio",
@@ -216,7 +216,7 @@ async def knowledge_scenario(
 
     # --- One-time setup (per session) ---
     builder = ScenarioBuilderKnowledge()
-    existing_contexts = unify.get_contexts(
+    existing_contexts = unisdk.get_contexts(
         prefix=ctx,
     )  # fetch newly created contexts by builder
 
@@ -225,7 +225,7 @@ async def knowledge_scenario(
         await builder.create()
 
         def commit_context_and_store(ctx):
-            commit_info = unify.commit_context(
+            commit_info = unisdk.commit_context(
                 name=ctx,
                 commit_message="Initial seed data for knowledge manager tests",
             )
@@ -233,13 +233,13 @@ async def knowledge_scenario(
 
         existing_ctx_names = list(existing_contexts.keys())
         if existing_ctx_names:
-            unify.map(
+            unisdk.map(
                 commit_context_and_store,
                 existing_ctx_names,
                 mode="asyncio",
             )
 
-    unify.unset_context()
+    unisdk.unset_context()
     return builder.km, _KNOWLEDGE_IDS
 
 
@@ -274,7 +274,7 @@ def knowledge_manager_scenario(knowledge_scenario):
     km, knowledge_map = knowledge_scenario
 
     def rollback_context(ctx):
-        unify.rollback_context(
+        unisdk.rollback_context(
             name=ctx,
             commit_hash=SCENARIO_COMMIT_HASHES[ctx],
         )
@@ -283,7 +283,7 @@ def knowledge_manager_scenario(knowledge_scenario):
         restore_scenario_context("tests/knowledge/Scenario")
         ctx_names = list(SCENARIO_COMMIT_HASHES.keys())
         if ctx_names:
-            unify.map(rollback_context, ctx_names, mode="asyncio")
+            unisdk.map(rollback_context, ctx_names, mode="asyncio")
 
         restore_scenario_context("tests/knowledge/Scenario")
         yield km, knowledge_map

--- a/tests/knowledge_manager/test_destination_routing.py
+++ b/tests/knowledge_manager/test_destination_routing.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import unify
+import unisdk
 
 from tests.destination_routing_helpers import (
     manager_routing_context as manager_routing_context,  # noqa: F401
@@ -43,8 +43,8 @@ def test_knowledge_writes_route_to_destination_and_reads_merge_roots(
         rows=[{"title": "Only personal root"}],
     )
 
-    personal_rows = unify.get_logs(context=f"{manager._ctx}/Runbooks")
-    shared_rows = unify.get_logs(context=f"Teams/{team_id}/Knowledge/Runbooks")
+    personal_rows = unisdk.get_logs(context=f"{manager._ctx}/Runbooks")
+    shared_rows = unisdk.get_logs(context=f"Teams/{team_id}/Knowledge/Runbooks")
 
     assert [row.entries["audience"] for row in personal_rows] == ["personal"]
     assert [row.entries["audience"] for row in shared_rows] == ["shared"]

--- a/tests/knowledge_manager/test_sys_msgs.py
+++ b/tests/knowledge_manager/test_sys_msgs.py
@@ -40,14 +40,14 @@ def _build_prompt_in_subprocess(
         f"""
         import os, sys
         sys.path.insert(0, os.getcwd())
-        import unify
+        import unisdk
         # Activate the test project before setting context
         project_name = os.environ.get("UNITY_TEST_PROJECT_NAME", "UnityTests")
-        unify.activate(project_name, overwrite=False)
+        unisdk.activate(project_name, overwrite=False)
         # Set test-specific context before creating KnowledgeManager to avoid races
         test_ctx = os.environ.get("_TEST_CONTEXT")
         if test_ctx:
-            unify.set_context(test_ctx, relative=False)
+            unisdk.set_context(test_ctx, relative=False)
         # Install the same static timestamp override used by pytest's autouse fixture,
         # but inside this fresh process so the time footer is deterministic.
         import unity.common.prompt_helpers as _ph

--- a/tests/knowledge_manager/test_tool_definitions.py
+++ b/tests/knowledge_manager/test_tool_definitions.py
@@ -44,14 +44,14 @@ def _build_tools_schema_in_subprocess(method: str, test_context: str) -> str:
         f"""
 		import os, sys, json
 		sys.path.insert(0, os.getcwd())
-		import unify
+		import unisdk
 		# Activate the test project before setting context
 		project_name = os.environ.get("UNITY_TEST_PROJECT_NAME", "UnityTests")
-		unify.activate(project_name, overwrite=False)
+		unisdk.activate(project_name, overwrite=False)
 		# Set test-specific context before creating KnowledgeManager to avoid races
 		test_ctx = os.environ.get("_TEST_CONTEXT")
 		if test_ctx:
-			unify.set_context(test_ctx, relative=False)
+			unisdk.set_context(test_ctx, relative=False)
 		from unity.common.llm_helpers import method_to_schema
 		def _unwrap_callable(tool):
 			return getattr(tool, "fn", tool)

--- a/tests/local_storage/test_context_store.py
+++ b/tests/local_storage/test_context_store.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 import pytest
 import requests
 
-import unify
-from unify.utils.http import RequestError
+from unisdk.utils.http import RequestError
 from unity.common.context_store import TableStore, _create_context_with_retry
 
 

--- a/tests/local_storage/test_context_store.py
+++ b/tests/local_storage/test_context_store.py
@@ -17,13 +17,13 @@ def _reset_ensured_cache():
 
 def test_ensure_creates_and_idempotent(monkeypatch):
     # Arrange: stable project and call counters
-    monkeypatch.setattr(unify, "active_project", lambda: "proj-ctx")
+    monkeypatch.setattr(unisdk, "active_project", lambda: "proj-ctx")
 
     # Simulate 404 so ensure_context proceeds to creation
     def _fail_get(*args, **kwargs):
         raise Exception("Context not found")
 
-    monkeypatch.setattr(unify, "get_context", _fail_get)
+    monkeypatch.setattr(unisdk, "get_context", _fail_get)
 
     calls = {"create_context": 0, "create_fields": 0}
 
@@ -48,8 +48,8 @@ def test_ensure_creates_and_idempotent(monkeypatch):
         assert context == "Test/Contacts"
         assert fields == {"first_name": {"type": "str"}, "surname": {"type": "str"}}
 
-    monkeypatch.setattr(unify, "create_context", _create_context)
-    monkeypatch.setattr(unify, "create_fields", _create_fields)
+    monkeypatch.setattr(unisdk, "create_context", _create_context)
+    monkeypatch.setattr(unisdk, "create_fields", _create_fields)
 
     store = TableStore(
         "Test/Contacts",
@@ -72,7 +72,7 @@ def test_ensure_creates_and_idempotent(monkeypatch):
 
 def test_get_columns_transforms(monkeypatch):
     # Arrange stable project and capture parameters
-    monkeypatch.setattr(unify, "active_project", lambda: "proj-Z")
+    monkeypatch.setattr(unisdk, "active_project", lambda: "proj-Z")
     seen = {"project_name": None, "context": None}
 
     def _get_fields(*, project, context):
@@ -86,7 +86,7 @@ def test_get_columns_transforms(monkeypatch):
             },  # still returned by backend – consumer filters
         }
 
-    monkeypatch.setattr(unify, "get_fields", _get_fields)
+    monkeypatch.setattr(unisdk, "get_fields", _get_fields)
 
     store = TableStore("Org/Contacts")
     cols = store.get_columns()
@@ -102,7 +102,7 @@ def test_ensure_context_treats_400_context_already_exists_as_success(monkeypatch
     response._content = b"A context with this name already exists in the project."
 
     monkeypatch.setattr(
-        unify,
+        unisdk,
         "create_context",
         lambda *_, **__: (_ for _ in ()).throw(
             RequestError("https://api.unify.ai", "POST", response),

--- a/tests/local_storage/test_data_store.py
+++ b/tests/local_storage/test_data_store.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import pytest
 
-import unify
 from unity.common.data_store import DataStore
 
 

--- a/tests/local_storage/test_data_store.py
+++ b/tests/local_storage/test_data_store.py
@@ -8,14 +8,14 @@ from unity.common.data_store import DataStore
 @pytest.fixture(autouse=True)
 def _stable_project_and_clean_registry(monkeypatch):
     # Ensure a stable project id per test and clear singleton registry
-    monkeypatch.setattr(unify, "active_project", lambda: "proj-test")
+    monkeypatch.setattr(unisdk, "active_project", lambda: "proj-test")
     DataStore._REGISTRY.clear()
     yield
     DataStore._REGISTRY.clear()
 
 
 def test_singleton_per_project_context(monkeypatch):
-    monkeypatch.setattr(unify, "active_project", lambda: "P1")
+    monkeypatch.setattr(unisdk, "active_project", lambda: "P1")
 
     a = DataStore.for_context("Ctx/A", key_fields=("id",))
     b = DataStore.for_context("Ctx/A", key_fields=("id",))

--- a/tests/local_storage/test_metrics.py
+++ b/tests/local_storage/test_metrics.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import uuid
-import unify
+import unisdk
 
 
 def test_count_matches_rows_and_resets():
@@ -24,13 +24,13 @@ def test_count_matches_rows_and_resets():
 
     def _create_ctx():
         # Ensure a context with auto-counting on 'row_id'
-        unify.create_context(
+        unisdk.create_context(
             ctx,
             unique_keys={"row_id": "int"},
             auto_counting={"row_id": None},
             description="Metrics test context",
         )
-        unify.create_fields(
+        unisdk.create_fields(
             {
                 "row_id": {"type": "int"},
                 "name": {"type": "str"},
@@ -46,7 +46,7 @@ def test_count_matches_rows_and_resets():
         _create_ctx()
 
         # Initial metric should be zero in a fresh context
-        initial_metric = unify.get_logs_metric(
+        initial_metric = unisdk.get_logs_metric(
             metric="count",
             key="row_id",
             context=ctx,
@@ -56,13 +56,13 @@ def test_count_matches_rows_and_resets():
         ), f"Expected initial metric 0 for fresh context, got {initial_metric} (context={ctx})"
 
         # Insert three rows; 'id' is auto-incremented by the backend
-        unify.log(context=ctx, new=True, name="A")
-        unify.log(context=ctx, new=True, name="B")
-        unify.log(context=ctx, new=True, name="C")
+        unisdk.log(context=ctx, new=True, name="A")
+        unisdk.log(context=ctx, new=True, name="B")
+        unisdk.log(context=ctx, new=True, name="C")
 
-        rows = unify.get_logs(context=ctx, return_ids_only=False)
+        rows = unisdk.get_logs(context=ctx, return_ids_only=False)
         row_count = len(rows)
-        metric_after = unify.get_logs_metric(metric="count", key="row_id", context=ctx)
+        metric_after = unisdk.get_logs_metric(metric="count", key="row_id", context=ctx)
 
         assert row_count == 3, f"Expected 3 rows, got {row_count} (context={ctx})"
         assert (
@@ -70,15 +70,15 @@ def test_count_matches_rows_and_resets():
         ), f"Metric/row mismatch in context={ctx}: metric={_as_int0(metric_after)}, rows={row_count}"
 
         # Delete context and recreate; metric must reset to 0
-        unify.delete_context(ctx)
+        unisdk.delete_context(ctx)
         _create_ctx()
-        metric_reset = unify.get_logs_metric(metric="count", key="row_id", context=ctx)
+        metric_reset = unisdk.get_logs_metric(metric="count", key="row_id", context=ctx)
         assert (
             _as_int0(metric_reset) == 0
         ), f"Expected metric to reset to 0 after context deletion, got {_as_int0(metric_reset)} (context={ctx})"
 
     finally:
-        unify.delete_context(ctx)
+        unisdk.delete_context(ctx)
 
 
 def test_max_matches_row_ids_and_resets():
@@ -99,13 +99,13 @@ def test_max_matches_row_ids_and_resets():
         return 0 if v is None else int(v)
 
     def _create_ctx():
-        unify.create_context(
+        unisdk.create_context(
             ctx,
             unique_keys={"row_id": "int"},
             auto_counting={"row_id": None},
             description="Metrics test context (max)",
         )
-        unify.create_fields(
+        unisdk.create_fields(
             {
                 "row_id": {"type": "int"},
                 "name": {"type": "str"},
@@ -116,17 +116,17 @@ def test_max_matches_row_ids_and_resets():
     try:
         _create_ctx()
 
-        initial_max = unify.get_logs_metric(metric="max", key="row_id", context=ctx)
+        initial_max = unisdk.get_logs_metric(metric="max", key="row_id", context=ctx)
         assert (
             _as_int0(initial_max) == 0
         ), f"Expected initial max 0 for fresh context, got {initial_max} (context={ctx})"
 
         # Insert three rows; backend assigns row_id automatically
-        unify.log(context=ctx, new=True, name="A")
-        unify.log(context=ctx, new=True, name="B")
-        unify.log(context=ctx, new=True, name="C")
+        unisdk.log(context=ctx, new=True, name="A")
+        unisdk.log(context=ctx, new=True, name="B")
+        unisdk.log(context=ctx, new=True, name="C")
 
-        logs = unify.get_logs(context=ctx, return_ids_only=False)
+        logs = unisdk.get_logs(context=ctx, return_ids_only=False)
         # Extract row_id values from returned logs
         row_ids = []
         for lg in logs:
@@ -143,7 +143,7 @@ def test_max_matches_row_ids_and_resets():
         ), f"Expected 3 row_id values after inserts, got {len(row_ids)} (context={ctx})"
 
         computed_max = max(row_ids) if row_ids else 0
-        metric_max_after = unify.get_logs_metric(
+        metric_max_after = unisdk.get_logs_metric(
             metric="max",
             key="row_id",
             context=ctx,
@@ -153,9 +153,9 @@ def test_max_matches_row_ids_and_resets():
         ), f"Metric max mismatch in context={ctx}: metric={_as_int0(metric_max_after)}, rows_max={computed_max}, rows={sorted(row_ids)}"
 
         # Delete context and recreate; metric must reset to 0
-        unify.delete_context(ctx)
+        unisdk.delete_context(ctx)
         _create_ctx()
-        metric_max_reset = unify.get_logs_metric(
+        metric_max_reset = unisdk.get_logs_metric(
             metric="max",
             key="row_id",
             context=ctx,
@@ -165,4 +165,4 @@ def test_max_matches_row_ids_and_resets():
         ), f"Expected max metric to reset to 0 after context deletion, got {_as_int0(metric_max_reset)} (context={ctx})"
 
     finally:
-        unify.delete_context(ctx)
+        unisdk.delete_context(ctx)

--- a/tests/parallel_run.sh
+++ b/tests/parallel_run.sh
@@ -543,15 +543,15 @@ is_random_projects_mode() {
 # ---------------------------------------------------------------------------
 delete_shared_project() {
   local phase="$1"  # "start" or "exit"
-  echo "Deleting project '${UNIFY_PROJECT:-UnityTests}'..."
+  echo "Deleting project '${UNISDK_PROJECT:-UnityTests}'..."
   "$VENV_PY" - << 'PYEOF'
 import os
 import sys
 try:
-    import unify
-    project_name = os.environ.get("UNIFY_PROJECT", "UnityTests")
+    import unisdk
+    project_name = os.environ.get("UNISDK_PROJECT", "UnityTests")
     try:
-        unify.delete_project(project_name, missing_ok=False)
+        unisdk.delete_project(project_name, missing_ok=False)
         print(f"Deleted project '{project_name}'")
     except Exception:
         print(f"Project '{project_name}' did not exist, skipping deletion")
@@ -601,8 +601,8 @@ build_env_exports() {
   if ! is_var_in_env_overrides "UNITY_OTEL"; then
     exports="$exports UNITY_OTEL=true"
   fi
-  if ! is_var_in_env_overrides "UNIFY_OTEL"; then
-    exports="$exports UNIFY_OTEL=true"
+  if ! is_var_in_env_overrides "UNISDK_OTEL"; then
+    exports="$exports UNISDK_OTEL=true"
   fi
   if ! is_var_in_env_overrides "UNILLM_OTEL"; then
     exports="$exports UNILLM_OTEL=true"
@@ -613,8 +613,8 @@ build_env_exports() {
   if ! is_var_in_env_overrides "UNITY_OTEL_LOG_DIR"; then
     exports="$exports UNITY_OTEL_LOG_DIR=$otel_log_dir"
   fi
-  if ! is_var_in_env_overrides "UNIFY_OTEL_LOG_DIR"; then
-    exports="$exports UNIFY_OTEL_LOG_DIR=$otel_log_dir"
+  if ! is_var_in_env_overrides "UNISDK_OTEL_LOG_DIR"; then
+    exports="$exports UNISDK_OTEL_LOG_DIR=$otel_log_dir"
   fi
   if ! is_var_in_env_overrides "UNILLM_OTEL_LOG_DIR"; then
     exports="$exports UNILLM_OTEL_LOG_DIR=$otel_log_dir"
@@ -800,7 +800,7 @@ else
   if is_env_truthy "UNIFY_TESTS_DELETE_PROJ_ON_START"; then
     delete_shared_project "start"
   fi
-  echo "Preparing shared project '${UNIFY_PROJECT:-UnityTests}'..."
+  echo "Preparing shared project '${UNISDK_PROJECT:-UnityTests}'..."
   if [[ -f "$SCRIPT_DIR/_prepare_shared_project.py" ]]; then
     "$VENV_PY" "$SCRIPT_DIR/_prepare_shared_project.py"
   else

--- a/tests/secret_manager/conftest.py
+++ b/tests/secret_manager/conftest.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import uuid
 
 import pytest
-import unify
+import unisdk
 
 from unity.common.context_registry import ContextRegistry
 from unity.session_details import SESSION_DETAILS
@@ -17,12 +17,12 @@ def secret_manager_context(request):
     SESSION_DETAILS.reset()
     # Create a fresh, test-specific context and make it active
     try:
-        unify.set_context(ctx, relative=False)
+        unisdk.set_context(ctx, relative=False)
     except Exception:
         pass
     yield ctx
-    unify.delete_context(ctx)
-    unify.unset_context()
+    unisdk.delete_context(ctx)
+    unisdk.unset_context()
     ContextRegistry.clear()
     SESSION_DETAILS.reset()
 
@@ -48,7 +48,7 @@ def secret_manager_teams():
     yield team_ids
     for team_id in team_ids:
         try:
-            unify.delete_context(f"Teams/{team_id}/Secrets")
+            unisdk.delete_context(f"Teams/{team_id}/Secrets")
         except Exception:
             pass
     SESSION_DETAILS.team_ids = []

--- a/tests/secret_manager/test_ask_update.py
+++ b/tests/secret_manager/test_ask_update.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import pytest
-import unify
+import unisdk
 
 pytestmark = [pytest.mark.eval, pytest.mark.llm_call]
 
@@ -95,11 +95,11 @@ async def test_update_routes_team_credential_to_shared_team(
     )
     await handle.result()
 
-    personal_matches = unify.get_logs(
+    personal_matches = unisdk.get_logs(
         context=manager._ctx,
         filter="name == 'patch_ops_slack_bot'",
     )
-    shared_matches = unify.get_logs(
+    shared_matches = unisdk.get_logs(
         context=f"Teams/{patch_team_id}/Secrets",
         filter="name == 'patch_ops_slack_bot'",
     )

--- a/tests/secret_manager/test_basic.py
+++ b/tests/secret_manager/test_basic.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import pytest
-import unify
+import unisdk
 
 from unity.secret_manager.secret_manager import SecretManager
 
@@ -97,7 +97,7 @@ def test_filter_and_search_tolerate_null_description(secret_manager_context):
     # Insert a row with description=None directly, bypassing _create_secret
     # which coerces None→"". This reproduces how secrets appear when created
     # through Orchestra/Console without providing a description.
-    unify.log(
+    unisdk.log(
         context=sm._ctx,
         secret_id=0,
         name="SF_USER",
@@ -106,7 +106,7 @@ def test_filter_and_search_tolerate_null_description(secret_manager_context):
         new=True,
         mutable=True,
     )
-    unify.log(
+    unisdk.log(
         context=sm._ctx,
         secret_id=1,
         name="SF_PASS",

--- a/tests/secret_manager/test_destination_routing.py
+++ b/tests/secret_manager/test_destination_routing.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import pytest
-import unify
+import unisdk
 
 from unity.common.tool_outcome import ToolError
 from unity.function_manager.function_manager import VenvPool
@@ -9,7 +9,7 @@ from unity.secret_manager.secret_manager import SecretManager
 
 
 def _rows(context: str) -> list[dict]:
-    return [log.entries for log in unify.get_logs(context=context)]
+    return [log.entries for log in unisdk.get_logs(context=context)]
 
 
 def test_secret_writes_route_to_destination_and_reads_merge_roots(

--- a/tests/secret_manager/test_dotenv.py
+++ b/tests/secret_manager/test_dotenv.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import tempfile
 import pathlib
 
-import unify
+import unisdk
 
 from unity.settings import SETTINGS
 from unity.secret_manager.secret_manager import SecretManager
@@ -109,7 +109,7 @@ def test_externally_added_secret_synced_on_ask(monkeypatch, secret_manager_conte
         # Simulate an external write — the Console UI writes directly to
         # Orchestra, bypassing SecretManager entirely.  This is the gap:
         # .env has no idea this secret exists.
-        unify.log(
+        unisdk.log(
             context=sm._ctx,
             name="external_key",
             value="val-external",

--- a/tests/secret_manager/test_sys_msgs.py
+++ b/tests/secret_manager/test_sys_msgs.py
@@ -55,14 +55,14 @@ def _build_prompt_in_subprocess(method: str, test_context: str) -> str:
             f"""
             import os, sys
             sys.path.insert(0, os.getcwd())
-            import unify
+            import unisdk
             # Activate the test project before setting context
             project_name = os.environ.get("UNITY_TEST_PROJECT_NAME", "UnityTests")
-            unify.activate(project_name, overwrite=False)
+            unisdk.activate(project_name, overwrite=False)
             # Set test-specific context before creating SecretManager to avoid races
             test_ctx = os.environ.get("_TEST_CONTEXT")
             if test_ctx:
-                unify.set_context(test_ctx, relative=False)
+                unisdk.set_context(test_ctx, relative=False)
             # Install the same static timestamp override used by pytest's autouse fixture,
             # but inside this fresh process so the time footer is deterministic.
             import unity.common.prompt_helpers as _ph

--- a/tests/secret_manager/test_tool_docstrings.py
+++ b/tests/secret_manager/test_tool_docstrings.py
@@ -61,14 +61,14 @@ def _build_tools_schema_in_subprocess(method: str, test_context: str) -> str:
             f"""
             import os, sys, json
             sys.path.insert(0, os.getcwd())
-            import unify
+            import unisdk
             # Activate the test project before setting context
             project_name = os.environ.get("UNITY_TEST_PROJECT_NAME", "UnityTests")
-            unify.activate(project_name, overwrite=False)
+            unisdk.activate(project_name, overwrite=False)
             # Set test-specific context before creating SecretManager to avoid races
             test_ctx = os.environ.get("_TEST_CONTEXT")
             if test_ctx:
-                unify.set_context(test_ctx, relative=False)
+                unisdk.set_context(test_ctx, relative=False)
             from unity.common.llm_helpers import method_to_schema
             def _unwrap_callable(tool):
                 return getattr(tool, "fn", tool)

--- a/tests/task_scheduler/conftest.py
+++ b/tests/task_scheduler/conftest.py
@@ -8,7 +8,7 @@ from typing import Dict, Any, List, Tuple
 
 import pytest
 import pytest_asyncio
-import unify
+import unisdk
 
 from unity.task_scheduler.task_scheduler import TaskScheduler
 from unity.manager_registry import ManagerRegistry
@@ -69,9 +69,9 @@ def _rebuild_commit_hashes(
     commit_hashes: Dict[str, Any],
 ) -> None:
     """Rebuild commit hashes from existing context commits."""
-    existing_contexts = unify.get_contexts(prefix=ctx_prefix)
+    existing_contexts = unisdk.get_contexts(prefix=ctx_prefix)
     for ctx_name in existing_contexts.keys():
-        history = unify.get_context_commits(ctx_name)
+        history = unisdk.get_context_commits(ctx_name)
         if history:
             commit_hashes[ctx_name] = history[0]["commit_hash"]
 
@@ -81,9 +81,9 @@ def _commit_contexts_for_rollback(
     commit_hashes: Dict[str, Any],
 ) -> None:
     """Commit all contexts under prefix and store hashes for rollback."""
-    existing_contexts = unify.get_contexts(prefix=ctx_prefix)
+    existing_contexts = unisdk.get_contexts(prefix=ctx_prefix)
     for ctx_name in existing_contexts.keys():
-        commit_info = unify.commit_context(
+        commit_info = unisdk.commit_context(
             name=ctx_name,
             commit_message="Initial seed data for task scheduler tests",
         )
@@ -110,13 +110,13 @@ def _setup_scenario(
 
     # If --overwrite-scenarios is set, delete existing contexts first
     if overwrite_scenarios:
-        existing_contexts = unify.get_contexts(prefix=ctx)
+        existing_contexts = unisdk.get_contexts(prefix=ctx)
         for ctx_name in existing_contexts.keys():
-            unify.delete_context(ctx_name)
+            unisdk.delete_context(ctx_name)
 
     # Set context before any operations
-    unify.create_context(ctx)  # exist_ok=True by default
-    unify.set_context(ctx, relative=False)
+    unisdk.create_context(ctx)  # exist_ok=True by default
+    unisdk.set_context(ctx, relative=False)
 
     # Create scheduler
     ts = TaskScheduler()
@@ -135,7 +135,7 @@ def _setup_scenario(
             task_ids = _seed_tasks(ts)
             _commit_contexts_for_rollback(ctx, commit_hashes)
 
-    unify.unset_context()
+    unisdk.unset_context()
     return ts, task_ids
 
 
@@ -175,7 +175,7 @@ def task_scheduler_read_scenario(task_read_scenario):
     ts, task_ids = task_read_scenario
 
     def rollback_context(ctx):
-        unify.rollback_context(
+        unisdk.rollback_context(
             name=ctx,
             commit_hash=_READ_SCENARIO_COMMIT_HASHES[ctx],
         )
@@ -184,7 +184,7 @@ def task_scheduler_read_scenario(task_read_scenario):
     restore_scenario_context("tests/task_scheduler/ReadScenario")
     ctx_names = list(_READ_SCENARIO_COMMIT_HASHES.keys())
     if ctx_names:
-        unify.map(rollback_context, ctx_names, mode="asyncio")
+        unisdk.map(rollback_context, ctx_names, mode="asyncio")
 
     restore_scenario_context("tests/task_scheduler/ReadScenario")
     yield ts, task_ids
@@ -230,7 +230,7 @@ def task_scheduler_mutation_scenario(task_mutation_scenario):
     ts, task_ids = task_mutation_scenario
 
     def rollback_context(ctx):
-        unify.rollback_context(
+        unisdk.rollback_context(
             name=ctx,
             commit_hash=_MUTATION_SCENARIO_COMMIT_HASHES[ctx],
         )
@@ -241,7 +241,7 @@ def task_scheduler_mutation_scenario(task_mutation_scenario):
         # from rolling back while this test is running
         ctx_names = list(_MUTATION_SCENARIO_COMMIT_HASHES.keys())
         if ctx_names:
-            unify.map(rollback_context, ctx_names, mode="asyncio")
+            unisdk.map(rollback_context, ctx_names, mode="asyncio")
 
         restore_scenario_context("tests/task_scheduler/MutationScenario")
         yield ts, task_ids

--- a/tests/task_scheduler/test_creation_deletion.py
+++ b/tests/task_scheduler/test_creation_deletion.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta, timezone
 
 from tests.helpers import _handle_project
 import pytest
-import unify
+import unisdk
 
 from unity.common.context_registry import ContextRegistry
 from unity.common.tool_outcome import ToolErrorException
@@ -101,7 +101,7 @@ def test_create_team_task_routes_to_shared_root():
         assert rows[0].assistant_id == SESSION_DETAILS.assistant_context
     finally:
         try:
-            unify.delete_context("Teams/987654/Tasks")
+            unisdk.delete_context("Teams/987654/Tasks")
         except Exception:
             pass
         SESSION_DETAILS.team_ids = []
@@ -155,7 +155,7 @@ def test_clone_recurring_task_instance_uses_space_destination_root():
         assert all(row.destination == f"team:{team_id}" for row in rows)
     finally:
         try:
-            unify.delete_context(f"Teams/{team_id}/Tasks")
+            unisdk.delete_context(f"Teams/{team_id}/Tasks")
         except Exception:
             pass
         SESSION_DETAILS.team_ids = []
@@ -189,7 +189,7 @@ def test_duplicate_task_id_update_requires_destination():
         assert by_destination["team:987657"] == "Shared duplicate updated"
     finally:
         try:
-            unify.delete_context("Teams/987657/Tasks")
+            unisdk.delete_context("Teams/987657/Tasks")
         except Exception:
             pass
         SESSION_DETAILS.team_ids = []

--- a/tests/task_scheduler/test_foreign_keys.py
+++ b/tests/task_scheduler/test_foreign_keys.py
@@ -15,7 +15,7 @@ Coverage
 
 from __future__ import annotations
 
-import unify
+import unisdk
 from tests.helpers import _handle_project
 from unity.function_manager.function_manager import FunctionManager
 from unity.task_scheduler.task_scheduler import TaskScheduler
@@ -36,7 +36,7 @@ def test_entrypoint_valid_reference():
     fm.add_functions(implementations=src)
 
     # Get function ID
-    funcs = unify.get_logs(
+    funcs = unisdk.get_logs(
         context=fm._compositional_ctx,
         from_fields=["function_id", "name"],
     )
@@ -51,7 +51,7 @@ def test_entrypoint_valid_reference():
     )
 
     # Verify task was created with entrypoint
-    tasks = unify.get_logs(
+    tasks = unisdk.get_logs(
         context=ts._ctx,
         from_fields=["task_id", "name", "entrypoint"],
     )
@@ -70,7 +70,7 @@ def test_entrypoint_set_null_on_delete():
     fm.add_functions(implementations=src)
 
     # Get function ID
-    funcs = unify.get_logs(context=fm._compositional_ctx, from_fields=["function_id"])
+    funcs = unisdk.get_logs(context=fm._compositional_ctx, from_fields=["function_id"])
     func_id = int(funcs[0].entries["function_id"])
 
     # Create task with this function as entrypoint
@@ -81,7 +81,7 @@ def test_entrypoint_set_null_on_delete():
     )
 
     # Verify task has entrypoint
-    tasks = unify.get_logs(context=ts._ctx, from_fields=["task_id", "entrypoint"])
+    tasks = unisdk.get_logs(context=ts._ctx, from_fields=["task_id", "entrypoint"])
     assert len(tasks) == 1
     assert tasks[0].entries["entrypoint"] == func_id
 
@@ -89,7 +89,7 @@ def test_entrypoint_set_null_on_delete():
     fm.delete_function(function_id=func_id)
 
     # Verify task still exists but entrypoint is null (SET NULL behavior)
-    tasks_after = unify.get_logs(
+    tasks_after = unisdk.get_logs(
         context=ts._ctx,
         from_fields=["task_id", "name", "entrypoint"],
     )
@@ -109,7 +109,7 @@ def test_entrypoint_null_does_not_break_scheduler_init():
     fm.add_functions(implementations=src)
 
     # Get function ID
-    funcs = unify.get_logs(context=fm._compositional_ctx, from_fields=["function_id"])
+    funcs = unisdk.get_logs(context=fm._compositional_ctx, from_fields=["function_id"])
     func_id = int(funcs[0].entries["function_id"])
 
     # Create task with entrypoint
@@ -121,7 +121,7 @@ def test_entrypoint_null_does_not_break_scheduler_init():
     tid = result["details"]["task_id"]
 
     # Verify task has entrypoint
-    tasks = unify.get_logs(context=ts._ctx, from_fields=["task_id", "entrypoint"])
+    tasks = unisdk.get_logs(context=ts._ctx, from_fields=["task_id", "entrypoint"])
     assert len(tasks) == 1
     assert tasks[0].entries["entrypoint"] == func_id
 
@@ -129,7 +129,10 @@ def test_entrypoint_null_does_not_break_scheduler_init():
     fm.delete_function(function_id=func_id)
 
     # Verify entrypoint is now null
-    tasks_after = unify.get_logs(context=ts._ctx, from_fields=["task_id", "entrypoint"])
+    tasks_after = unisdk.get_logs(
+        context=ts._ctx,
+        from_fields=["task_id", "entrypoint"],
+    )
     assert len(tasks_after) == 1
     assert tasks_after[0].entries.get("entrypoint") is None
 
@@ -137,7 +140,7 @@ def test_entrypoint_null_does_not_break_scheduler_init():
     ts_new = TaskScheduler()
 
     # Verify the new scheduler can read tasks with null entrypoint without errors
-    tasks_from_new = unify.get_logs(
+    tasks_from_new = unisdk.get_logs(
         context=ts_new._ctx,
     )
     assert len(tasks_from_new) == 1
@@ -167,7 +170,7 @@ def test_entrypoint_explicit_none_on_create():
     tid = result["details"]["task_id"]
 
     # Verify task was created with null entrypoint
-    tasks = unify.get_logs(
+    tasks = unisdk.get_logs(
         context=ts._ctx,
     )
     assert len(tasks) == 1
@@ -191,7 +194,7 @@ def test_entrypoint_clone_after_set_null():
     # Create function
     src = "def cloneable():\n    return 'clone me'\n"
     fm.add_functions(implementations=src)
-    funcs = unify.get_logs(context=fm._compositional_ctx, from_fields=["function_id"])
+    funcs = unisdk.get_logs(context=fm._compositional_ctx, from_fields=["function_id"])
     func_id = int(funcs[0].entries["function_id"])
 
     # Create recurring task with entrypoint
@@ -207,7 +210,7 @@ def test_entrypoint_clone_after_set_null():
     tid = result["details"]["task_id"]
 
     # Verify task has entrypoint
-    tasks = unify.get_logs(
+    tasks = unisdk.get_logs(
         context=ts._ctx,
         filter=f"task_id == {tid}",
         from_fields=["task_id", "entrypoint", "instance_id"],
@@ -220,7 +223,7 @@ def test_entrypoint_clone_after_set_null():
     fm.delete_function(function_id=func_id)
 
     # Verify entrypoint is now null (include task_id to avoid NULL-only field issue)
-    tasks_after_delete = unify.get_logs(
+    tasks_after_delete = unisdk.get_logs(
         context=ts._ctx,
         filter=f"task_id == {tid}",
         from_fields=["task_id", "entrypoint"],
@@ -231,7 +234,7 @@ def test_entrypoint_clone_after_set_null():
     # Trigger cloning by fetching the task and calling _clone_task_instance
     from unity.task_scheduler.types.task import Task
 
-    task_entries = unify.get_logs(
+    task_entries = unisdk.get_logs(
         context=ts._ctx,
         filter=f"task_id == {tid}",
     )[0].entries
@@ -241,7 +244,7 @@ def test_entrypoint_clone_after_set_null():
     ts._clone_task_instance(task_obj)
 
     # Verify clone was created with null entrypoint
-    all_instances = unify.get_logs(
+    all_instances = unisdk.get_logs(
         context=ts._ctx,
         filter=f"task_id == {tid}",
         from_fields=["task_id", "instance_id", "entrypoint"],

--- a/tests/task_scheduler/test_local_scheduler_integration.py
+++ b/tests/task_scheduler/test_local_scheduler_integration.py
@@ -25,7 +25,7 @@ import asyncio
 from datetime import datetime, timedelta, timezone
 
 import pytest
-import unify
+import unisdk
 
 from tests.helpers import _handle_project
 from unity.session_details import SESSION_DETAILS
@@ -46,7 +46,7 @@ def _local_orchestra_authenticated() -> bool:
     """
 
     try:
-        unify.get_projects()
+        unisdk.get_projects()
         return True
     except Exception:
         return False

--- a/tests/task_scheduler/test_machine_state.py
+++ b/tests/task_scheduler/test_machine_state.py
@@ -141,7 +141,7 @@ def test_get_task_activation_queries_for_null_personal_destination(monkeypatch):
         captured.update(kwargs)
         return []
 
-    monkeypatch.setattr("unity.task_scheduler.storage.unify.get_logs", _fake_get_logs)
+    monkeypatch.setattr("unity.task_scheduler.storage.unisdk.get_logs", _fake_get_logs)
     monkeypatch.setattr(machine_state.SESSION_DETAILS.user, "id", "user-1")
     monkeypatch.setattr(machine_state.SESSION_DETAILS.assistant, "agent_id", 2069)
 
@@ -188,7 +188,7 @@ def test_get_task_activation_queries_assistants_machine_state_project(monkeypatc
         captured.update(kwargs)
         return [_FakeRow()]
 
-    monkeypatch.setattr("unity.task_scheduler.storage.unify.get_logs", _fake_get_logs)
+    monkeypatch.setattr("unity.task_scheduler.storage.unisdk.get_logs", _fake_get_logs)
     monkeypatch.setattr(machine_state.SESSION_DETAILS.user, "id", "user-1")
     monkeypatch.setattr(machine_state.SESSION_DETAILS.assistant, "agent_id", 42)
 

--- a/tests/task_scheduler/test_search.py
+++ b/tests/task_scheduler/test_search.py
@@ -1,5 +1,5 @@
 import pytest
-import unify
+import unisdk
 
 from unity.task_scheduler.task_scheduler import TaskScheduler
 from tests.helpers import _handle_project
@@ -34,7 +34,7 @@ def test_search_tasks_single_reference_basic():
     assert results[0].name == "Send quick status text"
 
     # Ensure vector column was created for the referenced source
-    cols = unify.get_fields(context=ts._ctx)
+    cols = unisdk.get_fields(context=ts._ctx)
     assert "_description_emb" in cols
 
 
@@ -67,7 +67,7 @@ def test_search_tasks_multi_columns_json_and_vec_created():
     assert results[0].name == "Set up quick texting"
 
     # Ensure vector columns were created for each referenced source
-    cols = unify.get_fields(context=ts._ctx)
+    cols = unisdk.get_fields(context=ts._ctx)
     assert "_description_emb" in cols
     assert "_name_emb" in cols
 
@@ -100,7 +100,7 @@ def test_search_tasks_all_columns_default_derivation():
     assert results[0].name == "Configure email notifications"
 
     # Ensure a derived embedding column exists for the composite expression
-    cols = unify.get_fields(context=ts._ctx)
+    cols = unisdk.get_fields(context=ts._ctx)
     assert any(k.startswith("_expr_") and k.endswith("_emb") for k in cols.keys())
 
 
@@ -147,7 +147,7 @@ def test_search_tasks_mean_of_cosine_ranking():
     )
 
     # Ensure columns and vectors were created
-    cols = unify.get_fields(context=ts._ctx)
+    cols = unisdk.get_fields(context=ts._ctx)
     assert "response_policy" in cols
     assert "_response_policy_emb" in cols
     assert "_description_emb" in cols

--- a/tests/task_scheduler/test_storage_project.py
+++ b/tests/task_scheduler/test_storage_project.py
@@ -11,7 +11,7 @@ def test_tasks_store_get_rows_passes_explicit_project_override(monkeypatch):
         captured.update(kwargs)
         return []
 
-    monkeypatch.setattr("unity.task_scheduler.storage.unify.get_logs", _fake_get_logs)
+    monkeypatch.setattr("unity.task_scheduler.storage.unisdk.get_logs", _fake_get_logs)
 
     store = TasksStore("Tasks/Activations", project=TASK_MACHINE_STATE_PROJECT)
     rows = store.get_rows(limit=5)
@@ -28,9 +28,9 @@ def test_tasks_store_defaults_to_active_project(monkeypatch):
         captured.update(kwargs)
         return []
 
-    monkeypatch.setattr("unity.task_scheduler.storage.unify.get_logs", _fake_get_logs)
+    monkeypatch.setattr("unity.task_scheduler.storage.unisdk.get_logs", _fake_get_logs)
     monkeypatch.setattr(
-        "unity.task_scheduler.storage.unify.active_project",
+        "unity.task_scheduler.storage.unisdk.active_project",
         lambda: "Assistants",
     )
 

--- a/tests/task_scheduler/test_sys_msgs.py
+++ b/tests/task_scheduler/test_sys_msgs.py
@@ -147,14 +147,14 @@ def _build_prompt_in_subprocess(method: str, test_context: str) -> str:
         f"""
         import os, sys
         sys.path.insert(0, os.getcwd())
-        import unify
+        import unisdk
         # Activate the test project before setting context
         project_name = os.environ.get("UNITY_TEST_PROJECT_NAME", "UnityTests")
-        unify.activate(project_name, overwrite=False)
+        unisdk.activate(project_name, overwrite=False)
         # Set test-specific context before creating TaskScheduler to avoid races
         test_ctx = os.environ.get("_TEST_CONTEXT")
         if test_ctx:
-            unify.set_context(test_ctx, relative=False)
+            unisdk.set_context(test_ctx, relative=False)
         import unity.common.prompt_helpers as _ph
         from datetime import datetime, timezone
         def _static_now(time_only: bool = False):

--- a/tests/task_scheduler/test_tool_docstrings.py
+++ b/tests/task_scheduler/test_tool_docstrings.py
@@ -60,14 +60,14 @@ def _build_tools_schema_in_subprocess(method: str, test_context: str) -> str:
         f"""
 		import os, sys, json
 		sys.path.insert(0, os.getcwd())
-		import unify
+		import unisdk
 		# Activate the test project before setting context
 		project_name = os.environ.get("UNITY_TEST_PROJECT_NAME", "UnityTests")
-		unify.activate(project_name, overwrite=False)
+		unisdk.activate(project_name, overwrite=False)
 		# Set test-specific context before creating TaskScheduler to avoid races
 		test_ctx = os.environ.get("_TEST_CONTEXT")
 		if test_ctx:
-			unify.set_context(test_ctx, relative=False)
+			unisdk.set_context(test_ctx, relative=False)
 		from unity.common.llm_helpers import method_to_schema
 		def _unwrap_callable(tool):
 			return getattr(tool, "fn", tool)

--- a/tests/transcript_manager/conftest.py
+++ b/tests/transcript_manager/conftest.py
@@ -11,7 +11,7 @@ from typing import List, Dict, Any, Tuple
 import pytest
 import pytest_asyncio
 import os
-import unify
+import unisdk
 
 from unity.contact_manager.contact_manager import ContactManager
 from unity.transcript_manager.transcript_manager import TranscriptManager
@@ -69,7 +69,7 @@ def _ensure_embeddings_exist(context: str) -> bool:
     Returns True if any embeddings were created (scenario needs recommit).
     """
     try:
-        fields = unify.get_fields(context=context)
+        fields = unisdk.get_fields(context=context)
     except Exception:
         return False
 
@@ -429,12 +429,12 @@ class ScenarioBuilder:
 
 def _commit_contexts_for_rollback(ctx_prefix: str) -> None:
     """Commit all contexts under prefix for rollback support."""
-    created_contexts = unify.get_contexts(prefix=ctx_prefix)
+    created_contexts = unisdk.get_contexts(prefix=ctx_prefix)
     created_context_names = list(created_contexts.keys())
 
     def commit_context_and_store(ctx_name):
         try:
-            commit_info = unify.commit_context(
+            commit_info = unisdk.commit_context(
                 name=ctx_name,
                 commit_message="Initial seed data for tests",
             )
@@ -443,15 +443,15 @@ def _commit_contexts_for_rollback(ctx_prefix: str) -> None:
             pass  # May already be committed
 
     if created_context_names:
-        unify.map(commit_context_and_store, created_context_names, mode="asyncio")
+        unisdk.map(commit_context_and_store, created_context_names, mode="asyncio")
 
 
 def _rebuild_commit_hashes(ctx_prefix: str) -> None:
     """Rebuild commit hashes from existing contexts for rollback support."""
-    existing_contexts = unify.get_contexts(prefix=ctx_prefix)
+    existing_contexts = unisdk.get_contexts(prefix=ctx_prefix)
     for ctx_name in existing_contexts.keys():
         try:
-            history = unify.get_context_commits(ctx_name)
+            history = unisdk.get_context_commits(ctx_name)
             if history:
                 SCENARIO_COMMIT_HASHES[ctx_name] = history[0]["commit_hash"]
         except Exception:
@@ -479,18 +479,18 @@ def _setup_tm_scenario(
 
     # If --overwrite-scenarios is set, delete existing contexts first
     if overwrite_scenarios:
-        existing_contexts = unify.get_contexts(prefix=ctx)
+        existing_contexts = unisdk.get_contexts(prefix=ctx)
         existing_context_names = list(existing_contexts.keys())
         if existing_context_names:
-            unify.map(
-                lambda c: unify.delete_context(c),
+            unisdk.map(
+                lambda c: unisdk.delete_context(c),
                 existing_context_names,
                 mode="asyncio",
             )
 
     # Set context before any operations (create first like ContactManager does)
-    unify.create_context(ctx)  # exist_ok=True by default
-    unify.set_context(ctx, relative=False)
+    unisdk.create_context(ctx)  # exist_ok=True by default
+    unisdk.set_context(ctx, relative=False)
 
     # Create managers
     cm = ContactManager()
@@ -525,7 +525,7 @@ def _setup_tm_scenario(
             _commit_contexts_for_rollback(ctx)
 
     # Unset context after setup, like ContactManager does
-    unify.unset_context()
+    unisdk.unset_context()
 
     return tm, dict(_ID_BY_NAME)
 
@@ -560,7 +560,7 @@ def tm_manager_scenario(tm_scenario):
     tm, _ID_BY_NAME = tm_scenario
 
     def rollback_context(ctx):
-        unify.rollback_context(
+        unisdk.rollback_context(
             name=ctx,
             commit_hash=SCENARIO_COMMIT_HASHES[ctx],
         )
@@ -573,7 +573,7 @@ def tm_manager_scenario(tm_scenario):
         # from rolling back while this test is running
         scenario_names = list(SCENARIO_COMMIT_HASHES.keys())
         if scenario_names:
-            unify.map(rollback_context, scenario_names, mode="asyncio")
+            unisdk.map(rollback_context, scenario_names, mode="asyncio")
 
         restore_scenario_context("tests/transcript_manager/Scenario")
         yield tm, _ID_BY_NAME

--- a/tests/transcript_manager/test_api_message_medium.py
+++ b/tests/transcript_manager/test_api_message_medium.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
-import unify
+import unisdk
 
 from tests.helpers import _handle_project
 from unity.conversation_manager.cm_types import Medium
@@ -61,7 +61,7 @@ def test_api_message_exchange_medium():
         },
     )
 
-    rows = unify.get_logs(
+    rows = unisdk.get_logs(
         context=tm._exchanges_ctx,
         filter=f"exchange_id == {exchange_id}",
         limit=1,

--- a/tests/transcript_manager/test_authoring_attribution.py
+++ b/tests/transcript_manager/test_authoring_attribution.py
@@ -4,7 +4,7 @@ import time
 from datetime import UTC, datetime
 
 import pytest
-import unify
+import unisdk
 
 from tests.helpers import _handle_project
 from unity.common.colleague_cache import ColleagueNameCache
@@ -29,16 +29,16 @@ def _message_payload(content: str, *, exchange_id: int) -> dict:
 
 def _delete_context_tree(root: str) -> None:
     try:
-        children = list(unify.get_contexts(prefix=f"{root}/").keys())
+        children = list(unisdk.get_contexts(prefix=f"{root}/").keys())
     except Exception:
         children = []
     for context in sorted(children, key=len, reverse=True):
         try:
-            unify.delete_context(context)
+            unisdk.delete_context(context)
         except Exception:
             pass
     try:
-        unify.delete_context(root)
+        unisdk.delete_context(root)
     except Exception:
         pass
 
@@ -96,7 +96,7 @@ def test_shared_authoring_attribution_enriches_messages_and_reuses_cache(monkeyp
             ]
 
         monkeypatch.setattr(
-            "unity.common.colleague_cache.unify.list_assistants",
+            "unity.common.colleague_cache.unisdk.list_assistants",
             fake_list_assistants,
         )
 
@@ -150,7 +150,7 @@ def test_colleague_name_cache_invalidates_when_org_scope_changes(monkeypatch):
         return [{"agent_id": 999, "first_name": "Rafi", "surname": "Ops"}]
 
     monkeypatch.setattr(
-        "unity.common.colleague_cache.unify.list_assistants",
+        "unity.common.colleague_cache.unisdk.list_assistants",
         fake_list_assistants,
     )
 
@@ -173,7 +173,7 @@ def test_colleague_name_cache_caches_error_fallback(monkeypatch):
         raise RuntimeError("temporary transport error")
 
     monkeypatch.setattr(
-        "unity.common.colleague_cache.unify.list_assistants",
+        "unity.common.colleague_cache.unisdk.list_assistants",
         failing_list_assistants,
     )
 
@@ -202,7 +202,7 @@ def test_shared_authoring_attribution_uses_former_colleague_fallback(monkeypatch
         SESSION_DETAILS.assistant.agent_id = 321
 
         monkeypatch.setattr(
-            "unity.common.colleague_cache.unify.list_assistants",
+            "unity.common.colleague_cache.unisdk.list_assistants",
             lambda **_: [],
         )
 

--- a/tests/transcript_manager/test_basics.py
+++ b/tests/transcript_manager/test_basics.py
@@ -2,7 +2,7 @@ import time
 import random
 import pytest
 from datetime import datetime, UTC
-import unify
+import unisdk
 
 from unity.transcript_manager.types.message import Message
 from unity.conversation_manager.cm_types import VALID_MEDIA
@@ -323,7 +323,7 @@ def test_clear():
     tm.clear()
 
     # After clear: context should exist again and exchange_id present
-    fields_exchanges = unify.get_fields(context=tm._exchanges_ctx)
+    fields_exchanges = unisdk.get_fields(context=tm._exchanges_ctx)
     assert "exchange_id" in fields_exchanges
 
     # Prior messages should be gone

--- a/tests/transcript_manager/test_destination_routing.py
+++ b/tests/transcript_manager/test_destination_routing.py
@@ -4,7 +4,7 @@ import time
 from datetime import UTC, datetime
 
 import pytest
-import unify
+import unisdk
 
 from tests.helpers import _handle_project
 from unity.image_manager.image_manager import ImageManager
@@ -20,21 +20,21 @@ def _team_id() -> int:
 
 
 def _logs(context: str, filter_expr: str):
-    return unify.get_logs(context=context, filter=filter_expr, return_ids_only=False)
+    return unisdk.get_logs(context=context, filter=filter_expr, return_ids_only=False)
 
 
 def _delete_context_tree(root: str) -> None:
     try:
-        children = list(unify.get_contexts(prefix=f"{root}/").keys())
+        children = list(unisdk.get_contexts(prefix=f"{root}/").keys())
     except Exception:
         children = []
     for context in sorted(children, key=len, reverse=True):
         try:
-            unify.delete_context(context)
+            unisdk.delete_context(context)
         except Exception:
             pass
     try:
-        unify.delete_context(root)
+        unisdk.delete_context(root)
     except Exception:
         pass
 

--- a/tests/transcript_manager/test_destination_routing_eval.py
+++ b/tests/transcript_manager/test_destination_routing_eval.py
@@ -4,7 +4,7 @@ from datetime import UTC, datetime
 import time
 
 import pytest
-import unify
+import unisdk
 
 from tests.assertion_helpers import assertion_failed
 from tests.helpers import _handle_project
@@ -33,16 +33,16 @@ def _message(content: str, *, exchange_id: int) -> Message:
 
 def _delete_context_tree(root: str) -> None:
     try:
-        children = list(unify.get_contexts(prefix=f"{root}/").keys())
+        children = list(unisdk.get_contexts(prefix=f"{root}/").keys())
     except Exception:
         children = []
     for context in sorted(children, key=len, reverse=True):
         try:
-            unify.delete_context(context)
+            unisdk.delete_context(context)
         except Exception:
             pass
     try:
-        unify.delete_context(root)
+        unisdk.delete_context(root)
     except Exception:
         pass
 

--- a/tests/transcript_manager/test_exchanges.py
+++ b/tests/transcript_manager/test_exchanges.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, UTC
-import unify
+import unisdk
 
 from unity.transcript_manager.transcript_manager import TranscriptManager
 from unity.transcript_manager.types.exchange import Exchange
@@ -26,7 +26,7 @@ def test_row_created_explicit_id():
     )
     tm.join_published()
 
-    rows = unify.get_logs(
+    rows = unisdk.get_logs(
         context=tm._exchanges_ctx,
         filter=f"exchange_id == {ex_id}",
         limit=1,

--- a/tests/transcript_manager/test_foreign_keys.py
+++ b/tests/transcript_manager/test_foreign_keys.py
@@ -27,7 +27,7 @@ Coverage
 from __future__ import annotations
 
 import pytest
-import unify
+import unisdk
 from datetime import datetime
 from tests.helpers import _handle_project
 from unity.contact_manager.contact_manager import ContactManager
@@ -69,7 +69,10 @@ def test_fk_message_sender_id_valid_reference():
     )
 
     # Get contact IDs
-    contacts = unify.get_logs(context=cm._ctx, from_fields=["contact_id", "first_name"])
+    contacts = unisdk.get_logs(
+        context=cm._ctx,
+        from_fields=["contact_id", "first_name"],
+    )
     alice_id = next(
         int(c.entries["contact_id"])
         for c in contacts
@@ -93,7 +96,7 @@ def test_fk_message_sender_id_valid_reference():
     )
 
     # Verify message was created
-    messages = unify.get_logs(
+    messages = unisdk.get_logs(
         context=tm._transcripts_ctx,
         from_fields=["message_id", "sender_id"],
     )
@@ -119,7 +122,10 @@ def test_fk_message_sender_id_set_null_on_delete():
         phone_number="2222222222",
     )
 
-    contacts = unify.get_logs(context=cm._ctx, from_fields=["contact_id", "first_name"])
+    contacts = unisdk.get_logs(
+        context=cm._ctx,
+        from_fields=["contact_id", "first_name"],
+    )
     alice_id = next(
         int(c.entries["contact_id"])
         for c in contacts
@@ -152,7 +158,7 @@ def test_fk_message_sender_id_set_null_on_delete():
     )
 
     # Verify messages exist with Alice as sender
-    messages = unify.get_logs(
+    messages = unisdk.get_logs(
         context=tm._transcripts_ctx,
         from_fields=["message_id", "sender_id"],
     )
@@ -163,7 +169,7 @@ def test_fk_message_sender_id_set_null_on_delete():
     cm._delete_contact(contact_id=alice_id)
 
     # Verify Alice's messages still exist but sender_id is null (SET NULL behavior)
-    messages_after = unify.get_logs(
+    messages_after = unisdk.get_logs(
         context=tm._transcripts_ctx,
         from_fields=["message_id", "sender_id", "content"],
     )
@@ -193,7 +199,10 @@ def test_fk_message_sender_id_null_does_not_break_manager_init():
         phone_number="2222222222",
     )
 
-    contacts = unify.get_logs(context=cm._ctx, from_fields=["contact_id", "first_name"])
+    contacts = unisdk.get_logs(
+        context=cm._ctx,
+        from_fields=["contact_id", "first_name"],
+    )
     alice_id = next(
         int(c.entries["contact_id"])
         for c in contacts
@@ -223,7 +232,7 @@ def test_fk_message_sender_id_null_does_not_break_manager_init():
     tm_new = TranscriptManager()
 
     # Verify the new manager can successfully read messages with null sender_id
-    messages = unify.get_logs(
+    messages = unisdk.get_logs(
         context=tm_new._transcripts_ctx,
     )
     assert len(messages) == 1
@@ -263,7 +272,10 @@ def test_fk_message_receiver_ids_null_does_not_break_manager_init():
         phone_number="3333333333",
     )
 
-    contacts = unify.get_logs(context=cm._ctx, from_fields=["contact_id", "first_name"])
+    contacts = unisdk.get_logs(
+        context=cm._ctx,
+        from_fields=["contact_id", "first_name"],
+    )
     alice_id = next(
         int(c.entries["contact_id"])
         for c in contacts
@@ -292,7 +304,7 @@ def test_fk_message_receiver_ids_null_does_not_break_manager_init():
     )
 
     # Verify message exists with both receivers
-    messages = unify.get_logs(context=tm._transcripts_ctx)
+    messages = unisdk.get_logs(context=tm._transcripts_ctx)
     assert len(messages) == 1
     assert set(messages[0].entries["receiver_ids"]) == {bob_id, charlie_id}
 
@@ -300,7 +312,7 @@ def test_fk_message_receiver_ids_null_does_not_break_manager_init():
     cm._delete_contact(contact_id=charlie_id)
 
     # Verify message now has [bob_id, None] in receiver_ids
-    messages = unify.get_logs(context=tm._transcripts_ctx)
+    messages = unisdk.get_logs(context=tm._transcripts_ctx)
     assert len(messages) == 1
     receiver_ids = messages[0].entries["receiver_ids"]
     assert bob_id in receiver_ids
@@ -311,7 +323,7 @@ def test_fk_message_receiver_ids_null_does_not_break_manager_init():
     tm_new = TranscriptManager()
 
     # Verify the new manager can successfully read messages with null entries in receiver_ids
-    messages = unify.get_logs(context=tm_new._transcripts_ctx)
+    messages = unisdk.get_logs(context=tm_new._transcripts_ctx)
     assert len(messages) == 1
     assert bob_id in messages[0].entries["receiver_ids"]
     assert None in messages[0].entries["receiver_ids"]
@@ -343,7 +355,10 @@ def test_fk_message_images_null_does_not_break_manager_init():
         phone_number="2222222222",
     )
 
-    contacts = unify.get_logs(context=cm._ctx, from_fields=["contact_id", "first_name"])
+    contacts = unisdk.get_logs(
+        context=cm._ctx,
+        from_fields=["contact_id", "first_name"],
+    )
     alice_id = next(
         int(c.entries["contact_id"])
         for c in contacts
@@ -389,7 +404,7 @@ def test_fk_message_images_null_does_not_break_manager_init():
     )
 
     # Verify message exists with both images
-    messages = unify.get_logs(context=tm._transcripts_ctx)
+    messages = unisdk.get_logs(context=tm._transcripts_ctx)
     assert len(messages) == 1
     image_ids_in_msg = [
         img["raw_image_ref"]["image_id"]
@@ -399,16 +414,16 @@ def test_fk_message_images_null_does_not_break_manager_init():
     assert img2_id in image_ids_in_msg
 
     # Delete img2 (should trigger SET NULL on nested image_id)
-    img2_logs = unify.get_logs(
+    img2_logs = unisdk.get_logs(
         context=im._ctx,
         filter=f"image_id == {img2_id}",
         return_ids_only=True,
     )
     assert img2_logs, "Image not found"
-    unify.delete_logs(context=im._ctx, logs=img2_logs[0])
+    unisdk.delete_logs(context=im._ctx, logs=img2_logs[0])
 
     # Verify message now has one valid image_id and one None
-    messages = unify.get_logs(context=tm._transcripts_ctx)
+    messages = unisdk.get_logs(context=tm._transcripts_ctx)
     assert len(messages) == 1
     images_list = messages[0].entries.get("images", [])
     assert len(images_list) == 2
@@ -421,7 +436,7 @@ def test_fk_message_images_null_does_not_break_manager_init():
     tm_new = TranscriptManager()
 
     # Verify the new manager can successfully read messages with null image_ids
-    messages = unify.get_logs(context=tm_new._transcripts_ctx)
+    messages = unisdk.get_logs(context=tm_new._transcripts_ctx)
     assert len(messages) == 1
     images_list = messages[0].entries.get("images", [])
     assert len(images_list) == 2
@@ -465,7 +480,10 @@ def test_fk_message_receiver_ids_valid_reference():
         phone_number="3333333333",
     )
 
-    contacts = unify.get_logs(context=cm._ctx, from_fields=["contact_id", "first_name"])
+    contacts = unisdk.get_logs(
+        context=cm._ctx,
+        from_fields=["contact_id", "first_name"],
+    )
     contact_map = {
         c.entries["first_name"]: int(c.entries["contact_id"]) for c in contacts
     }
@@ -482,7 +500,7 @@ def test_fk_message_receiver_ids_valid_reference():
     )
 
     # Verify message was created with all receivers
-    messages = unify.get_logs(
+    messages = unisdk.get_logs(
         context=tm._transcripts_ctx,
         from_fields=["message_id", "receiver_ids"],
     )
@@ -515,7 +533,10 @@ def test_fk_message_receiver_ids_set_null_on_delete():
         phone_number="3333333333",
     )
 
-    contacts = unify.get_logs(context=cm._ctx, from_fields=["contact_id", "first_name"])
+    contacts = unisdk.get_logs(
+        context=cm._ctx,
+        from_fields=["contact_id", "first_name"],
+    )
     contact_map = {
         c.entries["first_name"]: int(c.entries["contact_id"]) for c in contacts
     }
@@ -532,7 +553,7 @@ def test_fk_message_receiver_ids_set_null_on_delete():
     )
 
     # Verify both receivers
-    messages = unify.get_logs(
+    messages = unisdk.get_logs(
         context=tm._transcripts_ctx,
         from_fields=["message_id", "receiver_ids"],
     )
@@ -544,7 +565,7 @@ def test_fk_message_receiver_ids_set_null_on_delete():
     cm._delete_contact(contact_id=contact_map["Bob"])
 
     # Verify Bob replaced with None in receiver_ids array (SET NULL = in-place replacement)
-    messages_after = unify.get_logs(
+    messages_after = unisdk.get_logs(
         context=tm._transcripts_ctx,
         from_fields=["message_id", "receiver_ids"],
     )
@@ -578,7 +599,10 @@ def test_fk_message_exchange_id_cascade_delete():
         phone_number="2222222222",
     )
 
-    contacts = unify.get_logs(context=cm._ctx, from_fields=["contact_id", "first_name"])
+    contacts = unisdk.get_logs(
+        context=cm._ctx,
+        from_fields=["contact_id", "first_name"],
+    )
     alice_id = next(
         int(c.entries["contact_id"])
         for c in contacts
@@ -615,7 +639,7 @@ def test_fk_message_exchange_id_cascade_delete():
     )
 
     # Verify 2 messages in exchange
-    messages_in_exchange = unify.get_logs(
+    messages_in_exchange = unisdk.get_logs(
         context=tm._transcripts_ctx,
         filter=f"exchange_id == {exchange_id}",
         from_fields=["message_id"],
@@ -623,16 +647,16 @@ def test_fk_message_exchange_id_cascade_delete():
     assert len(messages_in_exchange) == 2
 
     # Delete the exchange (get log ID first, then delete)
-    exchange_logs = unify.get_logs(
+    exchange_logs = unisdk.get_logs(
         context=tm._exchanges_ctx,
         filter=f"exchange_id == {exchange_id}",
         return_ids_only=True,
     )
     assert exchange_logs, "Exchange not found"
-    unify.delete_logs(context=tm._exchanges_ctx, logs=exchange_logs[0])
+    unisdk.delete_logs(context=tm._exchanges_ctx, logs=exchange_logs[0])
 
     # Verify all messages in exchange were cascade deleted
-    messages_after = unify.get_logs(
+    messages_after = unisdk.get_logs(
         context=tm._transcripts_ctx,
         from_fields=["message_id", "exchange_id"],
     )
@@ -663,7 +687,10 @@ def test_fk_message_images_valid_reference():
         phone_number="2222222222",
     )
 
-    contacts = unify.get_logs(context=cm._ctx, from_fields=["contact_id", "first_name"])
+    contacts = unisdk.get_logs(
+        context=cm._ctx,
+        from_fields=["contact_id", "first_name"],
+    )
     alice_id = next(
         int(c.entries["contact_id"])
         for c in contacts
@@ -703,7 +730,7 @@ def test_fk_message_images_valid_reference():
     )
 
     # Verify message created with nested image references
-    messages = unify.get_logs(
+    messages = unisdk.get_logs(
         context=tm._transcripts_ctx,
         from_fields=["message_id", "images"],
     )
@@ -733,7 +760,10 @@ def test_fk_message_images_set_null_on_delete():
         phone_number="2222222222",
     )
 
-    contacts = unify.get_logs(context=cm._ctx, from_fields=["contact_id", "first_name"])
+    contacts = unisdk.get_logs(
+        context=cm._ctx,
+        from_fields=["contact_id", "first_name"],
+    )
     alice_id = next(
         int(c.entries["contact_id"])
         for c in contacts
@@ -776,20 +806,23 @@ def test_fk_message_images_set_null_on_delete():
     )
 
     # Verify 3 images
-    messages = unify.get_logs(context=tm._transcripts_ctx, from_fields=["images"])
+    messages = unisdk.get_logs(context=tm._transcripts_ctx, from_fields=["images"])
     assert len(messages[0].entries["images"]) == 3
 
     # Delete middle image (img2) - get log ID first, then delete
-    img2_logs = unify.get_logs(
+    img2_logs = unisdk.get_logs(
         context=im._ctx,
         filter=f"image_id == {img2_id}",
         return_ids_only=True,
     )
     assert img2_logs, "Image not found"
-    unify.delete_logs(context=im._ctx, logs=img2_logs[0])
+    unisdk.delete_logs(context=im._ctx, logs=img2_logs[0])
 
     # Verify img2 replaced with None in nested structure (SET NULL = in-place replacement)
-    messages_after = unify.get_logs(context=tm._transcripts_ctx, from_fields=["images"])
+    messages_after = unisdk.get_logs(
+        context=tm._transcripts_ctx,
+        from_fields=["images"],
+    )
     images_after = messages_after[0].entries.get("images", [])
     assert len(images_after) == 3  # Array length unchanged (in-place replacement)
 
@@ -839,7 +872,10 @@ def test_contact_merge_with_transcripts():
         phone_number="3333333333",
     )
 
-    contacts = unify.get_logs(context=cm._ctx, from_fields=["contact_id", "first_name"])
+    contacts = unisdk.get_logs(
+        context=cm._ctx,
+        from_fields=["contact_id", "first_name"],
+    )
     contact_map = {
         c.entries["first_name"]: int(c.entries["contact_id"]) for c in contacts
     }
@@ -881,7 +917,7 @@ def test_contact_merge_with_transcripts():
     )
 
     # Verify 3 messages before merge
-    messages_before = unify.get_logs(
+    messages_before = unisdk.get_logs(
         context=tm._transcripts_ctx,
         from_fields=["message_id"],
     )
@@ -891,7 +927,7 @@ def test_contact_merge_with_transcripts():
     cm._merge_contacts(contact_id_1=alice1_id, contact_id_2=alice2_id)
 
     # Verify Alice2 contact deleted (exclude system contacts: 0=assistant, 1=user)
-    contacts_after = unify.get_logs(
+    contacts_after = unisdk.get_logs(
         context=cm._ctx,
         filter="contact_id > 1",
         from_fields=["contact_id", "first_name"],
@@ -902,7 +938,7 @@ def test_contact_merge_with_transcripts():
     assert alice2_id not in remaining_ids
 
     # Verify all 3 messages still exist
-    messages_after = unify.get_logs(
+    messages_after = unisdk.get_logs(
         context=tm._transcripts_ctx,
         from_fields=["message_id", "sender_id", "receiver_ids", "content"],
     )
@@ -968,7 +1004,10 @@ def test_contact_blacklist_anonymizes_transcripts():
         phone_number="2222222222",
     )
 
-    contacts = unify.get_logs(context=cm._ctx, from_fields=["contact_id", "first_name"])
+    contacts = unisdk.get_logs(
+        context=cm._ctx,
+        from_fields=["contact_id", "first_name"],
+    )
     contact_map = {
         c.entries["first_name"]: int(c.entries["contact_id"]) for c in contacts
     }
@@ -1008,7 +1047,7 @@ def test_contact_blacklist_anonymizes_transcripts():
     )
 
     # Verify 3 messages before blacklist
-    messages_before = unify.get_logs(
+    messages_before = unisdk.get_logs(
         context=tm._transcripts_ctx,
         from_fields=["message_id"],
     )
@@ -1018,7 +1057,7 @@ def test_contact_blacklist_anonymizes_transcripts():
     cm._move_to_blacklist(contact_id=spammer_id, reason="sending spam")
 
     # Verify spammer contact deleted (exclude system contacts: 0=assistant, 1=user)
-    contacts_after = unify.get_logs(
+    contacts_after = unisdk.get_logs(
         context=cm._ctx,
         filter="contact_id > 1",
         from_fields=["contact_id", "first_name"],
@@ -1028,7 +1067,7 @@ def test_contact_blacklist_anonymizes_transcripts():
     assert spammer_id not in remaining_ids
 
     # Verify all 3 messages still exist (SET NULL preserves messages)
-    messages_after = unify.get_logs(
+    messages_after = unisdk.get_logs(
         context=tm._transcripts_ctx,
         from_fields=["message_id", "sender_id", "receiver_ids", "content"],
     )

--- a/tests/transcript_manager/test_images.py
+++ b/tests/transcript_manager/test_images.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 from datetime import datetime, UTC
-import unify
+import unisdk
 
 from unity.transcript_manager.transcript_manager import TranscriptManager
 from unity.transcript_manager.types.message import Message
@@ -44,7 +44,7 @@ def test_schema_roundtrip():
     tm.join_published()
 
     # 1) Column exists in Transcripts context
-    fields = unify.get_fields(context=tm._transcripts_ctx)
+    fields = unisdk.get_fields(context=tm._transcripts_ctx)
     assert "images" in fields, "images column should exist in Transcripts"
 
     # 2) Round-trip retrieval preserves references
@@ -106,7 +106,7 @@ def test_images_field_schema_enforced():
     tm = TranscriptManager()
 
     # 1) The Transcripts context should expose a nested JSON schema for the images field
-    fields = unify.get_fields(context=tm._transcripts_ctx)
+    fields = unisdk.get_fields(context=tm._transcripts_ctx)
     assert "images" in fields
     dtype = str(fields["images"].get("data_type"))
     # Expect array/list with object items including raw_image_ref + annotation and nested image_id
@@ -127,7 +127,7 @@ def test_images_field_schema_enforced():
             {"raw_image_ref": {"image_id": 101}, "annotation": "blue square"},
         ],
     }
-    _ = unify.log(context=tm._transcripts_ctx, **valid_payload, new=True, mutable=True)
+    _ = unisdk.log(context=tm._transcripts_ctx, **valid_payload, new=True, mutable=True)
 
     # 3) Invalid nested payload – wrong key name for image id → must be rejected
     invalid_payload_bad_key = {
@@ -137,7 +137,7 @@ def test_images_field_schema_enforced():
         ],
     }
     with pytest.raises(Exception):
-        unify.log(
+        unisdk.log(
             context=tm._transcripts_ctx,
             **invalid_payload_bad_key,
             new=True,
@@ -152,7 +152,7 @@ def test_images_field_schema_enforced():
         ],
     }
     with pytest.raises(Exception):
-        unify.log(
+        unisdk.log(
             context=tm._transcripts_ctx,
             **invalid_payload_bad_type,
             new=True,

--- a/tests/transcript_manager/test_log_first_message.py
+++ b/tests/transcript_manager/test_log_first_message.py
@@ -6,7 +6,7 @@ from datetime import datetime, UTC
 from unity.transcript_manager.transcript_manager import TranscriptManager
 from unity.transcript_manager.types.message import Message
 from tests.helpers import _handle_project
-import unify
+import unisdk
 
 
 @_handle_project
@@ -69,7 +69,7 @@ def test_creates_exchange_returns_id():
     assert isinstance(tm_msg_id, int)
 
     # Exchanges row should exist (metadata default to dict) and medium set
-    rows_e = unify.get_logs(
+    rows_e = unisdk.get_logs(
         context=tm._exchanges_ctx,
         filter=f"exchange_id == {exid}",
         limit=1,
@@ -79,7 +79,7 @@ def test_creates_exchange_returns_id():
     assert rows_e[0].entries.get("medium") == "sms_message"
 
     # Transcript message should exist for this exchange
-    rows_m = unify.get_logs(
+    rows_m = unisdk.get_logs(
         context=tm._transcripts_ctx,
         filter=f"exchange_id == {exid}",
         limit=1,
@@ -106,7 +106,7 @@ def test_sets_initial_metadata():
     )
     assert isinstance(exid, int) and exid >= 0
 
-    rows_e = unify.get_logs(
+    rows_e = unisdk.get_logs(
         context=tm._exchanges_ctx,
         filter=f"exchange_id == {exid}",
         limit=1,

--- a/tests/transcript_manager/test_log_messages.py
+++ b/tests/transcript_manager/test_log_messages.py
@@ -74,9 +74,9 @@ def test_missing_id_raises_error():
 def test_async_mode_uses_async_logger(monkeypatch):
     """
     With synchronous=False, log_messages should use the async logger
-    (AsyncLoggerManager.log_create) rather than blocking unify.log.
+    (AsyncLoggerManager.log_create) rather than blocking unisdk.log.
     """
-    import unify
+    import unisdk
 
     tm = TranscriptManager()
 
@@ -84,7 +84,7 @@ def test_async_mode_uses_async_logger(monkeypatch):
     sync_transcript_calls = []
     async_log_create_calls = []
 
-    original_unify_log = unify.log
+    original_unify_log = unisdk.log
     original_log_create = TranscriptManager._LOGGER.log_create
 
     def mock_unify_log(*args, **kwargs):
@@ -117,12 +117,12 @@ def test_async_mode_uses_async_logger(monkeypatch):
     tm.log_messages(message, synchronous=False)
 
     # With synchronous=False, the async logger (log_create) should be used,
-    # NOT the blocking unify.log for Transcripts
+    # NOT the blocking unisdk.log for Transcripts
     assert (
         len(async_log_create_calls) > 0
     ), "synchronous=False should use AsyncLoggerManager.log_create, but it wasn't called"
     assert len(sync_transcript_calls) == 0, (
-        f"synchronous=False should NOT call unify.log for Transcripts persistence, "
+        f"synchronous=False should NOT call unisdk.log for Transcripts persistence, "
         f"but it was called {len(sync_transcript_calls)} time(s)"
     )
 

--- a/tests/transcript_manager/test_log_messages.py
+++ b/tests/transcript_manager/test_log_messages.py
@@ -98,7 +98,7 @@ def test_async_mode_uses_async_logger(monkeypatch):
         async_log_create_calls.append((args, kwargs))
         return original_log_create(*args, **kwargs)
 
-    monkeypatch.setattr(unify, "log", mock_unify_log)
+    monkeypatch.setattr(unisdk, "log", mock_unify_log)
     monkeypatch.setattr(TranscriptManager._LOGGER, "log_create", mock_log_create)
 
     message = {

--- a/tests/transcript_manager/test_system_prompts.py
+++ b/tests/transcript_manager/test_system_prompts.py
@@ -44,14 +44,14 @@ def _build_prompt_in_subprocess(test_context: str) -> str:
         """
         import os, sys
         sys.path.insert(0, os.getcwd())
-        import unify
+        import unisdk
         # Activate the test project before setting context
         project_name = os.environ.get("UNITY_TEST_PROJECT_NAME", "UnityTests")
-        unify.activate(project_name, overwrite=False)
+        unisdk.activate(project_name, overwrite=False)
         # Set test-specific context before creating TranscriptManager to avoid races
         test_ctx = os.environ.get("_TEST_CONTEXT")
         if test_ctx:
-            unify.set_context(test_ctx, relative=False)
+            unisdk.set_context(test_ctx, relative=False)
         # Install a deterministic timestamp inside this fresh process
         import unity.common.prompt_helpers as _ph
         from datetime import datetime, timezone

--- a/tests/transcript_manager/test_tool_docstrings.py
+++ b/tests/transcript_manager/test_tool_docstrings.py
@@ -44,14 +44,14 @@ def _build_tools_schema_in_subprocess(method: str, test_context: str) -> str:
         f"""
 		import os, sys, json
 		sys.path.insert(0, os.getcwd())
-		import unify
+		import unisdk
 		# Activate the test project before setting context
 		project_name = os.environ.get("UNITY_TEST_PROJECT_NAME", "UnityTests")
-		unify.activate(project_name, overwrite=False)
+		unisdk.activate(project_name, overwrite=False)
 		# Set test-specific context before creating TranscriptManager to avoid races
 		test_ctx = os.environ.get("_TEST_CONTEXT")
 		if test_ctx:
-			unify.set_context(test_ctx, relative=False)
+			unisdk.set_context(test_ctx, relative=False)
 		from unity.common.llm_helpers import method_to_schema
 		def _unwrap_callable(tool):
 			return getattr(tool, "fn", tool)

--- a/tests/web_searcher/test_sys_msgs.py
+++ b/tests/web_searcher/test_sys_msgs.py
@@ -35,14 +35,14 @@ def _build_prompt_in_subprocess(method: str, test_context: str) -> str:
         f"""
         import os, sys
         sys.path.insert(0, os.getcwd())
-        import unify
+        import unisdk
         # Activate the test project before setting context
         project_name = os.environ.get("UNITY_TEST_PROJECT_NAME", "UnityTests")
-        unify.activate(project_name, overwrite=False)
+        unisdk.activate(project_name, overwrite=False)
         # Set test-specific context before creating WebSearcher to avoid races
         test_ctx = os.environ.get("_TEST_CONTEXT")
         if test_ctx:
-            unify.set_context(test_ctx, relative=False)
+            unisdk.set_context(test_ctx, relative=False)
         # Install the same static timestamp override used by pytest's autouse fixture,
         # but inside this fresh process so the time footer is deterministic.
         import unity.common.prompt_helpers as _ph

--- a/tests/web_searcher/test_tool_docstrings.py
+++ b/tests/web_searcher/test_tool_docstrings.py
@@ -44,14 +44,14 @@ def _build_tools_schema_in_subprocess(method: str, test_context: str) -> str:
         f"""
 		import os, sys, json
 		sys.path.insert(0, os.getcwd())
-		import unify
+		import unisdk
 		# Activate the test project before setting context
 		project_name = os.environ.get("UNITY_TEST_PROJECT_NAME", "UnityTests")
-		unify.activate(project_name, overwrite=False)
+		unisdk.activate(project_name, overwrite=False)
 		# Set test-specific context before creating WebSearcher to avoid races
 		test_ctx = os.environ.get("_TEST_CONTEXT")
 		if test_ctx:
-			unify.set_context(test_ctx, relative=False)
+			unisdk.set_context(test_ctx, relative=False)
 		from unity.common.llm_helpers import method_to_schema
 		def _unwrap_callable(tool):
 			return getattr(tool, "fn", tool)

--- a/unity/__init__.py
+++ b/unity/__init__.py
@@ -30,13 +30,13 @@ except Exception:
 
 from unity.common.context_registry import ContextRegistry
 
-# Attempt to import the external 'unify' SDK. If unavailable, provide a minimal
+# Attempt to import the external 'unisdk' SDK. If unavailable, provide a minimal
 # no-op shim so importing the 'unity' package does not require extra installs.
 try:  # pragma: no cover - simple import guard
-    import unify  # type: ignore
+    import unisdk  # type: ignore
 except Exception:  # ImportError or others
 
-    class _UnifyShim:
+    class _UnisdkShim:
 
         def active_project(self) -> bool:
             return False
@@ -50,7 +50,7 @@ except Exception:  # ImportError or others
         def get_active_context(self) -> dict:
             return {}
 
-    unify = _UnifyShim()  # type: ignore
+    unisdk = _UnisdkShim()  # type: ignore
 
 
 # Logging is configured entirely in unity.logger — import it so that
@@ -90,10 +90,10 @@ def init(
         _SETTINGS.validate_llm_providers()
 
     with startup_timing(LOGGER, "unity.init.active_project"):
-        active_project = unify.active_project()
+        active_project = unisdk.active_project()
     if not active_project:
         with startup_timing(LOGGER, "unity.init.activate", f"project={project_name}"):
-            unify.activate(project_name, overwrite)
+            unisdk.activate(project_name, overwrite)
 
     # Set the Unify context using user_id/assistant_id (e.g., "42/7")
     full_ctx = f"{SESSION_DETAILS.user_context}/{SESSION_DETAILS.assistant_context}"
@@ -101,10 +101,10 @@ def init(
     # Idempotent context setup: tolerate concurrent creation from parallel processes
     with startup_timing(LOGGER, "unity.init.set_context", f"context={full_ctx}"):
         try:
-            unify.set_context(full_ctx)
+            unisdk.set_context(full_ctx)
         except Exception as e:
             if "already exists" in str(e).lower():
-                unify.set_context(full_ctx, skip_create=True)
+                unisdk.set_context(full_ctx, skip_create=True)
             else:
                 raise
 
@@ -181,7 +181,7 @@ def ensure_initialised(
     Otherwise, it calls :pyfunc:`init` to set up project, context, and EventBus.
     """
     try:
-        ctxs = unify.get_active_context()
+        ctxs = unisdk.get_active_context()
         read_ctx = ctxs.get("read") if isinstance(ctxs, dict) else None
         write_ctx = ctxs.get("write") if isinstance(ctxs, dict) else None
     except Exception:

--- a/unity/actor/prompt_builders.py
+++ b/unity/actor/prompt_builders.py
@@ -203,7 +203,7 @@ _EXECUTION_RULES = textwrap.dedent("""
     for clarification instead of writing misleading ownership fields.
 
     For read-only validation, direct SDK reads such as
-    `unify.get_logs(project="Assistants", context="<user_id>/<assistant_id>/...")`
+    `unisdk.get_logs(project="Assistants", context="<user_id>/<assistant_id>/...")`
     may be used when you know the exact absolute context and have access.
     Avoid direct cross-assistant writes through low-level SDK calls unless a
     documented primitive or user-confirmed administrative workflow explicitly

--- a/unity/blacklist_manager/blacklist_manager.py
+++ b/unity/blacklist_manager/blacklist_manager.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Any, Dict, Optional, Tuple
 import functools
 
-import unify
+import unisdk
 
 from ..common.log_utils import log as unity_log
 from ..common.data_store import DataStore
@@ -121,7 +121,7 @@ class BlackListManager(BaseBlackListManager):
             context = self._blacklist_context_for_destination(destination)
         except ToolErrorException as exc:
             return exc.payload  # type: ignore[return-value]
-        unify.delete_context(context)
+        unisdk.delete_context(context)
 
         # Force re-provisioning by clearing TableStore ensure memo for this context
         ContextRegistry.forget(self, "BlackList")
@@ -136,7 +136,7 @@ class BlackListManager(BaseBlackListManager):
 
             for _ in range(3):
                 try:
-                    unify.get_fields(context=context)
+                    unisdk.get_fields(context=context)
                     break
                 except Exception:
                     _time.sleep(0.05)
@@ -253,7 +253,7 @@ class BlackListManager(BaseBlackListManager):
             )
 
         # Resolve target log id
-        target_ids = unify.get_logs(
+        target_ids = unisdk.get_logs(
             context=context,
             filter=f"blacklist_id == {int(blacklist_id)}",
             return_ids_only=True,
@@ -268,7 +268,7 @@ class BlackListManager(BaseBlackListManager):
             )
         log_id = target_ids[0]
 
-        unify.update_logs(
+        unisdk.update_logs(
             logs=[log_id],
             context=context,
             entries=updates,
@@ -276,7 +276,7 @@ class BlackListManager(BaseBlackListManager):
         )
 
         # Refresh local cache from backend
-        row = unify.get_logs(
+        row = unisdk.get_logs(
             context=context,
             filter=f"blacklist_id == {int(blacklist_id)}",
             limit=1,
@@ -305,7 +305,7 @@ class BlackListManager(BaseBlackListManager):
         # / "multiple rows" sanity checks; aggregation contexts are queried
         # separately below since they hold independent log ids — see the
         # cascade loop comment).
-        target_ids = unify.get_logs(
+        target_ids = unisdk.get_logs(
             context=context,
             filter=f"blacklist_id == {int(blacklist_id)}",
             limit=2,
@@ -319,13 +319,13 @@ class BlackListManager(BaseBlackListManager):
             raise RuntimeError(
                 f"Multiple blacklist rows found with blacklist_id {blacklist_id}. Data integrity issue.",
             )
-        ids_in_ctx = unify.get_logs(
+        ids_in_ctx = unisdk.get_logs(
             context=context,
             filter=f"blacklist_id == {int(blacklist_id)}",
             return_ids_only=True,
         )
         for log_id in ids_in_ctx:
-            unify.delete_logs(context=context, logs=log_id)
+            unisdk.delete_logs(context=context, logs=log_id)
         try:
             self._data_store_for_context(context).delete(blacklist_id)
         except KeyError:

--- a/unity/common/backfill.py
+++ b/unity/common/backfill.py
@@ -33,7 +33,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional, Union
 
-import unify
+import unisdk
 
 
 def backfill_private_fields(
@@ -93,7 +93,7 @@ def backfill_private_fields(
 
     while True:
         # Fetch logs with entries to check fields client-side
-        logs = unify.get_logs(
+        logs = unisdk.get_logs(
             context=context,
             filter=filter,  # Only apply user's additional filter
             offset=offset,
@@ -130,7 +130,7 @@ def backfill_private_fields(
                 entries["_org_id"] = org_id
 
             # Batch update
-            unify.update_logs(
+            unisdk.update_logs(
                 logs=logs_to_update,
                 context=context,
                 entries=entries,
@@ -181,7 +181,7 @@ def backfill_all_contexts_for_user_assistant(
     """
     if contexts is None:
         prefix = f"{user_context}/{assistant_context}/"
-        all_contexts = unify.get_contexts(prefix=prefix)
+        all_contexts = unisdk.get_contexts(prefix=prefix)
         contexts = list(all_contexts.keys())
 
     results: Dict[str, Dict[str, Any]] = {}
@@ -226,7 +226,7 @@ def backfill_all_contexts_for_assistant(
 ) -> Dict[str, Dict[str, Any]]:
     """Backward-compatible wrapper - discovers contexts by old single-prefix pattern."""
     if contexts is None:
-        all_contexts = unify.get_contexts(prefix=f"{assistant_context}/")
+        all_contexts = unisdk.get_contexts(prefix=f"{assistant_context}/")
         contexts = list(all_contexts.keys())
 
     results: Dict[str, Dict[str, Any]] = {}

--- a/unity/common/builtins.py
+++ b/unity/common/builtins.py
@@ -18,9 +18,9 @@ from contextlib import contextmanager
 from typing import Dict, Iterator
 from urllib.parse import quote
 
-import unify
-from unify.utils import http
-from unify.utils.helpers import _create_request_header, _validate_api_key
+import unisdk
+from unisdk.utils import http
+from unisdk.utils.helpers import _create_request_header, _validate_api_key
 
 
 def builtins_project() -> str:
@@ -32,11 +32,11 @@ def builtins_project() -> str:
 
 def ensure_builtins_project(project: str) -> None:
     """Create and converge the public-read Builtins project."""
-    unify.create_project(project, exist_ok=True, is_public_read=True)
+    unisdk.create_project(project, exist_ok=True, is_public_read=True)
     api_key = _validate_api_key(None)
     headers = _create_request_header(api_key)
     http.patch(
-        f"{unify.BASE_URL}/project/{quote(project, safe='')}",
+        f"{unisdk.BASE_URL}/project/{quote(project, safe='')}",
         headers=headers,
         json={"is_public_read": True},
     )
@@ -73,7 +73,7 @@ def builtins_seed_key_override() -> Iterator[None]:
 
 def read_seed_hashes(project: str, *, meta_context: str, key: str) -> Dict[str, str]:
     """Read a catalogue's per-unit content-hash map from its meta row."""
-    logs = unify.get_logs(
+    logs = unisdk.get_logs(
         project=project,
         context=meta_context,
         filter="meta_id == 1",
@@ -92,19 +92,19 @@ def write_seed_hashes(
     key: str,
 ) -> None:
     """Replace a catalogue's per-unit content-hash map in its meta row."""
-    logs = unify.get_logs(
+    logs = unisdk.get_logs(
         project=project,
         context=meta_context,
         filter="meta_id == 1",
         limit=1,
     )
     if logs:
-        unify.delete_logs(
+        unisdk.delete_logs(
             project=project,
             context=meta_context,
             logs=[logs[0].id],
         )
-    unify.create_logs(
+    unisdk.create_logs(
         project=project,
         context=meta_context,
         entries=[{"meta_id": 1, key: hashes}],

--- a/unity/common/colleague_cache.py
+++ b/unity/common/colleague_cache.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
-import unify
-from unify.utils.http import RequestError
+import unisdk
+from unisdk.utils.http import RequestError
 
 from unity.session_details import SESSION_DETAILS
 
@@ -87,7 +87,7 @@ class ColleagueNameCache:
             return self.missing_label
 
         try:
-            assistants = unify.list_assistants(
+            assistants = unisdk.list_assistants(
                 agent_id=assistant_id,
                 list_all_org=SESSION_DETAILS.org_id is not None,
                 api_key=SESSION_DETAILS.unify_key,

--- a/unity/common/context_registry.py
+++ b/unity/common/context_registry.py
@@ -2,9 +2,9 @@ import logging
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any, Dict, Final, List, Optional, Type, Union
 
-import unify
+import unisdk
 from pydantic import BaseModel
-from unify import create_fields
+from unisdk import create_fields
 
 from unity.common.authorship import SHARED_SCOPED_TABLES, fields_with_authoring
 from unity.common.context_store import _create_context_with_retry
@@ -40,7 +40,7 @@ class ContextRegistry:
 
     @staticmethod
     def _get_active_context() -> str:
-        active_context = unify.get_active_context()
+        active_context = unisdk.get_active_context()
         assert (
             active_context["read"] == active_context["write"]
         ), "Read and write contexts must be the same"

--- a/unity/common/context_store.py
+++ b/unity/common/context_store.py
@@ -4,8 +4,8 @@ import logging
 import time
 from typing import Any, Dict, Optional
 
-import unify
-from unify.utils.http import RequestError as _UnifyRequestError
+import unisdk
+from unisdk.utils.http import RequestError as _UnifyRequestError
 
 from unity.common.authorship import fields_with_authoring, is_shared_authored_context
 
@@ -45,7 +45,7 @@ def _create_context_with_retry(
     owner_id: Optional[int] = None,
     project: Optional[str] = None,
 ) -> None:
-    """Call ``unify.create_context`` with retry on transient failures.
+    """Call ``unisdk.create_context`` with retry on transient failures.
 
     Retries up to ``_CREATE_CONTEXT_MAX_ATTEMPTS`` times with exponential
     backoff for transient HTTP errors (5xx, 429, network).  Non-transient
@@ -59,7 +59,7 @@ def _create_context_with_retry(
     last_exc: Optional[Exception] = None
     for attempt in range(_CREATE_CONTEXT_MAX_ATTEMPTS):
         try:
-            unify.create_context(
+            unisdk.create_context(
                 name,
                 unique_keys=unique_keys,
                 auto_counting=auto_counting,
@@ -120,7 +120,7 @@ class TableStore:
         foreign_keys: Optional[list[Dict[str, Any]]] = None,
     ) -> None:
         self._ctx = context
-        self._project = unify.active_project()
+        self._project = unisdk.active_project()
         self._unique_keys = dict(unique_keys or {})
         self._auto_counting = dict(auto_counting or {})
         self._description = description or ""
@@ -154,7 +154,7 @@ class TableStore:
 
         if self._fields:
             try:
-                unify.create_fields(self._fields, context=self._ctx)
+                unisdk.create_fields(self._fields, context=self._ctx)
             except Exception:
                 pass
 
@@ -191,7 +191,7 @@ class TableStore:
 
         # First attempt
         try:
-            data = unify.get_fields(project=self._project, context=self._ctx)
+            data = unisdk.get_fields(project=self._project, context=self._ctx)
             return _normalize_fields(data)
         except _UnifyRequestError as e:
             # 404: context missing (race / test teardown / eventual consistency).
@@ -206,7 +206,7 @@ class TableStore:
             if delay:
                 _time.sleep(delay)
             try:
-                data = unify.get_fields(project=self._project, context=self._ctx)
+                data = unisdk.get_fields(project=self._project, context=self._ctx)
                 return _normalize_fields(data)
             except _UnifyRequestError as e:
                 status = getattr(getattr(e, "response", None), "status_code", None)

--- a/unity/common/data_store.py
+++ b/unity/common/data_store.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Optional, Tuple, Union, Iterable
 import copy
 import threading
 
-import unify
+import unisdk
 
 KeyInput = Union[str, int, Tuple[Any, ...], Iterable[Any]]
 
@@ -56,7 +56,7 @@ class DataStore:
     ) -> None:
         if not key_fields or not isinstance(key_fields, tuple):
             raise ValueError("key_fields must be a non-empty tuple of field names")
-        self._project: str = project or unify.active_project()
+        self._project: str = project or unisdk.active_project()
         self._context: str = context
         self._key_fields: Tuple[str, ...] = key_fields
         self._lock = threading.RLock()
@@ -75,7 +75,7 @@ class DataStore:
         project: Optional[str] = None,
     ) -> "DataStore":
         """Return (and memoize) a DataStore for (project, context)."""
-        proj = project or unify.active_project()
+        proj = project or unisdk.active_project()
         key = (proj, context)
         if key in cls._REGISTRY:
             return cls._REGISTRY[key]

--- a/unity/common/embed_utils.py
+++ b/unity/common/embed_utils.py
@@ -7,7 +7,7 @@ import logging
 import os
 import sys
 import tempfile
-import unify
+import unisdk
 import threading
 from contextlib import contextmanager
 
@@ -121,7 +121,7 @@ def list_private_fields(context: str, *, project: str | None = None) -> list[str
     very large, so they should be excluded from payloads returned to clients.
     """
     try:
-        fields = unify.get_fields(context=context, project=project)
+        fields = unisdk.get_fields(context=context, project=project)
         return [name for name in fields.keys() if name.startswith("_")]
     except Exception:
         # If field introspection fails (e.g. offline tests), fall back to none
@@ -155,7 +155,7 @@ def ensure_derived_column(
     # Fast path: if field already exists and we are not doing targeted
     # derived logs creation using from_ids, return without locking or logging
     try:
-        fields = unify.get_fields(context=context, project=project)
+        fields = unisdk.get_fields(context=context, project=project)
         if key in fields and not from_ids:
             return
     except Exception:
@@ -174,7 +174,7 @@ def ensure_derived_column(
             # We intentionally do this to avoid redundant calls to create
             # duplicate embeddings that will get rejected by the backend
             # due to duplication constraint
-            existing = unify.get_fields(context=context, project=project)
+            existing = unisdk.get_fields(context=context, project=project)
             if key in existing and not from_ids:
                 return
 
@@ -190,7 +190,7 @@ def ensure_derived_column(
                         "lg": {"context": referenced_logs_context or context},
                     }
 
-                response = unify.create_derived_logs(
+                response = unisdk.create_derived_logs(
                     context=context,
                     key=key,
                     equation=equation,
@@ -208,7 +208,7 @@ def ensure_derived_column(
                     referenced_logs,
                     response,
                 )
-            except unify.RequestError as e:
+            except unisdk.RequestError as e:
                 body = getattr(e.response, "text", "") or ""
                 logger.debug(
                     "create_derived_logs FAILED context=%s key=%s "
@@ -265,7 +265,7 @@ def ensure_vector_column(
 
     # Early return if the embedding column already exists and
     # we are not doing targetted derived logs creation using from_ids
-    existing = unify.get_fields(context=context, project=project)
+    existing = unisdk.get_fields(context=context, project=project)
     if embed_column in existing and not from_ids:
         return
 

--- a/unity/common/federated_search.py
+++ b/unity/common/federated_search.py
@@ -5,8 +5,8 @@ from dataclasses import dataclass
 from functools import cmp_to_key
 from typing import Any, Callable, Literal, Mapping, Optional, Sequence, Union
 
-import unify
-from unify.utils.http import RequestError as _UnifyRequestError
+import unisdk
+from unisdk.utils.http import RequestError as _UnifyRequestError
 
 from .metrics_utils import SUPPORTED_REDUCTION_METRICS, reduce_logs
 from .semantic_search import (
@@ -193,7 +193,7 @@ def default_filter_fetcher(
         if spec.allowed_fields:
             kwargs["from_fields"] = list(spec.allowed_fields)
         try:
-            page = [row.entries for row in unify.get_logs(**kwargs)]
+            page = [row.entries for row in unisdk.get_logs(**kwargs)]
         except Exception as exc:
             if is_missing_context_error(exc):
                 break
@@ -476,7 +476,7 @@ def default_metric_fetcher(
         return empty
 
     try:
-        unify.get_context(spec.context, project=spec.project)
+        unisdk.get_context(spec.context, project=spec.project)
     except Exception as exc:
         if is_missing_context_error(exc):
             return _empty()

--- a/unity/common/grouping_helpers.py
+++ b/unity/common/grouping_helpers.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, Iterable, List, Union, Tuple
 import json
 import time
 import logging
-import unify
+import unisdk
 from .embed_utils import list_private_fields
 
 
@@ -172,15 +172,15 @@ def maybe_group_rows(
 
 
 def iter_unique_values_via_groups(context: str, column: str) -> List[Any]:
-    """Return a list of unique values for `column` using unify.get_groups.
+    """Return a list of unique values for `column` using unisdk.get_groups.
 
     Accept diverse backend return shapes (dict or list)."""
     try:
-        groups = unify.get_groups(context=context, key=column)
+        groups = unisdk.get_groups(context=context, key=column)
     except Exception:
         # Fallback: try alternate param name
         try:
-            groups = unify.get_groups(context=context, field=column)
+            groups = unisdk.get_groups(context=context, field=column)
         except Exception:
             groups = None
     vals: List[Any] = []
@@ -208,7 +208,7 @@ def read_all_rows(context: str, *, limit: int = 1000) -> List[Dict[str, Any]]:
     _t0 = time.perf_counter()
     while True:
         try:
-            batch = unify.get_logs(
+            batch = unisdk.get_logs(
                 context=context,
                 offset=offset,
                 limit=limit,

--- a/unity/common/image_content.py
+++ b/unity/common/image_content.py
@@ -6,7 +6,7 @@ import base64
 from pathlib import Path
 from typing import Any, Protocol
 
-import unify
+import unisdk
 
 
 class _BytesReader(Protocol):
@@ -51,7 +51,7 @@ def to_image_content_block(
     elif image.startswith("http://") or image.startswith("https://"):
         url = image
     elif image.startswith("gs://"):
-        url = unify.get_signed_url(image, expiration_minutes=60)
+        url = unisdk.get_signed_url(image, expiration_minutes=60)
     else:
         if adapter is not None:
             image_bytes = adapter.open_bytes(image)

--- a/unity/common/join_utils.py
+++ b/unity/common/join_utils.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import uuid
 from typing import Any, Dict, List, Optional, Union
 
-import unify
+import unisdk
 
 from .filter_utils import normalize_filter_expr
 from .search_utils import table_search_top_k
@@ -70,7 +70,7 @@ def create_join(
     """
     Create a joined context from two source contexts.
 
-    This is the core join operation that calls `unify.join_logs()` with the
+    This is the core join operation that calls `unisdk.join_logs()` with the
     pair_of_args pattern.
 
     Parameters
@@ -99,7 +99,7 @@ def create_join(
     str
         The destination context path.
     """
-    unify.join_logs(
+    unisdk.join_logs(
         pair_of_args=(
             {
                 "context": left_context,
@@ -321,7 +321,7 @@ def filter_join(
         excl = list_private_fields(dest_context)
         rows = [
             lg.entries
-            for lg in unify.get_logs(
+            for lg in unisdk.get_logs(
                 context=dest_context,
                 filter=result_where,
                 offset=result_offset,
@@ -333,7 +333,7 @@ def filter_join(
     finally:
         if cleanup:
             try:
-                unify.delete_context(dest_context)
+                unisdk.delete_context(dest_context)
             except Exception:
                 pass
 
@@ -421,7 +421,7 @@ def search_join(
     finally:
         if cleanup:
             try:
-                unify.delete_context(dest_context)
+                unisdk.delete_context(dest_context)
             except Exception:
                 pass
 
@@ -578,7 +578,7 @@ def filter_multi_join(
         excl = list_private_fields(previous_table)
         rows = [
             lg.entries
-            for lg in unify.get_logs(
+            for lg in unisdk.get_logs(
                 context=previous_table,
                 filter=result_where,
                 offset=result_offset,
@@ -591,7 +591,7 @@ def filter_multi_join(
         if cleanup:
             for ctx in tmp_tables:
                 try:
-                    unify.delete_context(ctx)
+                    unisdk.delete_context(ctx)
                 except Exception:
                     pass
 
@@ -750,6 +750,6 @@ def search_multi_join(
         if cleanup:
             for ctx in tmp_tables:
                 try:
-                    unify.delete_context(ctx)
+                    unisdk.delete_context(ctx)
                 except Exception:
                     pass

--- a/unity/common/llm_helpers.py
+++ b/unity/common/llm_helpers.py
@@ -228,7 +228,7 @@ def _dumps(
     context: dict | None = None,
 ) -> Any:
     # prevents circular import
-    from unify import Log
+    from unisdk import Log
 
     base = False
     if idx is None:

--- a/unity/common/log_utils.py
+++ b/unity/common/log_utils.py
@@ -1,5 +1,5 @@
 """
-Wrappers around unify.log/create_logs with:
+Wrappers around unisdk.log/create_logs with:
 1. _user injection (user ID, matches user_context path component)
 2. _user_id injection (user ID from SESSION_DETAILS)
 3. _assistant injection (assistant ID, matches assistant_context path component)
@@ -10,14 +10,14 @@ Wrappers around unify.log/create_logs with:
 
 Usage
 -----
-Replace direct unify.log/create_logs calls with these wrappers:
+Replace direct unisdk.log/create_logs calls with these wrappers:
 
     from unity.common.log_utils import log, create_logs
 
-    # Instead of: unify.log(context=ctx, **entries)
+    # Instead of: unisdk.log(context=ctx, **entries)
     log(context=ctx, **entries)
 
-    # Instead of: unify.create_logs(context=ctx, entries=entries_list)
+    # Instead of: unisdk.create_logs(context=ctx, entries=entries_list)
     create_logs(context=ctx, entries=entries_list)
 
 The wrappers automatically inject _user, _user_id, _assistant, _assistant_id,
@@ -31,7 +31,7 @@ from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
 import httpx
-import unify
+import unisdk
 
 from unity.common.authorship import (
     AUTHORING_ASSISTANT_ID_FIELD,
@@ -129,9 +129,9 @@ def log(
     project: Optional[str] = None,
     stamp_authoring: bool = False,
     **entries: Any,
-) -> unify.Log:
+) -> unisdk.Log:
     """
-    Wrapper around unify.log with private field injection.
+    Wrapper around unisdk.log with private field injection.
 
     Parameters
     ----------
@@ -146,13 +146,13 @@ def log(
 
     Returns
     -------
-    unify.Log
+    unisdk.Log
         The created log object
     """
     if stamp_authoring:
         entries[AUTHORING_ASSISTANT_ID_FIELD] = current_authoring_assistant_id()
     entries = _inject_private_fields(entries)
-    return unify.log(
+    return unisdk.log(
         project=project,
         context=context,
         new=new,
@@ -170,7 +170,7 @@ def create_logs(
     **kwargs: Any,
 ) -> Any:
     """
-    Wrapper around unify.create_logs with private field injection.
+    Wrapper around unisdk.create_logs with private field injection.
 
     Parameters
     ----------
@@ -179,12 +179,12 @@ def create_logs(
     entries : List[Dict[str, Any]]
         List of entry dicts to create
     **kwargs
-        Additional arguments passed to unify.create_logs (e.g., batched=True)
+        Additional arguments passed to unisdk.create_logs (e.g., batched=True)
 
     Returns
     -------
-    Dict[str, Any] | List[unify.Log]
-        Response from unify.create_logs. Returns a dict with log_event_ids normally,
+    Dict[str, Any] | List[unisdk.Log]
+        Response from unisdk.create_logs. Returns a dict with log_event_ids normally,
         or a list of Log objects when batched=True.
     """
     authoring_assistant_id = (
@@ -203,7 +203,7 @@ def create_logs(
         )
         for entry in entries
     ]
-    return unify.create_logs(
+    return unisdk.create_logs(
         project=project,
         context=context,
         entries=entries,
@@ -277,7 +277,7 @@ async def atomic_upsert(
         If the API request fails
     """
     if project is None:
-        project = unify.active_project()
+        project = unisdk.active_project()
 
     # Inject private fields into initial_data
     if initial_data is None:
@@ -336,7 +336,7 @@ def atomic_upsert_sync(
     See atomic_upsert() for full documentation.
     """
     if project is None:
-        project = unify.active_project()
+        project = unisdk.active_project()
 
     # Inject private fields into initial_data
     if initial_data is None:

--- a/unity/common/metrics_utils.py
+++ b/unity/common/metrics_utils.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Union, Optional
 
-import unify
+import unisdk
 
 from .filter_utils import normalize_filter_expr
 
@@ -51,7 +51,7 @@ def reduce_logs(
     """
     Compute one or more reduction metrics over a Unify context.
 
-    This is a thin convenience wrapper around :func:`unify.get_logs_metric`
+    This is a thin convenience wrapper around :func:`unisdk.get_logs_metric`
     that enforces a common contract for manager-level ``reduce`` tools.
 
     Parameters
@@ -69,7 +69,7 @@ def reduce_logs(
         returns a ``{key -> value}`` mapping.
     filter : str | dict[str, str] | None, default None
         Optional filter expression(s) to restrict which rows contribute to the
-        metric. Mirrors the behaviour of :func:`unify.get_logs_metric`:
+        metric. Mirrors the behaviour of :func:`unisdk.get_logs_metric`:
 
         * When a string, the same expression is applied for all keys.
         * When a dict, each key maps to its own filter expression.
@@ -86,7 +86,7 @@ def reduce_logs(
     Returns
     -------
     Any
-        The metric value(s) produced by :func:`unify.get_logs_metric`:
+        The metric value(s) produced by :func:`unisdk.get_logs_metric`:
 
         * Single key, no grouping  → scalar (float/int/str/bool).
         * Multiple keys, no grouping → ``dict[key -> scalar]``.
@@ -106,7 +106,7 @@ def reduce_logs(
 
     normalized_filter = _normalize_filter(filter)
 
-    return unify.get_logs_metric(
+    return unisdk.get_logs_metric(
         metric=metric_norm,
         key=keys,
         filter=normalized_filter,

--- a/unity/common/model_to_fields.py
+++ b/unity/common/model_to_fields.py
@@ -74,7 +74,7 @@ def _schema_to_column_type(prop: dict[str, Any]) -> str:
 def model_to_fields(model: type[BaseModel]) -> dict[str, dict[str, Any]]:
     """
     Translate a Pydantic model class into the structure expected by
-    `unify.create_fields`.
+    `unisdk.create_fields`.
 
     Uses Pydantic's JSON Schema with $ref dereferencing via jsonref.
     Nested object schemas are serialized as JSON strings for Orchestra.
@@ -87,7 +87,7 @@ def model_to_fields(model: type[BaseModel]) -> dict[str, dict[str, Any]]:
     Examples
     --------
     >>> fields_dict = model_to_fields(Contact)
-    >>> unify.create_fields(fields_dict, context=ctx)
+    >>> unisdk.create_fields(fields_dict, context=ctx)
     """
     # Get Pydantic's JSON Schema and dereference all $refs
     schema = model.model_json_schema()

--- a/unity/common/prompt_helpers.py
+++ b/unity/common/prompt_helpers.py
@@ -167,7 +167,7 @@ def _lookup_assistant_timezone() -> _AssistantTimezoneLookup:
                 error_type="",
             )
 
-    import unify as _unify
+    import unisdk as _unify
     from unity.session_details import SESSION_DETAILS
 
     result: str | None = None

--- a/unity/common/semantic_search.py
+++ b/unity/common/semantic_search.py
@@ -4,7 +4,7 @@ from typing import List, Tuple, Dict, Optional
 import json
 import hashlib
 
-import unify
+import unisdk
 
 from .embed_utils import (
     EMBED_MODEL,
@@ -105,7 +105,7 @@ def resolve_existing_vector_for_source(
     has no embeddings in this context.
     """
     embed_column_name = embed_column_for_source(source_expr)
-    fields = unify.get_fields(context=context, project=project)
+    fields = unisdk.get_fields(context=context, project=project)
     return embed_column_name if embed_column_name in fields else None
 
 
@@ -134,7 +134,7 @@ def ensure_join_context(
     This small wrapper standardizes aliasing/copy semantics so downstream code can
     reference bare column names in the joined context without fully qualified paths.
     """
-    unify.join_logs(
+    unisdk.join_logs(
         pair_of_args=(
             {"context": left_ctx},
             {"context": right_ctx},
@@ -250,7 +250,7 @@ def _fetch_single_term_scored(
     }
     if allowed_fields is not None:
         from_fields = list(dict.fromkeys([*allowed_fields, SORT_DISTANCE_KEY]))
-        logs = unify.get_logs(
+        logs = unisdk.get_logs(
             context=context,
             project=project,
             filter=row_filter,
@@ -265,7 +265,7 @@ def _fetch_single_term_scored(
             for f in list_private_fields(context, project=project)
             if f != SORT_DISTANCE_KEY
         ]
-        logs = unify.get_logs(
+        logs = unisdk.get_logs(
             context=context,
             project=project,
             filter=row_filter,
@@ -279,7 +279,7 @@ def _fetch_single_term_scored(
 
 def _context_unique_id_field(context: str, *, project: Optional[str] = None) -> str:
     """Return the unique-key column for a context (required for combining)."""
-    ctx_info = unify.get_context(context, project=project)
+    ctx_info = unisdk.get_context(context, project=project)
     unique_keys = ctx_info.get("unique_keys")
     if isinstance(unique_keys, dict):
         unique_keys = list(unique_keys)
@@ -443,7 +443,7 @@ def fetch_top_k_by_terms_with_score(
     if allowed_fields is not None:
         # Ensure the private score column is included in the payload
         from_fields = list(dict.fromkeys([*allowed_fields, sum_key]))
-        logs = unify.get_logs(
+        logs = unisdk.get_logs(
             context=context,
             project=project,
             filter=row_filter,
@@ -456,7 +456,7 @@ def fetch_top_k_by_terms_with_score(
         exclude_fields = [
             f for f in list_private_fields(context, project=project) if f != sum_key
         ]
-        logs = unify.get_logs(
+        logs = unisdk.get_logs(
             context=context,
             project=project,
             filter=row_filter,
@@ -493,7 +493,7 @@ def fetch_scores_for_ids(
     # Exclude all private fields except the score key we need to read
     exclude_fields = [f for f in list_private_fields(context) if f != sum_key]
 
-    rows = unify.get_logs(
+    rows = unisdk.get_logs(
         context=context,
         filter=id_filter,
         limit=len(ids),
@@ -531,7 +531,7 @@ def fetch_top_k_by_terms(
         embed_col, ref_text = terms[0]
         escaped_ref = ref_text.replace("'", "\\'")
         if allowed_fields is not None:
-            logs = unify.get_logs(
+            logs = unisdk.get_logs(
                 context=context,
                 project=project,
                 filter=row_filter,
@@ -542,7 +542,7 @@ def fetch_top_k_by_terms(
                 from_fields=allowed_fields,
             )
         else:
-            logs = unify.get_logs(
+            logs = unisdk.get_logs(
                 context=context,
                 project=project,
                 filter=row_filter,
@@ -558,7 +558,7 @@ def fetch_top_k_by_terms(
     # creating a summed-cosine derived column which can fail on empty contexts.
     try:
         if row_filter is not None:
-            any_rows = unify.get_logs(
+            any_rows = unisdk.get_logs(
                 context=context,
                 project=project,
                 filter=row_filter,
@@ -583,7 +583,7 @@ def fetch_top_k_by_terms(
     )
 
     if allowed_fields is not None:
-        logs = unify.get_logs(
+        logs = unisdk.get_logs(
             context=context,
             project=project,
             filter=row_filter,
@@ -592,7 +592,7 @@ def fetch_top_k_by_terms(
             from_fields=allowed_fields,
         )
     else:
-        logs = unify.get_logs(
+        logs = unisdk.get_logs(
             context=context,
             project=project,
             filter=row_filter,
@@ -705,7 +705,7 @@ def backfill_rows(
     # Determine unique id column if not supplied
     if unique_id_field is None:
         try:
-            ctx_info = unify.get_context(context, project=project)
+            ctx_info = unisdk.get_context(context, project=project)
             unique_id_field = ctx_info.get("unique_keys")
             if isinstance(unique_id_field, list):
                 unique_id_field = unique_id_field[0] if unique_id_field else None
@@ -743,7 +743,7 @@ def backfill_rows(
                     ),
                 ),
             )
-            fallback_logs = unify.get_logs(
+            fallback_logs = unisdk.get_logs(
                 context=context,
                 project=project,
                 filter=row_filter,
@@ -754,7 +754,7 @@ def backfill_rows(
             )
         else:
             try:
-                fallback_logs = unify.get_logs(
+                fallback_logs = unisdk.get_logs(
                     context=context,
                     project=project,
                     filter=row_filter,
@@ -768,7 +768,7 @@ def backfill_rows(
                 # created lazily), treat as "no rows to backfill" rather than failing
                 # the caller's semantic search.
                 try:
-                    from unify.utils.http import RequestError as _UnifyRequestError
+                    from unisdk.utils.http import RequestError as _UnifyRequestError
 
                     if isinstance(e, _UnifyRequestError):
                         status = getattr(

--- a/unity/contact_manager/backend_sync.py
+++ b/unity/contact_manager/backend_sync.py
@@ -48,7 +48,7 @@ def sync_user_timezone(assistant_id: int, target_email: str, timezone: str) -> b
         return False
 
     try:
-        from unify.utils import http
+        from unisdk.utils import http
 
         url = f"{base_url}/admin/assistant/update-user"
         headers = {"Authorization": f"Bearer {admin_key}"}
@@ -81,7 +81,7 @@ def sync_user_bio(assistant_id: int, target_email: str, bio: str) -> bool:
         return False
 
     try:
-        from unify.utils import http
+        from unisdk.utils import http
 
         url = f"{base_url}/admin/assistant/update-user"
         headers = {"Authorization": f"Bearer {admin_key}"}
@@ -119,7 +119,7 @@ def sync_assistant_timezone(assistant_id: int, timezone: str) -> bool:
         return False
 
     try:
-        from unify.utils import http
+        from unisdk.utils import http
 
         url = f"{base_url}/admin/assistant/{int(assistant_id)}"
         headers = {"Authorization": f"Bearer {admin_key}"}
@@ -151,7 +151,7 @@ def sync_assistant_about(assistant_id: int, about: str) -> bool:
         return False
 
     try:
-        from unify.utils import http
+        from unisdk.utils import http
 
         url = f"{base_url}/admin/assistant/{int(assistant_id)}"
         headers = {"Authorization": f"Bearer {admin_key}"}
@@ -186,7 +186,7 @@ def sync_assistant_job_title(assistant_id: int, job_title: str) -> bool:
         normalized = None
 
     try:
-        from unify.utils import http
+        from unisdk.utils import http
 
         url = f"{base_url}/admin/assistant/{int(assistant_id)}"
         headers = {"Authorization": f"Bearer {admin_key}"}

--- a/unity/contact_manager/contact_manager.py
+++ b/unity/contact_manager/contact_manager.py
@@ -12,7 +12,7 @@ from ..common.embed_utils import ensure_vector_column
 from ..common.tool_outcome import ToolErrorException, ToolOutcome
 from ..common.tool_spec import read_only, manager_tool, ToolSpec
 
-import unify
+import unisdk
 from .types.contact import Contact
 from .base import BaseContactManager
 from ..common.context_registry import ContextRegistry, TableContext
@@ -264,7 +264,7 @@ class ContactManager(BaseContactManager):
             )
             return
 
-        from unify.utils import http
+        from unisdk.utils import http
 
         target_scope, target_team_id = self._membership_target_for_destination(
             destination,
@@ -510,7 +510,7 @@ class ContactManager(BaseContactManager):
 
     @functools.wraps(BaseContactManager.clear, updated=())
     def clear(self) -> None:
-        unify.delete_context(self._ctx)
+        unisdk.delete_context(self._ctx)
 
         # Clear local cache and custom-field state so subsequent reads/writes
         # operate against a clean slate
@@ -532,7 +532,7 @@ class ContactManager(BaseContactManager):
 
             for _ in range(3):
                 try:
-                    unify.get_fields(context=self._ctx)
+                    unisdk.get_fields(context=self._ctx)
                     break
                 except Exception:
                     _time.sleep(0.05)
@@ -615,7 +615,7 @@ class ContactManager(BaseContactManager):
                     filt = f"contact_id == {misses[0]}"
                 else:
                     filt = f"contact_id in [{', '.join(str(x) for x in misses)}]"
-                rows = unify.get_logs(
+                rows = unisdk.get_logs(
                     context=context,
                     filter=filt,
                     limit=len(misses),
@@ -715,7 +715,7 @@ class ContactManager(BaseContactManager):
             grouping level, or a list such as ``[\"should_respond\", \"contact_id\"]``
             to group hierarchically in that order. When provided, the result
             becomes a nested mapping keyed by group values, mirroring
-            :func:`unify.get_logs_metric` behaviour.
+            :func:`unisdk.get_logs_metric` behaviour.
 
         Returns
         -------
@@ -827,7 +827,7 @@ class ContactManager(BaseContactManager):
             from_fields.extend(sorted(self._known_custom_fields))
 
         def fetcher(spec, row_filter, _sorting, fetch_limit):
-            logs = unify.get_logs(
+            logs = unisdk.get_logs(
                 context=spec.context,
                 filter=row_filter,
                 offset=0,
@@ -1338,7 +1338,7 @@ class ContactManager(BaseContactManager):
         store = self._data_store_for_context(context)
 
         # Fetch the contact row (public fields only)
-        rows = unify.get_logs(
+        rows = unisdk.get_logs(
             context=context,
             filter=f"contact_id == {int(contact_id)}",
             limit=1,
@@ -1396,7 +1396,7 @@ class ContactManager(BaseContactManager):
 
         # Best-effort de-duplication per (medium, contact_detail)
         for detail, med in detail_media:
-            existing = unify.get_logs(
+            existing = unisdk.get_logs(
                 context=blacklist_context,
                 filter=f"medium == '{med.value}' and contact_detail == '{detail}'",
                 limit=1,
@@ -1531,7 +1531,7 @@ class ContactManager(BaseContactManager):
 
         self_contact_id = int(SESSION_DETAILS.self_contact_id)
         boss_contact_id = int(SESSION_DETAILS.boss_contact_id)
-        existing_logs = unify.get_logs(
+        existing_logs = unisdk.get_logs(
             context=self._ctx,
             filter=f"contact_id == {self_contact_id} or contact_id == {boss_contact_id}",
             limit=2,

--- a/unity/contact_manager/custom_columns.py
+++ b/unity/contact_manager/custom_columns.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 from typing import Any, Dict, Optional
 
-import unify
+import unisdk
 
 from ..knowledge_manager.types import ColumnType
 
@@ -29,7 +29,10 @@ def create_custom_column(
     if column_description is not None:
         column_info["description"] = column_description
 
-    response = unify.create_fields(fields={column_name: column_info}, context=self._ctx)
+    response = unisdk.create_fields(
+        fields={column_name: column_info},
+        context=self._ctx,
+    )
 
     # Best-effort hygiene for DataStore rows after schema changes is done by callers/tests
     try:
@@ -46,7 +49,7 @@ def delete_custom_column(self, *, column_name: str) -> Dict[str, str]:
     if column_name in self._REQUIRED_COLUMNS:
         raise ValueError(f"Cannot delete required column '{column_name}'.")
 
-    response = unify.delete_fields(fields=[column_name], context=self._ctx)
+    response = unisdk.delete_fields(fields=[column_name], context=self._ctx)
 
     # Update local view of known custom columns on success & scrub DataStore
     try:

--- a/unity/contact_manager/ops.py
+++ b/unity/contact_manager/ops.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, Optional
 
-import unify
+import unisdk
 from pydantic import ValidationError
 
 from ..common.authorship import strip_authoring_assistant_id
@@ -58,7 +58,7 @@ def _maybe_sync_timezone_to_backend(
 
     if row is None:
         try:
-            rows = unify.get_logs(
+            rows = unisdk.get_logs(
                 context=context_name,
                 filter=f"contact_id == {contact_id}",
                 limit=1,
@@ -109,7 +109,7 @@ def _maybe_sync_bio_to_backend(
 
     if row is None:
         try:
-            rows = unify.get_logs(
+            rows = unisdk.get_logs(
                 context=context_name,
                 filter=f"contact_id == {contact_id}",
                 limit=1,
@@ -312,7 +312,7 @@ def update_contact(
         return ToolOutcome(output="No effective changes after normalization.")
 
     if _log_id is None:
-        target_ids = unify.get_logs(
+        target_ids = unisdk.get_logs(
             context=context_name,
             filter=f"contact_id == {contact_id}",
             return_ids_only=True,
@@ -329,14 +329,14 @@ def update_contact(
     else:
         log_to_update_id = _log_id
 
-    unify.update_logs(
+    unisdk.update_logs(
         logs=[log_to_update_id],
         context=context_name,
         entries=updates_dict,
         overwrite=True,
     )
     try:
-        rows = unify.get_logs(
+        rows = unisdk.get_logs(
             context=context_name,
             filter=f"contact_id == {contact_id}",
             limit=1,
@@ -398,7 +398,7 @@ def delete_contact(
 
     if _log_id is None:
         # Fetch with is_system to check for org member protection
-        rows = unify.get_logs(
+        rows = unisdk.get_logs(
             context=context_name,
             filter=f"contact_id == {contact_id}",
             limit=2,
@@ -426,7 +426,7 @@ def delete_contact(
             raise RuntimeError("Cannot delete assistant self or boss system contacts.")
         resolved_id = _log_id
 
-    unify.delete_logs(context=context_name, logs=resolved_id)
+    unisdk.delete_logs(context=context_name, logs=resolved_id)
     try:
         store.delete(contact_id)
     except Exception:
@@ -453,7 +453,7 @@ def merge_contacts(
         )
     overrides = overrides or {}
 
-    rows = unify.get_logs(
+    rows = unisdk.get_logs(
         context=context_name,
         filter=f"contact_id in [{contact_id_1}, {contact_id_2}]",
         limit=2,
@@ -537,14 +537,14 @@ def merge_contacts(
 
     # Rewrite transcripts BEFORE deleting the merged contact to avoid FK SET NULL
     try:
-        ctxs = unify.get_active_context()
+        ctxs = unisdk.get_active_context()
         read_ctx = ctxs.get("read")
     except Exception:
         read_ctx = None
     transcripts_ctx = f"{read_ctx}/Transcripts" if read_ctx else "Transcripts"
 
     try:
-        referenced = unify.get_logs(
+        referenced = unisdk.get_logs(
             context=transcripts_ctx,
             filter=f"(sender_id == {delete_id}) or ({delete_id} in receiver_ids)",
             limit=1,

--- a/unity/contact_manager/storage.py
+++ b/unity/contact_manager/storage.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional, Union
 
-import unify
+import unisdk
 
 from ..common.context_store import TableStore
 from ..common.model_to_fields import model_to_fields
@@ -87,7 +87,7 @@ def get_contact_info(
             filt = f"contact_id == {misses[0]}"
         else:
             filt = f"contact_id in [{', '.join(str(x) for x in misses)}]"
-        rows = unify.get_logs(
+        rows = unisdk.get_logs(
             context=self._ctx,
             filter=filt,
             limit=len(misses),
@@ -110,7 +110,7 @@ def get_contact_info(
 
 def num_contacts(self) -> int:
     """Return total number of contacts in the context."""
-    ret = unify.get_logs_metric(
+    ret = unisdk.get_logs_metric(
         metric="count",
         key="contact_id",
         context=self._ctx,

--- a/unity/contact_manager/system_contacts.py
+++ b/unity/contact_manager/system_contacts.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import logging
 from typing import Any, Dict, List
 
-import unify
-from unify.utils.http import RequestError
+import unisdk
+from unisdk.utils.http import RequestError
 
 _log = logging.getLogger(__name__)
 
@@ -65,7 +65,7 @@ def _upsert_personal_contact_membership(
         )
         return
 
-    from unify.utils import http
+    from unisdk.utils import http
 
     assistant_id = int(SESSION_DETAILS.assistant.agent_id)
     url = (
@@ -133,7 +133,7 @@ def _resolve_user_details(self) -> Dict[str, Any]:
 
     # In production (SESSION_DETAILS initialized), fetch real user info
     try:
-        data: Any = unify.get_user_basic_info()
+        data: Any = unisdk.get_user_basic_info()
     except Exception:
         _log.warning(
             "Failed to fetch user details from Orchestra, using session details",
@@ -555,7 +555,7 @@ def _fetch_org_members() -> List[Dict[str, Any]]:
         return []
 
     try:
-        from unify.utils import http
+        from unisdk.utils import http
 
         url = f"{base_url}/organizations/members"
         headers = {"Authorization": f"Bearer {api_key}"}
@@ -587,7 +587,7 @@ def provision_org_member_contacts(self) -> None:
     # Get primary user email to skip
     primary_user_email = None
     try:
-        primary_user_rows = unify.get_logs(
+        primary_user_rows = unisdk.get_logs(
             context=self._ctx,
             filter=f"contact_id == {SESSION_DETAILS.boss_contact_id}",
             limit=1,
@@ -615,7 +615,7 @@ def provision_org_member_contacts(self) -> None:
 
         try:
             # Check if contact with this email already exists
-            existing = unify.get_logs(
+            existing = unisdk.get_logs(
                 context=self._ctx,
                 filter=f"email_address == '{email}'",
                 limit=1,

--- a/unity/conversation_manager/assistant_jobs_api.py
+++ b/unity/conversation_manager/assistant_jobs_api.py
@@ -17,7 +17,7 @@ import time
 import traceback
 
 import requests
-import unify
+import unisdk
 
 log = logging.getLogger(__name__)
 
@@ -36,7 +36,7 @@ CONTEXT = "startup_events"
 def ensure_project_exists(api_key: str) -> None:
     """Create the AssistantJobs project if it doesn't already exist."""
     try:
-        unify.create_project(PROJECT_NAME, api_key=api_key)
+        unisdk.create_project(PROJECT_NAME, api_key=api_key)
     except Exception:
         log.exception("Error ensuring project exists")
 
@@ -53,9 +53,9 @@ def get_assistant_logs(
 ) -> list:
     """Fetch AssistantJobs log entries matching *filter_expr*.
 
-    Returns a list of ``unify.Log`` objects.
+    Returns a list of ``unisdk.Log`` objects.
     """
-    return unify.get_logs(
+    return unisdk.get_logs(
         project=PROJECT_NAME,
         context=CONTEXT,
         filter=filter_expr,
@@ -64,9 +64,9 @@ def get_assistant_logs(
     )
 
 
-def create_assistant_log(api_key: str, **entries) -> "unify.Log":
+def create_assistant_log(api_key: str, **entries) -> "unisdk.Log":
     """Create a new AssistantJobs audit log entry."""
-    return unify.log(
+    return unisdk.log(
         project=PROJECT_NAME,
         context=CONTEXT,
         api_key=api_key,

--- a/unity/conversation_manager/domains/managers_utils.py
+++ b/unity/conversation_manager/domains/managers_utils.py
@@ -45,7 +45,7 @@ def ensure_runtime_context(*, strict: bool = False) -> str:
     full_ctx = f"{SESSION_DETAILS.user_context}/{SESSION_DETAILS.assistant_context}"
     context_set = False
     try:
-        import unify as _unify
+        import unisdk as _unify
 
         active_ctx = _unify.get_active_context() or {}
         if active_ctx.get("read") != full_ctx or active_ctx.get("write") != full_ctx:

--- a/unity/conversation_manager/medium_scripts/common.py
+++ b/unity/conversation_manager/medium_scripts/common.py
@@ -1529,12 +1529,12 @@ async def hydrate_fast_brain_history(
 ) -> list[str]:
     """Load recent Comms events from the backend and render them for the fast brain.
 
-    Queries Orchestra directly via ``unify.get_logs()`` rather than going
+    Queries Orchestra directly via ``unisdk.get_logs()`` rather than going
     through the EventBus proxy, which is not initialised in the voice agent
     subprocess.  Returns a chronologically ordered list of rendered strings
     suitable for injecting as historical context before the current call begins.
     """
-    import unify
+    import unisdk
 
     context = (
         f"{SESSION_DETAILS.user_context}/" f"{SESSION_DETAILS.assistant_context}/Events"
@@ -1542,7 +1542,7 @@ async def hydrate_fast_brain_history(
 
     try:
         logs = await asyncio.to_thread(
-            unify.get_logs,
+            unisdk.get_logs,
             context=context,
             filter='type == "Comms"',
             sorting={"timestamp": "descending"},

--- a/unity/coordinator_manager/coordinator_manager.py
+++ b/unity/coordinator_manager/coordinator_manager.py
@@ -12,8 +12,8 @@ import functools
 from collections.abc import Callable, Sequence
 from typing import Any, Literal, TypedDict
 
-import unify
-from unify.utils.http import RequestError
+import unisdk
+from unisdk.utils.http import RequestError
 
 from unity.common.colleague_cache import (
     assistant_display_name as resolve_assistant_display_name,
@@ -329,7 +329,7 @@ class _CoordinatorToolCall:
             ],
         )
         try:
-            result = unify.create_assistant(
+            result = unisdk.create_assistant(
                 first_name=first_name,
                 surname=surname,
                 config=assistant_config,
@@ -411,7 +411,7 @@ class _CoordinatorToolCall:
             )
             return error
         try:
-            result = unify.delete_assistant(
+            result = unisdk.delete_assistant(
                 agent_id,
                 api_key=SESSION_DETAILS.unify_key,
             )
@@ -500,7 +500,7 @@ class _CoordinatorToolCall:
             )
             return error
         try:
-            result = unify.update_assistant_config(
+            result = unisdk.update_assistant_config(
                 agent_id,
                 dict(config),
                 api_key=SESSION_DETAILS.unify_key,
@@ -557,7 +557,7 @@ class _CoordinatorToolCall:
 
         list_all_org = resolved_organization_id is not None
         try:
-            assistants = unify.list_assistants(
+            assistants = unisdk.list_assistants(
                 phone=phone,
                 email=email,
                 agent_id=agent_id,
@@ -594,7 +594,7 @@ class _CoordinatorToolCall:
         if _is_tool_error(resolved_organization_id):
             return resolved_organization_id
         try:
-            return unify.list_org_members(
+            return unisdk.list_org_members(
                 resolved_organization_id,
                 api_key=SESSION_DETAILS.unify_key,
             )
@@ -676,7 +676,7 @@ class _CoordinatorToolCall:
             )
             return resolved_organization_id
         try:
-            result = unify.invite_org_member(
+            result = unisdk.invite_org_member(
                 resolved_organization_id,
                 normalized_email,
                 role_name=resolved_role_name,
@@ -796,7 +796,7 @@ class _CoordinatorToolCall:
             )
             return error
         try:
-            result = unify.delegate_to_colleague(
+            result = unisdk.delegate_to_colleague(
                 target_assistant_id,
                 instruction=normalized_instruction,
                 intent=intent,
@@ -868,7 +868,7 @@ class _CoordinatorToolCall:
             ],
         )
         try:
-            result = unify.create_team(
+            result = unisdk.create_team(
                 resolved_organization_id,
                 name=name,
                 description=description,
@@ -949,7 +949,7 @@ class _CoordinatorToolCall:
             )
             return error
         try:
-            result = unify.delete_team(
+            result = unisdk.delete_team(
                 resolved_organization_id,
                 team_id,
                 api_key=SESSION_DETAILS.unify_key,
@@ -1035,7 +1035,7 @@ class _CoordinatorToolCall:
             )
             return error
         try:
-            result = unify.update_team(
+            result = unisdk.update_team(
                 resolved_organization_id,
                 team_id,
                 patch,
@@ -1178,7 +1178,7 @@ class _CoordinatorToolCall:
                 return error
 
         try:
-            result = unify.add_team_member(
+            result = unisdk.add_team_member(
                 resolved_organization_id,
                 team_id,
                 assistant_id=assistant_id,
@@ -1429,7 +1429,7 @@ class _CoordinatorToolCall:
             return invalid
 
         try:
-            result = unify.remove_team_member(
+            result = unisdk.remove_team_member(
                 resolved_organization_id,
                 team_id,
                 assistant_id,
@@ -1479,7 +1479,7 @@ class _CoordinatorToolCall:
         if _is_tool_error(resolved_organization_id):
             return resolved_organization_id
         try:
-            teams = unify.list_teams(
+            teams = unisdk.list_teams(
                 resolved_organization_id,
                 api_key=SESSION_DETAILS.unify_key,
             )
@@ -1520,7 +1520,7 @@ class _CoordinatorToolCall:
         if not reachable:
             return _team_not_found(team_id)
         try:
-            return unify.list_team_members(
+            return unisdk.list_team_members(
                 resolved_organization_id,
                 team_id,
                 api_key=SESSION_DETAILS.unify_key,
@@ -1556,7 +1556,7 @@ class _CoordinatorToolCall:
         if not reachable:
             return _assistant_not_found(assistant_id)
         try:
-            return unify.list_teams_for_assistant(
+            return unisdk.list_teams_for_assistant(
                 assistant_id,
                 api_key=SESSION_DETAILS.unify_key,
             )
@@ -1645,7 +1645,7 @@ class _CoordinatorToolCall:
             organization_id=organization_id,
         )
         try:
-            created = unify.create_assistant(
+            created = unisdk.create_assistant(
                 first_name=assistant_first_name,
                 surname=assistant_surname,
                 config=resolved_assistant_config,
@@ -1711,7 +1711,7 @@ class _CoordinatorToolCall:
             return {"status": "reused", "team": team}
 
         try:
-            created = unify.create_team(
+            created = unisdk.create_team(
                 organization_id,
                 name=team_name,
                 description=team_description,
@@ -1739,7 +1739,7 @@ class _CoordinatorToolCall:
         ):
             return {"status": "already_member"}
         try:
-            unify.add_team_member(
+            unisdk.add_team_member(
                 organization_id,
                 team_id,
                 assistant_id=assistant_id,
@@ -2209,7 +2209,7 @@ class CoordinatorManager(metaclass=SingletonABCMeta):
             return []
 
         try:
-            members = unify.list_org_members(
+            members = unisdk.list_org_members(
                 SESSION_DETAILS.org_id,
                 api_key=SESSION_DETAILS.unify_key,
             )

--- a/unity/dashboard_manager/dashboard_manager.py
+++ b/unity/dashboard_manager/dashboard_manager.py
@@ -67,9 +67,9 @@ LAYOUTS_TABLE = "Dashboards/Layouts"
 def _get_active_project() -> str:
     """Get the currently active Unify project name."""
     try:
-        import unify
+        import unisdk
 
-        project = unify.active_project()
+        project = unisdk.active_project()
         return project or ""
     except Exception:
         return ""

--- a/unity/dashboard_manager/ops/tile_ops.py
+++ b/unity/dashboard_manager/ops/tile_ops.py
@@ -11,7 +11,7 @@ import re
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, List, Optional, Sequence, Union
 
-import unify
+import unisdk
 
 from unity.common.context_registry import ContextRegistry
 from unity.common.join_utils import rewrite_join_paths
@@ -92,7 +92,7 @@ def resolve_binding_contexts(
     """Resolve all context paths in *bindings* to fully qualified form.
 
     Fetches all contexts scoped to the requested root via
-    ``unify.get_contexts(prefix=base)`` and resolves each binding's context
+    ``unisdk.get_contexts(prefix=base)`` and resolves each binding's context
     path(s) through :func:`_match_context`. For join bindings, table
     references embedded in ``join_expr`` and ``select`` keys are rewritten
     to match the resolved table names.
@@ -102,12 +102,12 @@ def resolve_binding_contexts(
     """
     base = base_context or ContextRegistry._base_context
     if not base:
-        active = unify.get_active_context()
+        active = unisdk.get_active_context()
         base = (active or {}).get("read", "")
     if not base:
         return bindings
 
-    known = set(unify.get_contexts(prefix=base).keys())
+    known = set(unisdk.get_contexts(prefix=base).keys())
     if not known:
         return bindings
 

--- a/unity/data_manager/ops/ingest_ops.py
+++ b/unity/data_manager/ops/ingest_ops.py
@@ -30,7 +30,7 @@ import time
 import uuid
 from typing import Any, Callable, Dict, List, Literal, Optional, TYPE_CHECKING
 
-import unify as _unify
+import unisdk as _unify
 
 from unity.common.embed_utils import (
     ensure_derived_column as _ensure_derived_column,

--- a/unity/data_manager/ops/join_ops.py
+++ b/unity/data_manager/ops/join_ops.py
@@ -14,7 +14,7 @@ import logging
 import uuid
 from typing import Any, Callable, Dict, List, Optional, Union
 
-import unify
+import unisdk
 
 from unity.common.filter_utils import normalize_filter_expr
 from unity.common.search_utils import table_search_top_k
@@ -80,7 +80,7 @@ def join_tables_impl(
         dest_table,
     )
 
-    unify.join_logs(
+    unisdk.join_logs(
         pair_of_args=(
             {
                 "context": left_table,
@@ -213,7 +213,7 @@ def filter_join_impl(
         tables[1],
     )
 
-    result = unify.join_query(
+    result = unisdk.join_query(
         pair_of_args=(
             {
                 "context": tables[0],
@@ -304,7 +304,7 @@ def reduce_join_impl(
                 f"Missing: {', '.join(sorted(missing))}",
             )
 
-    return unify.join_query(
+    return unisdk.join_query(
         pair_of_args=(
             {
                 "context": tables[0],
@@ -407,7 +407,7 @@ def search_join_impl(
         return rows
     finally:
         try:
-            unify.delete_context(dest_context)
+            unisdk.delete_context(dest_context)
         except Exception:
             pass
 
@@ -556,7 +556,7 @@ def filter_multi_join_impl(
     try:
         rows: List[Dict[str, Any]] = [
             lg.entries
-            for lg in unify.get_logs(
+            for lg in unisdk.get_logs(
                 context=previous_ctx,
                 filter=result_where,
                 offset=result_offset,
@@ -569,7 +569,7 @@ def filter_multi_join_impl(
         # Clean up temporary contexts
         for ctx in tmp_contexts:
             try:
-                unify.delete_context(ctx)
+                unisdk.delete_context(ctx)
             except Exception:
                 pass
 
@@ -699,6 +699,6 @@ def search_multi_join_impl(
         # Clean up temporary contexts
         for ctx in tmp_contexts:
             try:
-                unify.delete_context(ctx)
+                unisdk.delete_context(ctx)
             except Exception:
                 pass

--- a/unity/data_manager/ops/mutation_ops.py
+++ b/unity/data_manager/ops/mutation_ops.py
@@ -10,8 +10,8 @@ from __future__ import annotations
 import logging
 from typing import Any, Dict, List, Optional
 
-import unify
-from unify.utils.http import RequestError
+import unisdk
+from unisdk.utils.http import RequestError
 
 from unity.common.filter_utils import normalize_filter_expr
 from unity.common.authorship import (
@@ -121,7 +121,7 @@ def update_rows_impl(
     filter_expr = normalize_filter_expr(filter)
 
     # Get matching rows
-    logs = unify.get_logs(context=context, filter=filter_expr)
+    logs = unisdk.get_logs(context=context, filter=filter_expr)
 
     if not logs:
         return 0
@@ -146,7 +146,7 @@ def update_rows_impl(
         # Delete old row
         log_id = log.id if hasattr(log, "id") else None
         if log_id:
-            unify.delete_logs(context=context, logs=[log_id])
+            unisdk.delete_logs(context=context, logs=[log_id])
 
         # Merge updates
         new_entries = {**existing, **cleaned_updates}
@@ -215,7 +215,7 @@ def delete_rows_impl(
     elif filter is not None:
         # Get log IDs using return_ids_only for efficiency
         filter_expr = normalize_filter_expr(filter)
-        result = unify.get_logs(
+        result = unisdk.get_logs(
             context=context,
             filter=filter_expr,
             return_ids_only=True,
@@ -227,7 +227,7 @@ def delete_rows_impl(
         return 0
 
     # Delete the logs
-    unify.delete_logs(
+    unisdk.delete_logs(
         context=context,
         logs=ids_to_delete,
         delete_empty_logs=delete_empty_rows,

--- a/unity/data_manager/ops/plot_ops.py
+++ b/unity/data_manager/ops/plot_ops.py
@@ -6,7 +6,7 @@ These are called by DataManager methods and should not be used directly.
 
 Architecture Note:
     Currently uses Console API (POST {ORCHESTRA_URL}/logs/plot).
-    This is the integration path until an equivalent path exists through unify.
+    This is the integration path until an equivalent path exists through unisdk.
 """
 
 from __future__ import annotations
@@ -172,9 +172,9 @@ def _get_active_project() -> str:
     Get the currently active Unify project name.
     """
     try:
-        import unify
+        import unisdk
 
-        project = unify.active_project()
+        project = unisdk.active_project()
         return project if project else ""
     except Exception:
         return ""
@@ -227,7 +227,7 @@ def generate_plot(
         project_name = _get_active_project()
         if not project_name:
             return PlotResult(
-                error="No active Unify project. Set project with unify.activate().",
+                error="No active Unify project. Set project with unisdk.activate().",
                 title=config.title,
                 context=context,
             )
@@ -357,7 +357,7 @@ def generate_plots_batch(
             base_title = config.title or f"{config.plot_type} chart"
             return [
                 PlotResult(
-                    error="No active Unify project. Set project with unify.activate().",
+                    error="No active Unify project. Set project with unisdk.activate().",
                     title=base_title,
                     context=ctx,
                 )

--- a/unity/data_manager/ops/query_ops.py
+++ b/unity/data_manager/ops/query_ops.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import logging
 from typing import Any, Dict, List, Optional, Union
 
-import unify
+import unisdk
 
 from unity.common.filter_utils import normalize_filter_expr
 from unity.common.search_utils import table_search_top_k
@@ -96,7 +96,7 @@ def filter_impl(
     if order_by:
         sorting = {order_by: "descending" if descending else "ascending"}
 
-    logs = unify.get_logs(
+    logs = unisdk.get_logs(
         context=context,
         filter=filter_expr,
         from_fields=from_fields,

--- a/unity/data_manager/ops/table_ops.py
+++ b/unity/data_manager/ops/table_ops.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
-import unify
+import unisdk
 
 from unity.common.authorship import fields_with_authoring, is_shared_authored_context
 
@@ -59,7 +59,7 @@ def create_table_impl(
     """
     logger.debug("Creating table context: %s", context)
 
-    unify.create_context(
+    unisdk.create_context(
         context,
         description=description,
         unique_keys=unique_keys,
@@ -69,7 +69,7 @@ def create_table_impl(
     if is_shared_authored_context(context):
         fields = fields_with_authoring(fields)
     if fields:
-        unify.create_fields(fields, context=context)
+        unisdk.create_fields(fields, context=context)
 
     return context
 
@@ -104,10 +104,10 @@ def describe_table_impl(context: str) -> "TableDescription":
     logger.debug("Describing table: %s", context)
 
     # Get context info
-    ctx_info = unify.get_context(context)
+    ctx_info = unisdk.get_context(context)
 
     # Get fields/columns
-    columns_raw = unify.get_fields(context=context) or {}
+    columns_raw = unisdk.get_fields(context=context) or {}
 
     # Detect embedding columns (pattern: _<name>_emb)
     embedding_cols = [
@@ -198,12 +198,14 @@ def list_tables_impl(
         include_column_info,
     )
 
-    raw_contexts = unify.get_contexts(prefix=prefix) if prefix else unify.get_contexts()
+    raw_contexts = (
+        unisdk.get_contexts(prefix=prefix) if prefix else unisdk.get_contexts()
+    )
 
     if not raw_contexts:
         return {} if include_column_info else []
 
-    # unify.get_contexts returns either:
+    # unisdk.get_contexts returns either:
     # - A list of dicts with 'name' and other fields (newer SDK)
     # - A dict mapping context_path -> context_info (older SDK)
     if isinstance(raw_contexts, list):
@@ -219,7 +221,7 @@ def list_tables_impl(
     else:
         all_contexts = {}
 
-    # Filter by prefix if needed (unify.get_contexts may not filter perfectly)
+    # Filter by prefix if needed (unisdk.get_contexts may not filter perfectly)
     if prefix:
         all_contexts = {k: v for k, v in all_contexts.items() if k.startswith(prefix)}
 
@@ -255,7 +257,7 @@ def delete_table_impl(context: str, *, dangerous_ok: bool = False) -> None:
             "This is a safety guard to prevent accidental data loss.",
         )
     logger.info("Deleting table context: %s", context)
-    unify.delete_context(context)
+    unisdk.delete_context(context)
 
 
 def get_columns_impl(table: str) -> Dict[str, Any]:
@@ -282,7 +284,7 @@ def get_columns_impl(table: str) -> Dict[str, Any]:
     """
     logger.debug("Getting columns for table: %s", table)
     try:
-        columns = unify.get_fields(context=table)
+        columns = unisdk.get_fields(context=table)
         return dict(columns) if columns else {}
     except Exception as e:
         logger.warning("Failed to get columns for %s: %s", table, e)
@@ -312,7 +314,7 @@ def get_table_impl(context: str) -> Dict[str, Any]:
     """
     logger.debug("Getting table metadata for: %s", context)
     try:
-        ctx_info = unify.get_context(context)
+        ctx_info = unisdk.get_context(context)
         return dict(ctx_info) if isinstance(ctx_info, dict) else {}
     except Exception as e:
         logger.warning("Failed to get table %s: %s", context, e)
@@ -343,7 +345,7 @@ def rename_table_impl(old_context: str, new_context: str) -> Dict[str, str]:
         If rename operation fails.
     """
     logger.info("Renaming table context: %s -> %s", old_context, new_context)
-    return unify.rename_context(old_context, new_context)
+    return unisdk.rename_context(old_context, new_context)
 
 
 def create_column_impl(
@@ -393,7 +395,7 @@ def create_column_impl(
         column_type,
         context,
     )
-    return unify.create_fields(
+    return unisdk.create_fields(
         context=context,
         fields={column_name: {"type": column_type, "mutable": mutable}},
         backfill_logs=backfill_logs,
@@ -428,7 +430,7 @@ def delete_column_impl(
         If column deletion fails.
     """
     logger.info("Deleting column %s from %s", column_name, context)
-    return unify.delete_fields(fields=[column_name], context=context)
+    return unisdk.delete_fields(fields=[column_name], context=context)
 
 
 def rename_column_impl(
@@ -473,7 +475,7 @@ def rename_column_impl(
         raise ValueError("Cannot rename a column to reserved name 'id'.")
 
     logger.debug("Renaming column %s -> %s in %s", old_name, new_name, context)
-    return unify.rename_field(name=old_name, new_name=new_name, context=context)
+    return unisdk.rename_field(name=old_name, new_name=new_name, context=context)
 
 
 def create_derived_column_impl(
@@ -520,7 +522,7 @@ def create_derived_column_impl(
     )
     # Transform equation to Unify's internal format
     transformed_equation = equation.replace("{", "{lg:")
-    return unify.create_derived_logs(
+    return unisdk.create_derived_logs(
         context=context,
         key=column_name,
         equation=transformed_equation,

--- a/unity/data_manager/ops/table_view_ops.py
+++ b/unity/data_manager/ops/table_view_ops.py
@@ -150,9 +150,9 @@ def _make_table_view_request(
 def _get_active_project() -> str:
     """Get the currently active Unify project name."""
     try:
-        import unify
+        import unisdk
 
-        project = unify.active_project()
+        project = unisdk.active_project()
         return project if project else ""
     except Exception:
         return ""
@@ -194,7 +194,7 @@ def generate_table_view(
         project_name = _get_active_project()
         if not project_name:
             return TableViewResult(
-                error="No active Unify project. Set project with unify.activate().",
+                error="No active Unify project. Set project with unisdk.activate().",
                 title=title,
                 context=context,
             )
@@ -307,7 +307,7 @@ def generate_table_views_batch(
         if not project_name:
             return [
                 TableViewResult(
-                    error="No active Unify project. Set project with unify.activate().",
+                    error="No active Unify project. Set project with unisdk.activate().",
                     title=title,
                     context=ctx,
                 )

--- a/unity/data_manager/types/table.py
+++ b/unity/data_manager/types/table.py
@@ -58,7 +58,7 @@ class TableSchema(BaseModel):
     # This is inconsistent with `create_context` which expects a dict.
     #
     # Failing example: Actor calls `primitives.data.describe_table("Data/Test/...")` which
-    # internally calls `unify.get_context()`. The response has `unique_keys: []` (empty list)
+    # internally calls `unisdk.get_context()`. The response has `unique_keys: []` (empty list)
     # which fails Pydantic validation expecting `dict[str, str] | None`.
     #
     # Workaround: Convert list to None until backend is updated to return dict format.

--- a/unity/events/event_bus.py
+++ b/unity/events/event_bus.py
@@ -4,7 +4,7 @@ restricted to Pydantic payload types declared in *events/types/*.
 
 from __future__ import annotations
 
-import unify
+import unisdk
 import json
 import asyncio
 import datetime as dt
@@ -315,7 +315,7 @@ class Subscription(BaseModel):
 
 
 class EventBus:
-    _LOGGER = unify.AsyncLoggerManager(name="EventBus", num_consumers=16)
+    _LOGGER = unisdk.AsyncLoggerManager(name="EventBus", num_consumers=16)
 
     # Class-level flag to control event publishing. Initialized from SETTINGS on
     # first EventBus instantiation. Can be overridden (e.g., tests use markers).
@@ -397,7 +397,7 @@ class EventBus:
         self._default_window = 50
 
         # ── Unify setup ────────────────────────────────────────────────
-        active_ctx = unify.get_active_context()
+        active_ctx = unisdk.get_active_context()
         base_ctx = active_ctx["write"]
         if not base_ctx:
             # Ensure the global assistant/context is selected before we derive our sub-context
@@ -407,22 +407,22 @@ class EventBus:
                 )  # local to avoid cycles
 
                 _ensure_initialised()
-                active_ctx = unify.get_active_context()
+                active_ctx = unisdk.get_active_context()
                 base_ctx = active_ctx["write"]
             except Exception:
                 # If ensure fails (e.g. offline tests), proceed; downstream will fall back safely
                 pass
         self._global_ctx = f"{base_ctx}/Events" if base_ctx else "Events"
-        unify.create_context(self._global_ctx)
+        unisdk.create_context(self._global_ctx)
 
         # Persisted subscription metadata lives here
         self._callbacks_ctx = f"{self._global_ctx}/_callbacks"
-        unify.create_context(
+        unisdk.create_context(
             self._callbacks_ctx,
             unique_keys={"row_id": "int"},
             auto_counting={"row_id": None},
         )
-        ctxs = unify.get_contexts(prefix=f"{self._global_ctx}/")
+        ctxs = unisdk.get_contexts(prefix=f"{self._global_ctx}/")
         self._window_sizes: Dict[str, int] = {
             ctx.split("/")[-1]: self._default_window for ctx in ctxs
         }
@@ -519,13 +519,13 @@ class EventBus:
                 continue
 
             # Create context
-            unify.create_context(ctx_name)
+            unisdk.create_context(ctx_name)
 
             # Create fields from Pydantic model + common event fields
             try:
                 payload_fields = model_to_fields(payload_model)
                 all_fields = {**self._COMMON_EVENT_FIELDS, **payload_fields}
-                unify.create_fields(all_fields, context=ctx_name)
+                unisdk.create_fields(all_fields, context=ctx_name)
             except Exception:
                 # Fields may already exist or context may have issues; proceed
                 pass
@@ -552,7 +552,7 @@ class EventBus:
         return self._prefill_done.is_set()
 
     @classmethod
-    def _get_logger(cls) -> unify.AsyncLoggerManager:
+    def _get_logger(cls) -> unisdk.AsyncLoggerManager:
         return cls._LOGGER
 
     # ------------------------------------------------------------------
@@ -609,7 +609,7 @@ class EventBus:
         async def _prefill_deque(etype: str, context: str, window_size: int):
             """Fetch recent events into the in-memory deque."""
             raw_logs = await asyncio.to_thread(
-                unify.get_logs,
+                unisdk.get_logs,
                 context=context,
                 limit=window_size,
                 sorting={"timestamp": "descending"},
@@ -626,7 +626,7 @@ class EventBus:
         async def _seed_row_id(etype: str, context: str):
             """Fetch only the latest row_id so the counter stays monotonic."""
             raw_logs = await asyncio.to_thread(
-                unify.get_logs,
+                unisdk.get_logs,
                 context=context,
                 limit=1,
                 sorting={"row_id": "descending"},
@@ -666,7 +666,7 @@ class EventBus:
         """Async wrapper around the former blocking `_load_subscriptions`."""
         try:
             rows = await asyncio.to_thread(
-                unify.get_logs,
+                unisdk.get_logs,
                 context=self._callbacks_ctx,
                 sorting={"row_id": "ascending"},
             )
@@ -794,7 +794,7 @@ class EventBus:
     # ------------------------------------------------------------------
     def _load_subscriptions(self) -> None:
         """Synchronously rebuild the in-memory subscription map."""
-        rows = unify.get_logs(
+        rows = unisdk.get_logs(
             context=self._callbacks_ctx,
             sorting={"row_id": "ascending"},
         )
@@ -1067,7 +1067,7 @@ class EventBus:
     def flush(self) -> None:
         """Batch-upload all buffered event writes, grouped by context.
 
-        Uses ``unify.create_logs`` (single HTTP POST per context) rather
+        Uses ``unisdk.create_logs`` (single HTTP POST per context) rather
         than N individual ``log_create`` calls.  Aggregation mirrors are
         attached in bulk after each batch completes.
 
@@ -1081,7 +1081,7 @@ class EventBus:
         snapshot = self._pending_writes
         self._pending_writes = []
 
-        project = unify.active_project()
+        project = unisdk.active_project()
 
         batches: dict[str, list[dict]] = defaultdict(list)
         for entries, context in snapshot:
@@ -1096,7 +1096,7 @@ class EventBus:
 
         for context, entries_list in batches.items():
             try:
-                unify.create_logs(
+                unisdk.create_logs(
                     project=project,
                     context=context,
                     entries=entries_list,
@@ -1243,7 +1243,7 @@ class EventBus:
                     full_filter += f" and ({filter})"
 
                 logs = await asyncio.to_thread(
-                    unify.get_logs,
+                    unisdk.get_logs,
                     context=self._global_ctx,
                     filter=full_filter,
                     sorting={"timestamp": "descending"},
@@ -1262,13 +1262,13 @@ class EventBus:
         # 3b. Per-type backend fetches – concurrently (as before) --------------
         async def _fetch_one(etype: str, want: int) -> tuple[str, list[Event]]:
             """
-            Run the blocking ``unify.get_logs`` call in a worker thread and
+            Run the blocking ``unisdk.get_logs`` call in a worker thread and
             re-wrap the raw log rows as :class:`Event` objects.
             """
             full_filter = f'type == "{etype}"' + (f" and ({filter})" if filter else "")
 
             logs = await asyncio.to_thread(
-                unify.get_logs,
+                unisdk.get_logs,
                 context=self._global_ctx,
                 filter=full_filter,
                 sorting={"timestamp": "descending"},
@@ -1523,7 +1523,7 @@ class EventBus:
         #    …/Events/<TYPE>, …/Events/_callbacks child) instead of enumerating
         #    and deleting each individually.
         if delete_contexts:
-            unify.delete_context(self._global_ctx, delete_children=True)
+            unisdk.delete_context(self._global_ctx, delete_children=True)
 
         # 4. Re-initialise this *same* instance
         self._get_logger().clear_queue()
@@ -1684,7 +1684,7 @@ class EventBus:
         *event_type* that matches *filter* (or ``(-1, None)`` if none exist).
         """
         recent_logs = await asyncio.to_thread(
-            unify.get_logs,
+            unisdk.get_logs,
             context=self._specific_ctxs[event_type],
             sorting={"row_id": "descending"},
             limit=100,

--- a/unity/file_manager/README.md
+++ b/unity/file_manager/README.md
@@ -59,7 +59,7 @@ flowchart LR
   PFB-->PA[parse_adapter.adapt_parse_result_for_file_manager]
   PA-->Rows[/Content rows/]
   PA-->Tables[/Tables/<label> rows/]
-  FM-->Ingest[unify.create_logs]
+  FM-->Ingest[unisdk.create_logs]
 ```
 
 ### Background attachment ingestion (conversation attachments)

--- a/unity/file_manager/managers/file_manager.py
+++ b/unity/file_manager/managers/file_manager.py
@@ -10,7 +10,7 @@ from typing import Any, Callable, Dict, List, Optional, Union, TYPE_CHECKING
 
 logger = logging.getLogger(__name__)
 
-import unify
+import unisdk
 
 from unity.common.tool_spec import manager_tool, read_only, ToolSpec
 from unity.file_manager.base import BaseFileManager
@@ -2227,7 +2227,7 @@ class FileManager(BaseFileManager):
             from unity.common.context_store import TableStore as _TS  # local import
 
             try:
-                _TS._ENSURED.discard((unify.active_project(), self._ctx))
+                _TS._ENSURED.discard((unisdk.active_project(), self._ctx))
             except Exception:
                 pass
         except Exception:

--- a/unity/file_manager/sync/manager.py
+++ b/unity/file_manager/sync/manager.py
@@ -229,7 +229,7 @@ class SyncManager:
 
         for attempt in range(1, max_retries + 1):
             try:
-                from unify.utils import http
+                from unisdk.utils import http
 
                 LOGGER.debug(
                     f"{ICONS['file_sync']} [FileSync] Fetching SSH key (attempt {attempt}/{max_retries})...",

--- a/unity/file_manager/sync/user_sftp.py
+++ b/unity/file_manager/sync/user_sftp.py
@@ -398,7 +398,7 @@ class UserHomeSFTP:
         admin/runtime-only ``user_desktop_filesync_keys`` map so the key never
         reaches the pod env via ``user_desktops``.
         """
-        from unify.utils import http
+        from unisdk.utils import http
 
         from unity.session_details import SESSION_DETAILS
         from unity.settings import SETTINGS

--- a/unity/function_manager/builtins_catalog.py
+++ b/unity/function_manager/builtins_catalog.py
@@ -17,8 +17,8 @@ from __future__ import annotations
 import logging
 from typing import Any, Dict, List, Tuple
 
-import unify
-from unify.utils.http import RequestError
+import unisdk
+from unisdk.utils.http import RequestError
 
 from ..common.builtins import (
     builtins_project,
@@ -45,13 +45,13 @@ def _ensure_catalog_storage(project: str) -> None:
     manager-owned contexts behave in practice.
     """
     ensure_builtins_project(project)
-    unify.create_context(
+    unisdk.create_context(
         BUILTINS_PRIMITIVES_CONTEXT,
         description="Builtin system action primitives with stable explicit IDs.",
         unique_keys={"function_id": "int"},
         project=project,
     )
-    unify.create_context(
+    unisdk.create_context(
         BUILTINS_META_CONTEXT,
         description="Seeding state for the builtin primitives catalogue.",
         unique_keys={"meta_id": "int"},
@@ -61,7 +61,7 @@ def _ensure_catalog_storage(project: str) -> None:
 
 def _read_existing_rows(project: str) -> List[Any]:
     """Return all stored primitive rows (entries + log id) for reconciliation."""
-    return unify.get_logs(
+    return unisdk.get_logs(
         project=project,
         context=BUILTINS_PRIMITIVES_CONTEXT,
         exclude_fields=list_private_fields(
@@ -116,12 +116,12 @@ def _replace_rows(
         )
     ]
     if stale_ids:
-        unify.delete_logs(
+        unisdk.delete_logs(
             project=project,
             context=BUILTINS_PRIMITIVES_CONTEXT,
             logs=stale_ids,
         )
-    unify.create_logs(
+    unisdk.create_logs(
         project=project,
         context=BUILTINS_PRIMITIVES_CONTEXT,
         entries=entries,

--- a/unity/function_manager/computer_backends.py
+++ b/unity/function_manager/computer_backends.py
@@ -10,7 +10,7 @@ from typing import Any
 from typing import Optional, List, Dict
 import logging
 import aiohttp
-from unify.utils import http
+from unisdk.utils import http
 from pydantic import BaseModel, PydanticUserError
 import asyncio
 import websockets

--- a/unity/function_manager/function_manager.py
+++ b/unity/function_manager/function_manager.py
@@ -35,9 +35,9 @@ from typing import (
     Union,
     TYPE_CHECKING,
 )
-import unify
+import unisdk
 from .shell_pool import ShellPool
-from unify.utils.http import RequestError as _UnifyRequestError
+from unisdk.utils.http import RequestError as _UnifyRequestError
 from ..common.authorship import strip_authoring_assistant_id
 from ..common.log_utils import create_logs as unity_create_logs
 from ..common.embed_utils import ensure_vector_column, list_private_fields
@@ -1917,7 +1917,7 @@ class FunctionManager(BaseFunctionManager):
             if limit is not None:
                 kwargs["limit"] = limit
             try:
-                logs = unify.get_logs(**kwargs)
+                logs = unisdk.get_logs(**kwargs)
             except _UnifyRequestError as e:
                 status = getattr(getattr(e, "response", None), "status_code", None)
                 if status == 404:
@@ -2517,8 +2517,8 @@ class FunctionManager(BaseFunctionManager):
         *,
         function_id: int,
         raise_if_missing: bool = True,
-    ) -> Optional[unify.Log]:
-        logs = unify.get_logs(
+    ) -> Optional[unisdk.Log]:
+        logs = unisdk.get_logs(
             context=self._compositional_ctx,
             filter=f"function_id == {function_id}",
             exclude_fields=list_private_fields(self._compositional_ctx),
@@ -2547,10 +2547,10 @@ class FunctionManager(BaseFunctionManager):
 
     @functools.wraps(BaseFunctionManager.clear, updated=())
     def clear(self) -> None:
-        unify.delete_context(self._compositional_ctx)
-        unify.delete_context(self._primitives_ctx)
-        unify.delete_context(self._venvs_ctx)
-        unify.delete_context(self._meta_ctx)
+        unisdk.delete_context(self._compositional_ctx)
+        unisdk.delete_context(self._primitives_ctx)
+        unisdk.delete_context(self._venvs_ctx)
+        unisdk.delete_context(self._meta_ctx)
 
         # Reset any manager-local counters or caches
         try:
@@ -2576,7 +2576,7 @@ class FunctionManager(BaseFunctionManager):
 
             for _ in range(3):
                 try:
-                    unify.get_fields(context=self._compositional_ctx)
+                    unisdk.get_fields(context=self._compositional_ctx)
                     break
                 except Exception:
                     _time.sleep(0.05)
@@ -2605,7 +2605,7 @@ class FunctionManager(BaseFunctionManager):
         """Read a hash map field from the singleton Functions/Meta row."""
 
         try:
-            logs = unify.get_logs(
+            logs = unisdk.get_logs(
                 context=self._meta_ctx,
                 filter="meta_id == 1",
                 limit=1,
@@ -2620,13 +2620,13 @@ class FunctionManager(BaseFunctionManager):
         """Store a hash map field on the singleton Functions/Meta row."""
 
         try:
-            logs = unify.get_logs(
+            logs = unisdk.get_logs(
                 context=self._meta_ctx,
                 filter="meta_id == 1",
                 limit=1,
             )
             if logs:
-                unify.update_logs(
+                unisdk.update_logs(
                     logs=[logs[0].id],
                     context=self._meta_ctx,
                     entries={field_name: hashes},
@@ -2748,7 +2748,7 @@ class FunctionManager(BaseFunctionManager):
             for backend_id, app_slug in app_keys
         )
         try:
-            logs = unify.get_logs(
+            logs = unisdk.get_logs(
                 context=self._primitives_ctx,
                 filter=filter_expr,
                 exclude_fields=list_private_fields(self._primitives_ctx),
@@ -2763,7 +2763,7 @@ class FunctionManager(BaseFunctionManager):
             ]
             if not ids_to_delete:
                 return 0
-            unify.delete_logs(
+            unisdk.delete_logs(
                 context=self._primitives_ctx,
                 logs=ids_to_delete,
             )
@@ -2784,7 +2784,7 @@ class FunctionManager(BaseFunctionManager):
             app_slug=app_slug,
         )
         try:
-            rows = unify.get_logs(
+            rows = unisdk.get_logs(
                 context=self._primitives_ctx,
                 filter=filter_expr,
                 exclude_fields=list_private_fields(self._primitives_ctx),
@@ -3241,13 +3241,13 @@ class FunctionManager(BaseFunctionManager):
             if len(ids) == 1
             else f"function_id in [{', '.join(str(function_id) for function_id in ids)}]"
         )
-        logs = unify.get_logs(
+        logs = unisdk.get_logs(
             context=self._primitives_ctx,
             filter=filter_expr,
             exclude_fields=list_private_fields(self._primitives_ctx),
         )
         if logs:
-            unify.delete_logs(
+            unisdk.delete_logs(
                 context=self._primitives_ctx,
                 logs=[log.id for log in logs],
             )
@@ -3288,7 +3288,7 @@ class FunctionManager(BaseFunctionManager):
     def _get_stored_custom_functions_hash(self) -> str:
         """Retrieve the stored custom functions hash from the Meta context."""
         try:
-            logs = unify.get_logs(
+            logs = unisdk.get_logs(
                 context=self._meta_ctx,
                 filter="meta_id == 1",
                 limit=1,
@@ -3302,13 +3302,13 @@ class FunctionManager(BaseFunctionManager):
     def _store_custom_functions_hash(self, hash_value: str) -> None:
         """Store the custom functions hash in the Meta context."""
         try:
-            logs = unify.get_logs(
+            logs = unisdk.get_logs(
                 context=self._meta_ctx,
                 filter="meta_id == 1",
                 limit=1,
             )
             if logs:
-                unify.update_logs(
+                unisdk.update_logs(
                     context=self._meta_ctx,
                     logs=[logs[0].id],
                     entries={"custom_functions_hash": hash_value},
@@ -3326,7 +3326,7 @@ class FunctionManager(BaseFunctionManager):
 
     def _get_custom_functions_from_db(self) -> Dict[str, Dict[str, Any]]:
         """Get all custom functions from the database (those with custom_hash set)."""
-        logs = unify.get_logs(
+        logs = unisdk.get_logs(
             context=self._compositional_ctx,
             filter="custom_hash != None",
             exclude_fields=list_private_fields(self._compositional_ctx),
@@ -3337,14 +3337,14 @@ class FunctionManager(BaseFunctionManager):
 
     def _delete_custom_function_by_name(self, name: str) -> bool:
         """Delete a custom function by name."""
-        logs = unify.get_logs(
+        logs = unisdk.get_logs(
             context=self._compositional_ctx,
             filter=f"name == '{name}' and custom_hash != None",
             limit=1,
         )
         if not logs:
             return False
-        unify.delete_logs(
+        unisdk.delete_logs(
             context=self._compositional_ctx,
             logs=[logs[0].id],
         )
@@ -3364,7 +3364,7 @@ class FunctionManager(BaseFunctionManager):
         update_data = strip_authoring_assistant_id(
             {k: v for k, v in data.items() if k != "function_id"},
         )
-        unify.update_logs(
+        unisdk.update_logs(
             context=self._compositional_ctx,
             logs=[log.id],
             entries=update_data,
@@ -3389,7 +3389,7 @@ class FunctionManager(BaseFunctionManager):
         elif isinstance(result, dict):
             log_ids = result.get("log_event_ids", [])
             if log_ids:
-                logs = unify.get_logs(
+                logs = unisdk.get_logs(
                     context=self._compositional_ctx,
                     filter=f"id == {log_ids[0]}",
                     limit=1,
@@ -3405,7 +3405,7 @@ class FunctionManager(BaseFunctionManager):
     def _get_stored_custom_venvs_hash(self) -> str:
         """Retrieve the stored custom venvs hash from the Meta context."""
         try:
-            logs = unify.get_logs(
+            logs = unisdk.get_logs(
                 context=self._meta_ctx,
                 filter="meta_id == 1",
                 limit=1,
@@ -3419,13 +3419,13 @@ class FunctionManager(BaseFunctionManager):
     def _store_custom_venvs_hash(self, hash_value: str) -> None:
         """Store the custom venvs hash in the Meta context."""
         try:
-            logs = unify.get_logs(
+            logs = unisdk.get_logs(
                 context=self._meta_ctx,
                 filter="meta_id == 1",
                 limit=1,
             )
             if logs:
-                unify.update_logs(
+                unisdk.update_logs(
                     context=self._meta_ctx,
                     logs=[logs[0].id],
                     entries={"custom_venvs_hash": hash_value},
@@ -3442,7 +3442,7 @@ class FunctionManager(BaseFunctionManager):
 
     def _get_custom_venvs_from_db(self) -> Dict[str, Dict[str, Any]]:
         """Get all custom venvs from the database (those with custom_hash set)."""
-        logs = unify.get_logs(
+        logs = unisdk.get_logs(
             context=self._venvs_ctx,
             filter="custom_hash != None",
             exclude_fields=list_private_fields(self._venvs_ctx),
@@ -3453,14 +3453,14 @@ class FunctionManager(BaseFunctionManager):
 
     def _delete_custom_venv_by_name(self, name: str) -> bool:
         """Delete a custom venv by name."""
-        logs = unify.get_logs(
+        logs = unisdk.get_logs(
             context=self._venvs_ctx,
             filter=f"name == '{name}' and custom_hash != None",
             limit=1,
         )
         if not logs:
             return False
-        unify.delete_logs(
+        unisdk.delete_logs(
             context=self._venvs_ctx,
             logs=[logs[0].id],
         )
@@ -3468,7 +3468,7 @@ class FunctionManager(BaseFunctionManager):
 
     def _update_custom_venv(self, venv_id: int, data: Dict[str, Any]) -> None:
         """Update an existing custom venv."""
-        logs = unify.get_logs(
+        logs = unisdk.get_logs(
             context=self._venvs_ctx,
             filter=f"venv_id == {venv_id}",
             limit=1,
@@ -3478,7 +3478,7 @@ class FunctionManager(BaseFunctionManager):
         update_data = strip_authoring_assistant_id(
             {k: v for k, v in data.items() if k != "venv_id"},
         )
-        unify.update_logs(
+        unisdk.update_logs(
             context=self._venvs_ctx,
             logs=[logs[0].id],
             entries=update_data,
@@ -3501,7 +3501,7 @@ class FunctionManager(BaseFunctionManager):
         elif isinstance(result, dict):
             log_ids = result.get("log_event_ids", [])
             if log_ids:
-                logs = unify.get_logs(
+                logs = unisdk.get_logs(
                     context=self._venvs_ctx,
                     filter=f"id == {log_ids[0]}",
                     limit=1,
@@ -3597,14 +3597,14 @@ class FunctionManager(BaseFunctionManager):
                     name_to_id[name] = db_entry["venv_id"]
                 else:
                     # Check for user-added venv with same name
-                    existing = unify.get_logs(
+                    existing = unisdk.get_logs(
                         context=self._venvs_ctx,
                         filter=f"name == '{name}'",
                         limit=1,
                     )
                     if existing:
                         logger.info(f"Overwriting user-added venv with custom: {name}")
-                        unify.delete_logs(
+                        unisdk.delete_logs(
                             context=self._venvs_ctx,
                             logs=[existing[0].id],
                         )
@@ -3737,7 +3737,7 @@ class FunctionManager(BaseFunctionManager):
                 else:
                     # Check if there's a user-added function with same name
                     # (no custom_hash) - if so, we need to delete it first
-                    existing = unify.get_logs(
+                    existing = unisdk.get_logs(
                         context=self._compositional_ctx,
                         filter=f"name == '{name}'",
                         limit=1,
@@ -3746,7 +3746,7 @@ class FunctionManager(BaseFunctionManager):
                         logger.info(
                             f"Overwriting user-added function with custom: {name}",
                         )
-                        unify.delete_logs(
+                        unisdk.delete_logs(
                             context=self._compositional_ctx,
                             logs=[existing[0].id],
                         )
@@ -4073,7 +4073,7 @@ class FunctionManager(BaseFunctionManager):
         # Batch update existing functions
         if log_ids_to_update and entries_to_update:
             try:
-                unify.update_logs(
+                unisdk.update_logs(
                     logs=log_ids_to_update,
                     context=self._compositional_ctx,
                     entries=[
@@ -4244,7 +4244,7 @@ class FunctionManager(BaseFunctionManager):
         # Batch update existing functions
         if log_ids_to_update and entries_to_update:
             try:
-                unify.update_logs(
+                unisdk.update_logs(
                     logs=log_ids_to_update,
                     context=self._compositional_ctx,
                     entries=[
@@ -4302,7 +4302,7 @@ class FunctionManager(BaseFunctionManager):
                 logs = []
                 for context in self._read_compositional_contexts():
                     logs.extend(
-                        unify.get_logs(
+                        unisdk.get_logs(
                             context=context,
                             filter=normalized,
                             limit=1,
@@ -4765,7 +4765,7 @@ class FunctionManager(BaseFunctionManager):
         for context in self._read_compositional_contexts():
             compositional_rows.extend(
                 lg.entries
-                for lg in unify.get_logs(
+                for lg in unisdk.get_logs(
                     context=context,
                     filter=self._scoped_filter(None),
                     exclude_fields=list_private_fields(context),
@@ -4840,7 +4840,7 @@ class FunctionManager(BaseFunctionManager):
         logs = []
         for context in self._read_compositional_contexts():
             logs.extend(
-                unify.get_logs(
+                unisdk.get_logs(
                     context=context,
                     filter=self._scoped_filter(f"name == '{function_name}'"),
                     limit=1,
@@ -4920,7 +4920,7 @@ class FunctionManager(BaseFunctionManager):
             results = {target_name: "deleted"}
         else:
             # Multiple functions - build from all logs
-            all_logs = unify.get_logs(
+            all_logs = unisdk.get_logs(
                 context=self._compositional_ctx,
                 exclude_fields=list_private_fields(self._compositional_ctx),
             )
@@ -4953,7 +4953,7 @@ class FunctionManager(BaseFunctionManager):
         if delete_dependents:
             # Get all logs if not already loaded
             if len(function_ids) == 1:
-                all_logs = unify.get_logs(
+                all_logs = unisdk.get_logs(
                     context=self._compositional_ctx,
                     exclude_fields=list_private_fields(self._compositional_ctx),
                 )
@@ -4988,7 +4988,7 @@ class FunctionManager(BaseFunctionManager):
 
         # Batch delete all functions
         if log_ids_to_delete:
-            unify.delete_logs(
+            unisdk.delete_logs(
                 context=self._compositional_ctx,
                 logs=log_ids_to_delete,
             )
@@ -5027,7 +5027,7 @@ class FunctionManager(BaseFunctionManager):
             if delay:
                 _time.sleep(delay)
             try:
-                logs = unify.get_logs(**kwargs)
+                logs = unisdk.get_logs(**kwargs)
                 rows = [lg.entries for lg in logs]
                 last_exc = None
                 break
@@ -5223,7 +5223,7 @@ class FunctionManager(BaseFunctionManager):
     # ------------------------------------------------------------------ #
 
     def _guidance_context(self) -> str:
-        ctxs = unify.get_active_context()
+        ctxs = unisdk.get_active_context()
         read_ctx = ctxs.get("read")
         return f"{read_ctx}/Guidance" if read_ctx else "Guidance"
 
@@ -5240,7 +5240,7 @@ class FunctionManager(BaseFunctionManager):
         # Fallback: scan Guidance rows that reference this function via function_ids
         gctx = self._guidance_context()
         try:
-            rows = unify.get_logs(
+            rows = unisdk.get_logs(
                 context=gctx,
                 filter=f"{int(function_id)} in function_ids",
                 exclude_fields=list_private_fields(gctx),
@@ -5276,7 +5276,7 @@ class FunctionManager(BaseFunctionManager):
                 gids = gids[:limit]
         cond = " or ".join(f"guidance_id == {int(g)}" for g in gids)
         gctx = self._guidance_context()
-        rows = unify.get_logs(
+        rows = unisdk.get_logs(
             context=gctx,
             filter=cond or "False",
             exclude_fields=list_private_fields(gctx),
@@ -5397,7 +5397,7 @@ class FunctionManager(BaseFunctionManager):
         limit: Optional[int] = None,
         exclude_fields: Optional[List[str]] = None,
         from_fields: Optional[List[str]] = None,
-    ) -> List[unify.Log]:
+    ) -> List[unisdk.Log]:
         """Best-effort venv reads; treat missing contexts as empty."""
         import time as _time
 
@@ -5406,7 +5406,7 @@ class FunctionManager(BaseFunctionManager):
             if delay:
                 _time.sleep(delay)
             try:
-                return unify.get_logs(
+                return unisdk.get_logs(
                     context=self._venvs_ctx,
                     filter=filter,
                     limit=limit,
@@ -5485,7 +5485,7 @@ class FunctionManager(BaseFunctionManager):
                     exclude_fields=list_private_fields(context),
                 )
                 if context == self._venvs_ctx
-                else unify.get_logs(
+                else unisdk.get_logs(
                     context=context,
                     filter=f"venv_id == {venv_id}",
                     limit=1,
@@ -5512,7 +5512,7 @@ class FunctionManager(BaseFunctionManager):
                         from_fields=None,
                     )
                     if context == self._venvs_ctx
-                    else unify.get_logs(
+                    else unisdk.get_logs(
                         context=context,
                         exclude_fields=list_private_fields(context),
                     )
@@ -5539,7 +5539,7 @@ class FunctionManager(BaseFunctionManager):
         )
         if not logs:
             return False
-        unify.delete_logs(
+        unisdk.delete_logs(
             context=self._venvs_ctx,
             logs=[logs[0].id],
         )
@@ -5562,7 +5562,7 @@ class FunctionManager(BaseFunctionManager):
         )
         if not logs:
             return False
-        unify.update_logs(
+        unisdk.update_logs(
             context=self._venvs_ctx,
             logs=[logs[0].id],
             entries={"venv": venv},
@@ -5592,7 +5592,7 @@ class FunctionManager(BaseFunctionManager):
         )
         if log is None:
             return False
-        unify.update_logs(
+        unisdk.update_logs(
             context=self._compositional_ctx,
             logs=[log.id],
             entries={"venv_id": venv_id},
@@ -5633,7 +5633,7 @@ class FunctionManager(BaseFunctionManager):
         from unity.file_manager.settings import get_local_root
 
         # Get current context for isolation
-        ctx = unify.get_active_context()
+        ctx = unisdk.get_active_context()
         ctx_name = ctx.get("read") or ctx.get("write") or "default"
         # Sanitize context name for filesystem use
         safe_ctx = ctx_name.replace("/", "_").replace("\\", "_")

--- a/unity/guidance_manager/builtins_catalog.py
+++ b/unity/guidance_manager/builtins_catalog.py
@@ -25,8 +25,8 @@ import logging
 from pathlib import Path
 from typing import Dict, List, Optional
 
-import unify
-from unify.utils.http import RequestError
+import unisdk
+from unisdk.utils.http import RequestError
 
 from ..common.builtins import (
     builtins_project,
@@ -89,7 +89,7 @@ def _ensure_catalog_storage(project: str) -> None:
     and ``function_ids``.
     """
     ensure_builtins_project(project)
-    unify.create_context(
+    unisdk.create_context(
         BUILTINS_GUIDANCE_CONTEXT,
         description="Builtin procedural guidance imported from the Agent Skills ecosystem.",
         unique_keys={"guidance_id": "int"},
@@ -97,12 +97,12 @@ def _ensure_catalog_storage(project: str) -> None:
     )
     # Pre-create the model schema so federated reads (from_fields
     # projections) are well-defined even before the first rows land.
-    unify.create_fields(
+    unisdk.create_fields(
         model_to_fields(Guidance),
         context=BUILTINS_GUIDANCE_CONTEXT,
         project=project,
     )
-    unify.create_context(
+    unisdk.create_context(
         BUILTINS_GUIDANCE_META_CONTEXT,
         description="Seeding state for the builtin guidance catalogue.",
         unique_keys={"meta_id": "int"},
@@ -114,14 +114,14 @@ def _delete_rows_by_ids(project: str, guidance_ids: List[int]) -> None:
     if not guidance_ids:
         return
     ids_expr = ", ".join(str(gid) for gid in sorted(set(guidance_ids)))
-    logs = unify.get_logs(
+    logs = unisdk.get_logs(
         project=project,
         context=BUILTINS_GUIDANCE_CONTEXT,
         filter=f"guidance_id in [{ids_expr}]",
         return_ids_only=True,
     )
     if logs:
-        unify.delete_logs(
+        unisdk.delete_logs(
             project=project,
             context=BUILTINS_GUIDANCE_CONTEXT,
             logs=logs,
@@ -164,7 +164,7 @@ def _insert_entries(project: str, entries: List[Dict[str, str]]) -> None:
         ).model_dump(mode="json")
         for entry in entries
     ]
-    unify.create_logs(
+    unisdk.create_logs(
         project=project,
         context=BUILTINS_GUIDANCE_CONTEXT,
         entries=rows,

--- a/unity/guidance_manager/guidance_manager.py
+++ b/unity/guidance_manager/guidance_manager.py
@@ -6,7 +6,7 @@ import functools
 import inspect
 import re
 
-import unify
+import unisdk
 
 from ..common.log_utils import log as unity_log
 from ..common.tool_outcome import ToolErrorException, ToolOutcome
@@ -213,7 +213,7 @@ class GuidanceManager(BaseGuidanceManager):
     def _is_builtin_guidance(self, guidance_id: int) -> bool:
         """Return whether an id refers to a row in the builtins catalogue."""
         try:
-            rows = unify.get_logs(
+            rows = unisdk.get_logs(
                 context=BUILTINS_GUIDANCE_CONTEXT,
                 project=builtins_project(),
                 filter=f"guidance_id == {int(guidance_id)}",
@@ -266,7 +266,7 @@ class GuidanceManager(BaseGuidanceManager):
 
     @functools.wraps(BaseGuidanceManager.clear, updated=())
     def clear(self) -> None:
-        unify.delete_context(self._ctx)
+        unisdk.delete_context(self._ctx)
 
         # Reset observed custom fields for this manager instance
         try:
@@ -284,7 +284,7 @@ class GuidanceManager(BaseGuidanceManager):
 
             for _ in range(3):
                 try:
-                    unify.get_fields(context=self._ctx)
+                    unisdk.get_fields(context=self._ctx)
                     break
                 except Exception:
                     _time.sleep(0.05)
@@ -396,7 +396,7 @@ class GuidanceManager(BaseGuidanceManager):
         info: Dict[str, Any] = {"type": str(column_type), "mutable": True}
         if column_description is not None:
             info["description"] = column_description
-        resp = unify.create_fields(fields={column_name: info}, context=self._ctx)
+        resp = unisdk.create_fields(fields={column_name: info}, context=self._ctx)
         try:
             self._known_custom_fields.add(column_name)
         except Exception:
@@ -418,7 +418,7 @@ class GuidanceManager(BaseGuidanceManager):
         """
         if column_name in self._REQUIRED_COLUMNS:
             raise ValueError(f"Cannot delete required column '{column_name}'.")
-        resp = unify.delete_fields(fields=[column_name], context=self._ctx)
+        resp = unisdk.delete_fields(fields=[column_name], context=self._ctx)
         try:
             if column_name in getattr(self, "_known_custom_fields", set()):
                 self._known_custom_fields.discard(column_name)
@@ -742,7 +742,7 @@ class GuidanceManager(BaseGuidanceManager):
         except ToolErrorException as exc:
             return exc.payload  # type: ignore[return-value]
         self._raise_if_builtin(guidance_id, "updated")
-        ids = unify.get_logs(
+        ids = unisdk.get_logs(
             context=context,
             filter=f"guidance_id == {int(guidance_id)}",
             limit=2,
@@ -756,7 +756,7 @@ class GuidanceManager(BaseGuidanceManager):
             raise RuntimeError(
                 f"Multiple rows found with guidance_id {guidance_id}. Data integrity issue.",
             )
-        unify.update_logs(
+        unisdk.update_logs(
             logs=[ids[0]],
             context=context,
             entries=updates,
@@ -803,7 +803,7 @@ class GuidanceManager(BaseGuidanceManager):
         funcs = []
         for context in self._function_contexts_for_read():
             funcs.extend(
-                unify.get_logs(
+                unisdk.get_logs(
                     context=context,
                     filter=filt or "False",
                     exclude_fields=list_private_fields(context),
@@ -864,7 +864,7 @@ class GuidanceManager(BaseGuidanceManager):
         except ToolErrorException as exc:
             return exc.payload  # type: ignore[return-value]
         self._raise_if_builtin(guidance_id, "deleted")
-        ids = unify.get_logs(
+        ids = unisdk.get_logs(
             context=context,
             filter=f"guidance_id == {int(guidance_id)}",
             limit=2,
@@ -878,7 +878,7 @@ class GuidanceManager(BaseGuidanceManager):
             raise RuntimeError(
                 f"Multiple rows found with guidance_id {guidance_id}. Data integrity issue.",
             )
-        unify.delete_logs(context=context, logs=ids[0])
+        unisdk.delete_logs(context=context, logs=ids[0])
         return {"outcome": "guidance deleted", "details": {"guidance_id": guidance_id}}
 
     @functools.wraps(BaseGuidanceManager.search, updated=())

--- a/unity/image_manager/image_manager.py
+++ b/unity/image_manager/image_manager.py
@@ -14,7 +14,7 @@ from ..common.llm_client import new_vision_llm_client
 from ..common.authorship import stamp_authoring_assistant_id
 from ..common.log_utils import log as unity_log, create_logs as unity_create_logs
 from ..common.context_dump import make_messages_safe_for_context_dump
-import unify
+import unisdk
 
 
 from ..common.model_to_fields import model_to_fields
@@ -305,7 +305,7 @@ class ImageHandle:
         """
         Return the decoded image bytes.
 
-        If the data is a GCS URL, it downloads the content via unify.download_object().
+        If the data is a GCS URL, it downloads the content via unisdk.download_object().
         Otherwise, it assumes the data is a base64 string and decodes it.
         """
         # Prefer locally cached base64 data from the DataStore to avoid re-downloading
@@ -317,7 +317,7 @@ class ImageHandle:
         except Exception:
             data_str = self._image.data
 
-        # Convert HTTPS GCS URLs to gs:// format for unify.download_object
+        # Convert HTTPS GCS URLs to gs:// format for unisdk.download_object
         gcs_uri = None
         if data_str.startswith("gs://"):
             gcs_uri = data_str
@@ -330,7 +330,7 @@ class ImageHandle:
 
         if gcs_uri:
             try:
-                content = unify.download_object(gcs_uri)
+                content = unisdk.download_object(gcs_uri)
                 # Cache the downloaded bytes as base64 in the DataStore to prevent future downloads
                 try:
                     import base64 as _b64
@@ -833,7 +833,7 @@ class ImageManager(BaseImageManager):
                 if not remaining:
                     break
                 id_list = ", ".join(str(int(i)) for i in remaining)
-                logs = unify.get_logs(
+                logs = unisdk.get_logs(
                     context=context,
                     filter=f"image_id in [{id_list}]",
                     limit=len(remaining),
@@ -1247,7 +1247,7 @@ class ImageManager(BaseImageManager):
                 if not handled:
                     log_ids = resp.get("log_event_ids") or resp.get("log_ids")
                     if isinstance(log_ids, list) and log_ids:
-                        fetched = unify.get_logs(
+                        fetched = unisdk.get_logs(
                             context=context,
                             from_ids=log_ids,
                             return_ids_only=False,
@@ -1392,7 +1392,7 @@ class ImageManager(BaseImageManager):
                 # No per-log explicit_types needed; field is strongly typed in schema
             if not entries:
                 continue
-            ids = unify.get_logs(
+            ids = unisdk.get_logs(
                 context=context,
                 filter=f"image_id == {image_id}",
                 limit=2,
@@ -1404,7 +1404,7 @@ class ImageManager(BaseImageManager):
                 raise RuntimeError(
                     f"Multiple rows found with image_id {image_id}. Data integrity issue.",
                 )
-            unify.update_logs(
+            unisdk.update_logs(
                 logs=[ids[0]],
                 context=context,
                 entries=entries,
@@ -1412,7 +1412,7 @@ class ImageManager(BaseImageManager):
             )
             # Refresh from backend and write-through to DataStore (preserve temp id)
             try:
-                rows = unify.get_logs(
+                rows = unisdk.get_logs(
                     context=context,
                     filter=f"image_id == {image_id}",
                     limit=1,
@@ -1479,7 +1479,7 @@ class ImageManager(BaseImageManager):
     # ------------------------------ Maintenance ---------------------------
     @functools.wraps(BaseImageManager.clear, updated=())
     def clear(self) -> None:
-        unify.delete_context(self._ctx)
+        unisdk.delete_context(self._ctx)
 
         # Ensure the schema exists again via shared provisioning helper
         ContextRegistry.refresh(self, IMAGES_TABLE)
@@ -1496,7 +1496,7 @@ class ImageManager(BaseImageManager):
 
             for _ in range(3):
                 try:
-                    unify.get_fields(context=self._ctx)
+                    unisdk.get_fields(context=self._ctx)
                     break
                 except Exception:
                     _time.sleep(0.05)
@@ -1524,7 +1524,7 @@ class ImageManager(BaseImageManager):
 
         source_context = self._context_for_root(source_root)
         target_context = self._context_for_root(target_root)
-        rows = unify.get_logs(
+        rows = unisdk.get_logs(
             context=source_context,
             filter=f"image_id == {int(image_id)}",
             limit=2,
@@ -1539,7 +1539,7 @@ class ImageManager(BaseImageManager):
             )
 
         payload = Image(**rows[0].entries).to_post_json()
-        target_ids = unify.get_logs(
+        target_ids = unisdk.get_logs(
             context=target_context,
             filter=f"image_id == {int(image_id)}",
             limit=2,
@@ -1550,7 +1550,7 @@ class ImageManager(BaseImageManager):
                 f"Multiple Images rows found with image_id={int(image_id)} in {target_context}.",
             )
         if target_ids:
-            unify.update_logs(
+            unisdk.update_logs(
                 context=target_context,
                 logs=[target_ids[0]],
                 entries=payload,
@@ -1564,7 +1564,7 @@ class ImageManager(BaseImageManager):
                 mutable=False,
             )
 
-        unify.delete_logs(context=source_context, logs=rows[0].id)
+        unisdk.delete_logs(context=source_context, logs=rows[0].id)
         try:
             self._data_store_for_context(target_context).put(payload)
             self._data_store_for_context(source_context).delete(int(image_id))

--- a/unity/integration_status/__init__.py
+++ b/unity/integration_status/__init__.py
@@ -101,11 +101,11 @@ def _read_local_secret_keyset() -> set[str]:
     available or the context can't be read.  Never raises.
     """
     try:
-        import unify
+        import unisdk
         from unity.manager_registry import ManagerRegistry
 
         sm = ManagerRegistry.get_secret_manager()
-        rows = unify.get_logs(context=sm._ctx)
+        rows = unisdk.get_logs(context=sm._ctx)
     except Exception:
         return set()
 
@@ -262,7 +262,7 @@ def schedule_register_available_integrations() -> None:
       has populated ``_base_context``, so manager constructions inside
       the worker can resolve their contexts.
     * Captures the calling thread's Unify active context and re-applies
-      it inside the worker so ``unify.get_logs(...)`` / context-resolving
+      it inside the worker so ``unisdk.get_logs(...)`` / context-resolving
       reads in the registration path see the same project + context the
       main thread does.
 
@@ -271,18 +271,18 @@ def schedule_register_available_integrations() -> None:
     import threading
 
     try:
-        import unify
+        import unisdk
 
-        captured_ctx = unify.get_active_context()
+        captured_ctx = unisdk.get_active_context()
     except Exception:
         captured_ctx = None
 
     def _worker() -> None:
         if captured_ctx is not None:
             try:
-                import unify
+                import unisdk
 
-                unify.set_context(
+                unisdk.set_context(
                     captured_ctx["read"],
                     skip_create=True,
                 )

--- a/unity/integrations/builtins_catalog.py
+++ b/unity/integrations/builtins_catalog.py
@@ -7,9 +7,9 @@ import json
 import logging
 from typing import Any, Dict, Iterable, List, Optional
 
-import unify
+import unisdk
 
-from unify.utils.http import RequestError
+from unisdk.utils.http import RequestError
 
 from unity.common.builtins import (
     builtins_project,
@@ -57,19 +57,19 @@ def _normalize_app_slug(value: Any) -> str:
 def _ensure_catalog_storage(project: str) -> None:
     logger.info("Ensuring integration catalogue storage project=%s", project)
     ensure_builtins_project(project)
-    unify.create_context(
+    unisdk.create_context(
         BUILTINS_INTEGRATION_APPS_CONTEXT,
         description="Public integration app catalogue.",
         unique_keys={"app_id": "int"},
         project=project,
     )
-    unify.create_context(
+    unisdk.create_context(
         BUILTINS_INTEGRATION_TOOLS_CONTEXT,
         description="Public integration tool catalogue.",
         unique_keys={"function_id": "int"},
         project=project,
     )
-    unify.create_context(
+    unisdk.create_context(
         BUILTINS_INTEGRATION_META_CONTEXT,
         description="Seeding state for the integration catalogue.",
         unique_keys={"meta_id": "int"},
@@ -299,7 +299,7 @@ def _delete_units(project: str, context: str, filters: list[str]) -> None:
     for index, filter_expr in enumerate(filters):
         page = 1
         while True:
-            logs = unify.get_logs(
+            logs = unisdk.get_logs(
                 project=project,
                 context=context,
                 filter=filter_expr,
@@ -319,7 +319,7 @@ def _delete_units(project: str, context: str, filters: list[str]) -> None:
                 page,
                 len(logs),
             )
-            unify.delete_logs(
+            unisdk.delete_logs(
                 project=project,
                 context=context,
                 logs=logs,
@@ -333,7 +333,7 @@ def _delete_function_ids(project: str, function_ids: Iterable[int]) -> None:
         batch = unique_ids[index : index + _DELETE_FILTER_BATCH_SIZE]
         page = 1
         while True:
-            logs = unify.get_logs(
+            logs = unisdk.get_logs(
                 project=project,
                 context=BUILTINS_INTEGRATION_TOOLS_CONTEXT,
                 filter=f"function_id in {json.dumps(batch)}",
@@ -353,7 +353,7 @@ def _delete_function_ids(project: str, function_ids: Iterable[int]) -> None:
                 page,
                 len(logs),
             )
-            unify.delete_logs(
+            unisdk.delete_logs(
                 project=project,
                 context=BUILTINS_INTEGRATION_TOOLS_CONTEXT,
                 logs=logs,
@@ -373,7 +373,7 @@ def _insert_rows(project: str, context: str, rows: List[Dict[str, Any]]) -> None
             total_batches,
             len(batch),
         )
-        unify.create_logs(
+        unisdk.create_logs(
             project=project,
             context=context,
             entries=batch,
@@ -672,7 +672,7 @@ def list_catalog_apps(
             project=project,
         )
         return rows
-    rows = unify.get_logs(
+    rows = unisdk.get_logs(
         project=project,
         context=BUILTINS_INTEGRATION_APPS_CONTEXT,
         limit=limit,
@@ -697,7 +697,7 @@ def list_catalog_tools(
         row_filter = f'({row_filter}) and metadata["integration"]["app_slug"] == {json.dumps(_normalize_app_slug(canonical_app_slug))}'
     if tool_id:
         row_filter = f'({row_filter}) and metadata["integration"]["tool_id"] == {json.dumps(tool_id)}'
-    rows = unify.get_logs(
+    rows = unisdk.get_logs(
         project=project,
         context=BUILTINS_INTEGRATION_TOOLS_CONTEXT,
         filter=row_filter,

--- a/unity/integrations/ops.py
+++ b/unity/integrations/ops.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 from typing import Any, Optional
 
-import unify
+import unisdk
 
 
 def _request_failed(helper_name: str, exc: Exception) -> dict[str, Any]:
@@ -31,7 +31,7 @@ def _request_failed(helper_name: str, exc: Exception) -> dict[str, Any]:
 
 def list_connections(**scope: Any) -> Any:
     try:
-        return unify.list_integration_connections(**_clean_scope(scope))
+        return unisdk.list_integration_connections(**_clean_scope(scope))
     except KeyError:
         raise
     except Exception as exc:
@@ -47,7 +47,7 @@ def run_tool(
     **scope: Any,
 ) -> Any:
     try:
-        return unify.run_integration_tool(
+        return unisdk.run_integration_tool(
             tool_id,
             arguments,
             confirmation_token=confirmation_token,
@@ -62,7 +62,7 @@ def run_tool(
 
 def get_tool_policy(connection_id: str, **scope: Any) -> Any:
     try:
-        return unify.get_integration_tool_policy(
+        return unisdk.get_integration_tool_policy(
             connection_id,
             **_clean_scope(scope),
         )
@@ -82,7 +82,7 @@ def patch_tool_policy(
     **scope: Any,
 ) -> Any:
     try:
-        return unify.patch_integration_tool_policy(
+        return unisdk.patch_integration_tool_policy(
             connection_id,
             tool_policies=tool_policies,
             bulk_approval_level=bulk_approval_level,
@@ -107,7 +107,7 @@ def approve_tool_execution(
     **owner_scope: Any,
 ) -> Any:
     try:
-        return unify.approve_integration_tool_execution(
+        return unisdk.approve_integration_tool_execution(
             audit_id,
             scope=scope,
             persist_policy=persist_policy,
@@ -133,7 +133,7 @@ def deny_tool_execution(
     **owner_scope: Any,
 ) -> Any:
     try:
-        return unify.deny_integration_tool_execution(
+        return unisdk.deny_integration_tool_execution(
             audit_id,
             scope=scope,
             persist_policy=persist_policy,
@@ -150,7 +150,7 @@ def deny_tool_execution(
 
 def test_connection(connection_id: str) -> Any:
     try:
-        return unify.test_integration_connection(connection_id)
+        return unisdk.test_integration_connection(connection_id)
     except KeyError:
         raise
     except Exception as exc:

--- a/unity/integrations/primitives.py
+++ b/unity/integrations/primitives.py
@@ -473,14 +473,14 @@ class IntegrationPrimitives:
     def _native_manifest_row_for_app(self, app_slug: str) -> dict[str, Any] | None:
         normalized = _normalize_app_slug(app_slug)
         try:
-            import unify
+            import unisdk
 
-            active = unify.get_active_context() or {}
+            active = unisdk.get_active_context() or {}
             root = active.get("read") or active.get("write") or ""
             context = (
                 f"{root}/Integrations/Manifests" if root else "Integrations/Manifests"
             )
-            rows = unify.get_logs(
+            rows = unisdk.get_logs(
                 context=context,
                 filter=f'slug == "{normalized}"',
                 limit=1,
@@ -503,14 +503,14 @@ class IntegrationPrimitives:
         if not function_names:
             return []
         try:
-            import unify
+            import unisdk
 
-            active = unify.get_active_context() or {}
+            active = unisdk.get_active_context() or {}
             root = active.get("read") or active.get("write") or ""
             context = f"{root}/Functions/Primitives" if root else "Functions/Primitives"
             rows: list[dict[str, Any]] = []
             for name in function_names[:100]:
-                matched = unify.get_logs(
+                matched = unisdk.get_logs(
                     context=context,
                     filter=f'name == "{name}"',
                     limit=1,
@@ -523,15 +523,15 @@ class IntegrationPrimitives:
     def _materialized_tool_rows_for_app(self, app_slug: str) -> list[dict[str, Any]]:
         normalized = _normalize_app_slug(app_slug)
         try:
-            import unify
+            import unisdk
 
-            active = unify.get_active_context() or {}
+            active = unisdk.get_active_context() or {}
             root = active.get("read") or active.get("write") or ""
             contexts = (
                 [f"{root}/Functions/Primitives"] if root else ["Functions/Primitives"]
             )
             for context in contexts:
-                rows = unify.get_logs(
+                rows = unisdk.get_logs(
                     context=context,
                     filter=(
                         'metadata["source"] == "provider_backed" '
@@ -1170,15 +1170,15 @@ class IntegrationPrimitives:
         except Exception:
             pass
         try:
-            import unify
+            import unisdk
 
-            active = unify.get_active_context() or {}
+            active = unisdk.get_active_context() or {}
             root = active.get("read") or active.get("write") or ""
             contexts = (
                 [f"{root}/Functions/Primitives"] if root else ["Functions/Primitives"]
             )
             for context in contexts:
-                rows = unify.get_logs(
+                rows = unisdk.get_logs(
                     context=context,
                     filter=(
                         f"name == {json.dumps(name)} "

--- a/unity/knowledge_manager/knowledge_manager.py
+++ b/unity/knowledge_manager/knowledge_manager.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import uuid
-import unify
+import unisdk
 import functools
 from typing import Any, Dict, List, Optional, Type, Union, TYPE_CHECKING
 from pydantic import BaseModel
@@ -320,7 +320,7 @@ class KnowledgeManager(BaseKnowledgeManager):
         """
         Decide whether to seed a synthetic first tool call `show_all` that dumps
         some or all tables, and if so return the seeded transcript. Otherwise None.
-        Uses `unify.get_groups`-based unique value enumeration for token estimation.
+        Uses `unisdk.get_groups`-based unique value enumeration for token estimation.
         """
         try:
             if not (self._full_table_dump or self._per_table_dumps):
@@ -988,7 +988,7 @@ class KnowledgeManager(BaseKnowledgeManager):
         """
         # One server-side subtree delete (root + every descendant) instead of
         # enumerating each child and deleting it individually.
-        unify.delete_context(self._ctx, delete_children=True)
+        unisdk.delete_context(self._ctx, delete_children=True)
 
         # Re-provision any required/linked storage
 
@@ -1316,7 +1316,7 @@ class KnowledgeManager(BaseKnowledgeManager):
         Notes
         -----
         Implemented by attaching the matching logs to the destination context
-        via ``unify.add_logs_to_context``.
+        via ``unisdk.add_logs_to_context``.
         """
         try:
             return _op_copy_column(
@@ -1518,7 +1518,7 @@ class KnowledgeManager(BaseKnowledgeManager):
         Returns
         -------
         dict[str, str]
-            Backend response from ``unify.update_logs``.
+            Backend response from ``unisdk.update_logs``.
         """
         try:
             res = _op_update_rows(
@@ -1653,7 +1653,7 @@ class KnowledgeManager(BaseKnowledgeManager):
     #                     try:
     #                         # Count records to be deleted using IDs-only
     #                         target_ctx = self._ctx_for_table(table)
-    #                         ids_to_delete = unify.get_logs(
+    #                         ids_to_delete = unisdk.get_logs(
     #                             context=target_ctx,
     #                             filter=filter_expr,
     #                             return_ids_only=True,
@@ -1850,7 +1850,7 @@ class KnowledgeManager(BaseKnowledgeManager):
         list[dict[str, Any]]
                 Up to ``k`` rows sorted by ascending semantic distance (best match first).
                 If similarity search yields fewer than ``k`` rows and there are more rows
-                overall, the remainder is backfilled from ``unify.get_logs(limit=k)`` in
+                overall, the remainder is backfilled from ``unisdk.get_logs(limit=k)`` in
                 returned order, skipping duplicates based on each table's unique id.
         """
         return _srch_search(
@@ -1921,7 +1921,7 @@ class KnowledgeManager(BaseKnowledgeManager):
             Up to `k` rows from the joined result, sorted by best semantic
             match first. If the similarity search yields fewer than `k` rows and
             there are more rows overall in the joined context, the remainder is
-            backfilled from `unify.get_logs(limit=k)` in returned order, skipping
+            backfilled from `unisdk.get_logs(limit=k)` in returned order, skipping
             duplicates based on the joined table's unique id.
         """
         return _srch_search_join(
@@ -1982,7 +1982,7 @@ class KnowledgeManager(BaseKnowledgeManager):
             Up to `k` rows from the final joined result, best semantic match
             first. If the similarity search yields fewer than `k` rows and
             there are more rows overall in the final joined context, the
-            remainder is backfilled from `unify.get_logs(limit=k)` in returned
+            remainder is backfilled from `unisdk.get_logs(limit=k)` in returned
             order, skipping duplicates based on the final context's unique id.
         """
 
@@ -2074,7 +2074,7 @@ class KnowledgeManager(BaseKnowledgeManager):
             grouping level, or a list such as ``[\"category\", \"row_id\"]`` to
             group hierarchically in that order. When provided, the result
             becomes a nested mapping keyed by group values, mirroring
-            :func:`unify.get_logs_metric` behaviour.
+            :func:`unisdk.get_logs_metric` behaviour.
 
         Returns
         -------

--- a/unity/knowledge_manager/ops.py
+++ b/unity/knowledge_manager/ops.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any, Dict, List, Optional, TYPE_CHECKING
 
-import unify
+import unisdk
 
 from ..common.authorship import strip_authoring_assistant_id
 from ..common.embed_utils import ensure_vector_column
@@ -120,8 +120,8 @@ def update_rows(
     log_ids = [lid for (lid, _) in matched]
     entries = [entry for (_, entry) in matched]
 
-    # Use unify.update_logs for now (needs DataManager.update_rows enhancement)
-    res = unify.update_logs(
+    # Use unisdk.update_logs for now (needs DataManager.update_rows enhancement)
+    res = unisdk.update_logs(
         logs=log_ids,
         context=ctx,
         entries=entries,
@@ -448,10 +448,10 @@ def copy_column(
     log_ids = [r.get("id") or r.get("_id") for r in rows if r.get("id") or r.get("_id")]
 
     if log_ids:
-        unify.add_logs_to_context(
+        unisdk.add_logs_to_context(
             log_ids,
             context=dest_ctx,
-            project=unify.active_project(),
+            project=unisdk.active_project(),
         )
 
     return {

--- a/unity/knowledge_manager/storage.py
+++ b/unity/knowledge_manager/storage.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import unify
+import unisdk
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any, Dict, List, Optional, Union, TYPE_CHECKING
 
@@ -132,7 +132,7 @@ def tables_overview(
     tables: Dict[str, Dict[str, Any]] = {}
     for table_name, full_path in table_contexts.items():
         try:
-            meta = unify.get_context(full_path)
+            meta = unisdk.get_context(full_path)
         except Exception:
             meta = {}
         desc = meta.get("description") if isinstance(meta, dict) else None
@@ -146,7 +146,7 @@ def tables_overview(
         and getattr(knowledge_manager, "_contacts_ctx", None) is not None
     ):
         try:
-            contacts_info = unify.get_context(knowledge_manager._contacts_ctx)
+            contacts_info = unisdk.get_context(knowledge_manager._contacts_ctx)
             if isinstance(contacts_info, dict):
                 desc = contacts_info.get("description")
                 if desc == "":

--- a/unity/secret_manager/secret_manager.py
+++ b/unity/secret_manager/secret_manager.py
@@ -9,7 +9,7 @@ from time import monotonic
 from typing import Any, Callable, Dict, List, Optional, Type
 from pydantic import BaseModel
 
-import unify
+import unisdk
 from unity.common.llm_client import new_llm_client
 from unity.common.log_utils import log as unity_log
 
@@ -229,7 +229,7 @@ class SecretManager(BaseSecretManager):
 
     @functools.wraps(BaseSecretManager.clear, updated=())
     def clear(self) -> None:
-        unify.delete_context(self._ctx)
+        unisdk.delete_context(self._ctx)
 
         # Force re-provisioning even if previously ensured
         self._ctx = ContextRegistry.refresh(self, SECRETS_TABLE)
@@ -243,7 +243,7 @@ class SecretManager(BaseSecretManager):
 
             for _ in range(3):
                 try:
-                    unify.get_fields(context=self._ctx)
+                    unisdk.get_fields(context=self._ctx)
                     break
                 except Exception:
                     _time.sleep(0.05)
@@ -350,7 +350,7 @@ class SecretManager(BaseSecretManager):
             return
 
         try:
-            from unify.utils import http
+            from unisdk.utils import http
 
             resp = http.get(
                 f"{base_url}/admin/assistant",
@@ -380,7 +380,7 @@ class SecretManager(BaseSecretManager):
             if not isinstance(value, str) or not value:
                 continue
             try:
-                existing = unify.get_logs(
+                existing = unisdk.get_logs(
                     context=self._ctx,
                     filter=f"name == {name!r}",
                     limit=1,
@@ -388,7 +388,7 @@ class SecretManager(BaseSecretManager):
                 )
                 description = "System-managed OAuth credential (auto-synced)"
                 if existing:
-                    unify.update_logs(
+                    unisdk.update_logs(
                         logs=[existing[0]],
                         context=self._ctx,
                         entries={"value": value, "description": description},
@@ -421,14 +421,14 @@ class SecretManager(BaseSecretManager):
         # context but are not removed based on the admin assistant payload.
         for stale_name in active_allowlist - secrets_dict.keys():
             try:
-                ids = unify.get_logs(
+                ids = unisdk.get_logs(
                     context=self._ctx,
                     filter=f"name == {stale_name!r}",
                     limit=1,
                     return_ids_only=True,
                 )
                 if ids:
-                    unify.delete_logs(context=self._ctx, logs=ids[0])
+                    unisdk.delete_logs(context=self._ctx, logs=ids[0])
                     self._env_remove(stale_name)
             except Exception:
                 continue
@@ -452,7 +452,7 @@ class SecretManager(BaseSecretManager):
         if not base_url or not admin_key:
             return
 
-        from unify.utils import http
+        from unisdk.utils import http
 
         from unity.workspace_files.policy import get_policy_store
 
@@ -535,7 +535,7 @@ class SecretManager(BaseSecretManager):
 
     def _get_secret_value(self, name: str) -> str | None:
         try:
-            rows = unify.get_logs(
+            rows = unisdk.get_logs(
                 context=self._ctx,
                 filter=f"name == {name!r}",
                 limit=1,
@@ -572,7 +572,7 @@ class SecretManager(BaseSecretManager):
         for code executed via ``os.environ``.
         """
         try:
-            rows = unify.get_logs(context=self._ctx)
+            rows = unisdk.get_logs(context=self._ctx)
         except Exception:
             rows = []
         name_to_value: Dict[str, str] = {}
@@ -708,7 +708,7 @@ class SecretManager(BaseSecretManager):
         value_to_name: Dict[str, str] = {}
         for context in self._read_secret_contexts():
             try:
-                rows = unify.get_logs(
+                rows = unisdk.get_logs(
                     context=context,
                     from_fields=["name", "value"],
                 )
@@ -969,7 +969,7 @@ class SecretManager(BaseSecretManager):
             If the credential is not stored in the resolved vault.
         """
         context = self._secret_context_for_destination(destination)
-        rows = unify.get_logs(
+        rows = unisdk.get_logs(
             context=context,
             filter=f"name == {integration!r}",
             limit=1,
@@ -1198,7 +1198,7 @@ class SecretManager(BaseSecretManager):
         names: set[str] = set()
         for context in self._read_secret_contexts():
             try:
-                rows = unify.get_logs(
+                rows = unisdk.get_logs(
                     context=context,
                     from_fields=["name"],
                 )
@@ -1270,7 +1270,7 @@ class SecretManager(BaseSecretManager):
             return exc.payload
 
         # Enforce uniqueness of name
-        existing = unify.get_logs(
+        existing = unisdk.get_logs(
             context=context,
             filter=f"name == {name!r}",
             limit=1,
@@ -1340,7 +1340,7 @@ class SecretManager(BaseSecretManager):
             return exc.payload
 
         # Find target log id
-        ids = unify.get_logs(
+        ids = unisdk.get_logs(
             context=context,
             filter=f"name == {name!r}",
             limit=2,
@@ -1361,7 +1361,7 @@ class SecretManager(BaseSecretManager):
         if not updates:
             raise ValueError("No updates provided.")
 
-        unify.update_logs(
+        unisdk.update_logs(
             logs=[log_id],
             context=context,
             entries=updates,
@@ -1408,7 +1408,7 @@ class SecretManager(BaseSecretManager):
         except ToolErrorException as exc:
             return exc.payload
 
-        ids = unify.get_logs(
+        ids = unisdk.get_logs(
             context=context,
             filter=f"name == {name!r}",
             limit=2,
@@ -1418,7 +1418,7 @@ class SecretManager(BaseSecretManager):
             raise ValueError(f"No secret found with name '{name}'.")
         if len(ids) > 1:
             raise RuntimeError(f"Multiple secrets found with name '{name}'.")
-        unify.delete_logs(context=context, logs=ids[0])
+        unisdk.delete_logs(context=context, logs=ids[0])
         try:
             if self._is_personal_context(context):
                 self._env_remove(name)

--- a/unity/spending_limits.py
+++ b/unity/spending_limits.py
@@ -14,9 +14,9 @@ Limit hierarchy:
 
 All checks run in parallel for minimal latency impact.
 
-Uses ``unify.AsyncSpendClient`` (aiohttp-backed) for connection pooling,
+Uses ``unisdk.AsyncSpendClient`` (aiohttp-backed) for connection pooling,
 automatic retries, and exponential backoff — matching the reliability
-characteristics of the sync ``unify.utils.http`` session.
+characteristics of the sync ``unisdk.utils.http`` session.
 """
 
 from __future__ import annotations
@@ -29,7 +29,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import TYPE_CHECKING, List, Optional
 
-from unify.async_admin import AsyncSpendClient, SpendRequestError
+from unisdk.async_admin import AsyncSpendClient, SpendRequestError
 
 if TYPE_CHECKING:
     from unillm.limit_hooks import LimitCheckRequest, LimitCheckResponse

--- a/unity/task_scheduler/storage.py
+++ b/unity/task_scheduler/storage.py
@@ -13,9 +13,9 @@ from typing import Any, Dict, Iterable, List, Optional, Union
 from enum import Enum
 from functools import cached_property
 
-import unify
+import unisdk
 
-from unify.utils.http import RequestError as _UnifyRequestError
+from unisdk.utils.http import RequestError as _UnifyRequestError
 from unity.common.authorship import strip_authoring_assistant_id
 from unity.common.log_utils import log as unity_log, create_logs as unity_create_logs
 from pydantic import BaseModel
@@ -38,7 +38,7 @@ class TasksStore:
         project: str | None = None,
     ) -> None:
         self._ctx = context
-        self._project = project or unify.active_project()
+        self._project = project or unisdk.active_project()
 
     # ----------------------------- Context ---------------------------------
     def ensure_context(
@@ -70,7 +70,7 @@ class TasksStore:
         # Ensure all required fields exist (idempotent per-field)
         try:
             existing = (
-                unify.get_fields(
+                unisdk.get_fields(
                     project=self._project,
                     context=self._ctx,
                 )
@@ -81,7 +81,7 @@ class TasksStore:
         missing = {k: v for k, v in fields.items() if k not in existing}
         if missing:
             try:
-                unify.create_fields(
+                unisdk.create_fields(
                     missing,
                     project=self._project,
                     context=self._ctx,
@@ -92,7 +92,7 @@ class TasksStore:
         # read the canonical 'data_type' representation.
         try:
             updated = (
-                unify.get_fields(
+                unisdk.get_fields(
                     project=self._project,
                     context=self._ctx,
                 )
@@ -114,7 +114,7 @@ class TasksStore:
     def fields(self) -> Dict[str, str]:
         try:
             fields = (
-                unify.get_fields(
+                unisdk.get_fields(
                     project=self._project,
                     context=self._ctx,
                 )
@@ -127,12 +127,12 @@ class TasksStore:
         except Exception:
             return {}
 
-    def _safe_get_logs(self, **kwargs) -> List[unify.Log] | List[int]:
+    def _safe_get_logs(self, **kwargs) -> List[unisdk.Log] | List[int]:
         """Get logs, treating missing contexts as empty during fresh/test runs."""
         if "project" not in kwargs:
             kwargs["project"] = self._project
         try:
-            return unify.get_logs(**kwargs)
+            return unisdk.get_logs(**kwargs)
         except _UnifyRequestError as e:
             status = getattr(getattr(e, "response", None), "status_code", None)
             if status == 404:
@@ -147,7 +147,7 @@ class TasksStore:
             raise
 
     def get_metric_count(self, *, key: str) -> int:
-        ret = unify.get_logs_metric(
+        ret = unisdk.get_logs_metric(
             metric="count",
             key=key,
             project=self._project,
@@ -161,7 +161,7 @@ class TasksStore:
 
         When the backend does not return a value (e.g., empty context), 0 is returned.
         """
-        ret = unify.get_logs_metric(
+        ret = unisdk.get_logs_metric(
             metric="max",
             key=key,
             project=self._project,
@@ -178,7 +178,7 @@ class TasksStore:
         return_ids_only: bool = False,
         exclude_fields: Optional[List[str]] = None,
         include_fields: Optional[List[str]] = None,
-    ) -> Union[List[int], List[unify.Log]]:
+    ) -> Union[List[int], List[unisdk.Log]]:
         return self._safe_get_logs(
             context=self._ctx,
             filter=filter,
@@ -194,7 +194,7 @@ class TasksStore:
         *,
         task_ids: Union[int, Iterable[int]],
         return_ids_only: bool = True,
-    ) -> List[Union[int, unify.Log]]:
+    ) -> List[Union[int, unisdk.Log]]:
         singular = isinstance(task_ids, int)
         original_id = task_ids if singular else None
         ids_list = [task_ids] if singular else list(task_ids)
@@ -219,7 +219,7 @@ class TasksStore:
         *,
         task_ids: Union[int, Iterable[int]],
         fields: Optional[List[str]] = None,
-    ) -> List[unify.Log]:
+    ) -> List[unisdk.Log]:
         """
         Fetch a minimal projection of rows for the specified task_ids.
 
@@ -287,7 +287,7 @@ class TasksStore:
     def update(
         self,
         *,
-        logs: Union[int, unify.Log, List[Union[int, unify.Log]]],
+        logs: Union[int, unisdk.Log, List[Union[int, unisdk.Log]]],
         entries: Union[Dict[str, Any], List[Dict[str, Any]]],
     ) -> Dict[str, str]:
         def _strip_nones(value: Any, *, top_level: bool) -> Any:
@@ -323,14 +323,14 @@ class TasksStore:
                 _strip_nones(TasksStore._norm(entries), top_level=True),
             ),
         )
-        return unify.update_logs(
+        return unisdk.update_logs(
             logs=logs,
             context=self._ctx,
             entries=norm_entries,
             overwrite=True,
         )
 
-    def log(self, *, entries: Dict[str, Any], new: bool = True) -> unify.Log:
+    def log(self, *, entries: Dict[str, Any], new: bool = True) -> unisdk.Log:
         norm_entries = TasksStore._with_explicit_task_types(TasksStore._norm(entries))
         # Create with expanded fields so auto-counting applies when ids are omitted
         return unity_log(
@@ -378,7 +378,7 @@ class TasksStore:
                     pass
             return {"log_event_ids": log_ids}
 
-    def get_rows_by_log_ids(self, *, log_ids: List[int]) -> List[unify.Log]:
+    def get_rows_by_log_ids(self, *, log_ids: List[int]) -> List[unisdk.Log]:
         """
         Fetch full log objects by their log-event ids. This avoids filtering by
         field values and allows precise retrieval of freshly-created rows.
@@ -398,7 +398,7 @@ class TasksStore:
         return res
 
     def delete(self, *, logs: Union[int, List[int]]) -> Dict[str, str]:
-        return unify.delete_logs(
+        return unisdk.delete_logs(
             project=self._project,
             context=self._ctx,
             logs=logs,

--- a/unity/task_scheduler/task_scheduler.py
+++ b/unity/task_scheduler/task_scheduler.py
@@ -20,7 +20,7 @@ from typing import (
     overload,
 )
 
-import unify
+import unisdk
 import unillm
 from pydantic import BaseModel
 
@@ -631,7 +631,7 @@ class TaskScheduler(BaseTaskScheduler):
     def clear(self) -> None:
         """Delete the current Tasks context and recreate local state."""
 
-        unify.delete_context(self._ctx)
+        unisdk.delete_context(self._ctx)
         self._num_tasks_cached = None
         self._active_task_root_context = None
 
@@ -659,7 +659,12 @@ class TaskScheduler(BaseTaskScheduler):
                 id_map[int(task_id)] = int(lg.id)
         return id_map
 
-    def _get_log_by_task_instance(self, *, task_id: int, instance_id: int) -> unify.Log:
+    def _get_log_by_task_instance(
+        self,
+        *,
+        task_id: int,
+        instance_id: int,
+    ) -> unisdk.Log:
         """Return the physical task row for one logical task instance."""
 
         task = self._get_task_or_raise(task_id)
@@ -770,7 +775,7 @@ class TaskScheduler(BaseTaskScheduler):
         ):
             return False
 
-        active_rows: list[tuple[str, unify.Log]] = []
+        active_rows: list[tuple[str, unisdk.Log]] = []
         for context_name in self._read_task_contexts():
             store = self._store_for_task_context(context_name)
             rows = store.get_rows(
@@ -783,7 +788,7 @@ class TaskScheduler(BaseTaskScheduler):
         if not active_rows:
             return True
 
-        stale_rows: list[tuple[str, unify.Log]] = []
+        stale_rows: list[tuple[str, unisdk.Log]] = []
         for context_name, row in active_rows:
             if int(row.id) == int(provenance.source_task_log_id):
                 return False
@@ -1291,7 +1296,7 @@ class TaskScheduler(BaseTaskScheduler):
         *,
         task_ids: Union[int, List[int]],
         return_ids_only: Literal[False],
-    ) -> List[unify.Log]: ...
+    ) -> List[unisdk.Log]: ...
 
     def _get_logs_by_task_ids(
         self,
@@ -1302,7 +1307,7 @@ class TaskScheduler(BaseTaskScheduler):
         """Fetch log objects or ids for one or many logical task ids."""
 
         task_id_list = task_ids if isinstance(task_ids, list) else [task_ids]
-        matches: list[unify.Log] = []
+        matches: list[unisdk.Log] = []
         for context_name in self._read_task_contexts():
             store = self._store_for_task_context(context_name)
             rows = store.get_logs_by_task_ids(
@@ -1983,7 +1988,7 @@ class TaskScheduler(BaseTaskScheduler):
     def _write_log_entries(
         self,
         *,
-        logs: Union[int, unify.Log, List[Union[int, unify.Log]]],
+        logs: Union[int, unisdk.Log, List[Union[int, unisdk.Log]]],
         entries: Union[Dict[str, Any], List[Dict[str, Any]]],
     ) -> Dict[str, str]:
         """Centralize task-row writes through the current store."""

--- a/unity/transcript_manager/activity_sync.py
+++ b/unity/transcript_manager/activity_sync.py
@@ -71,7 +71,7 @@ def touch_assistant_activity(assistant_id: int | str | None) -> bool:
         return False
 
     try:
-        from unify.utils import http
+        from unisdk.utils import http
 
         url = f"{base_url.rstrip('/')}/admin/assistant/{agent_id_int}/touch-activity"
         headers = {"Authorization": f"Bearer {admin_key}"}
@@ -126,7 +126,7 @@ def _post_followup_admin_action(
         return False
 
     try:
-        from unify.utils import http
+        from unisdk.utils import http
 
         url = f"{base_url.rstrip('/')}/admin/assistant/{agent_id_int}/{action_path}"
         headers = {"Authorization": f"Bearer {admin_key}"}

--- a/unity/transcript_manager/images.py
+++ b/unity/transcript_manager/images.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import base64
 from typing import Any, Dict, List, Optional
 
-import unify
+import unisdk
 
 from ..manager_registry import ManagerRegistry
 from .types.message import Message
@@ -22,7 +22,7 @@ def get_images_for_message(self, *, message_id: int) -> List[Dict[str, Any]]:
     logs = []
     transcript_context = self._transcripts_ctx
     for context in self._read_transcript_contexts():
-        logs = unify.get_logs(
+        logs = unisdk.get_logs(
             context=context,
             filter=f"message_id == {int(message_id)}",
             limit=1,
@@ -146,7 +146,7 @@ def attach_message_images_to_context(
     logs = []
     transcript_context = self._transcripts_ctx
     for context in self._read_transcript_contexts():
-        logs = unify.get_logs(
+        logs = unisdk.get_logs(
             context=context,
             filter=f"message_id == {int(message_id)}",
             limit=1,

--- a/unity/transcript_manager/search.py
+++ b/unity/transcript_manager/search.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional, Tuple
 
-import unify
+import unisdk
 
 from ..common.colleague_cache import (
     CURRENT_ASSISTANT_FALLBACK_LABEL,
@@ -360,7 +360,7 @@ def search_messages(
         all_messages = []
         offset = 0
         while True:
-            batch = unify.get_logs(
+            batch = unisdk.get_logs(
                 context=context,
                 offset=offset,
                 limit=SEARCH_BATCH_SIZE,

--- a/unity/transcript_manager/storage.py
+++ b/unity/transcript_manager/storage.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Dict, Optional, Set
 
-import unify
+import unisdk
 
 from ..common.federated_search import FederatedSearchContext, federated_count
 from ..common.log_utils import log as unity_log
@@ -59,8 +59,8 @@ def num_messages(self) -> int:
 
 def clear(self) -> None:
     """Delete both contexts and re-provision storage."""
-    unify.delete_context(self._transcripts_ctx)
-    unify.delete_context(self._exchanges_ctx)
+    unisdk.delete_context(self._transcripts_ctx)
+    unisdk.delete_context(self._exchanges_ctx)
 
     # No local cache to reset
 
@@ -77,7 +77,7 @@ def clear(self) -> None:
 
         for _ in range(3):
             try:
-                unify.get_fields(context=self._transcripts_ctx)
+                unisdk.get_fields(context=self._transcripts_ctx)
                 break
             except Exception:
                 _time.sleep(0.05)
@@ -89,7 +89,7 @@ def clear(self) -> None:
 
         for _ in range(3):
             try:
-                unify.get_fields(context=self._exchanges_ctx)
+                unisdk.get_fields(context=self._exchanges_ctx)
                 break
             except Exception:
                 _time.sleep(0.05)
@@ -112,7 +112,7 @@ def ensure_exchanges_records(
         ids_expr = ", ".join(str(i) for i in sorted(exchange_ids))
         existing: set[int] = set()
         try:
-            rows = unify.get_logs(
+            rows = unisdk.get_logs(
                 context=exchanges_context,
                 filter=f"exchange_id in [{ids_expr}]",
                 from_fields=["exchange_id"],

--- a/unity/transcript_manager/transcript_manager.py
+++ b/unity/transcript_manager/transcript_manager.py
@@ -5,7 +5,7 @@ import functools
 import threading
 from typing import List, Dict, Optional, Type, Union, Any, Callable, Literal
 
-import unify
+import unisdk
 from pydantic import BaseModel
 from ..common.authorship import stamp_authoring_assistant_id
 from ..common.colleague_cache import ColleagueNameCache
@@ -79,7 +79,7 @@ class TranscriptManager(BaseTranscriptManager):
     # ──────────────────────────────────────────────────────────────────────
     #  Class-level constants / configuration
     # ──────────────────────────────────────────────────────────────────────
-    _LOGGER = unify.AsyncLoggerManager(name="TranscriptManager", num_consumers=16)
+    _LOGGER = unisdk.AsyncLoggerManager(name="TranscriptManager", num_consumers=16)
 
     # Vector embedding column names
     _MSG_EMB = "_content_emb"
@@ -639,7 +639,7 @@ class TranscriptManager(BaseTranscriptManager):
                     if key not in {"explicit_types", "infer_untyped_fields"}
                 }
                 future = self._get_logger().log_create(
-                    project=unify.active_project(),
+                    project=unisdk.active_project(),
                     context={"name": transcripts_context},
                     entries=entries_with_private,
                 )
@@ -754,7 +754,7 @@ class TranscriptManager(BaseTranscriptManager):
         if exchange_id is None:
             return None
         try:
-            rows = unify.get_logs(
+            rows = unisdk.get_logs(
                 context=state["context"],
                 filter=f"exchange_id == {int(exchange_id)}",
                 limit=20,
@@ -975,7 +975,7 @@ class TranscriptManager(BaseTranscriptManager):
             or a list such as ``[\"medium\", \"sender_id\"]`` to group
             hierarchically in that order. When provided, the result becomes a
             nested mapping keyed by group values, mirroring
-            :func:`unify.get_logs_metric`.
+            :func:`unisdk.get_logs_metric`.
 
         Returns
         -------
@@ -1074,13 +1074,13 @@ class TranscriptManager(BaseTranscriptManager):
 
         # ── 1.  Bulk update all *sender_id* occurrences ────────────────────
         for context in self._read_transcript_contexts():
-            sender_log_ids = unify.get_logs(
+            sender_log_ids = unisdk.get_logs(
                 context=context,
                 filter=f"sender_id is not None and sender_id == {original_contact_id}",
                 return_ids_only=True,
             )
             if sender_log_ids:
-                unify.update_logs(
+                unisdk.update_logs(
                     logs=sender_log_ids,
                     context=context,
                     entries={"sender_id": new_contact_id},
@@ -1089,7 +1089,7 @@ class TranscriptManager(BaseTranscriptManager):
                 total_updates += len(sender_log_ids)
 
             # ── 2.  Update all *receiver_ids* lists containing the old id ──────
-            receiver_logs = unify.get_logs(
+            receiver_logs = unisdk.get_logs(
                 context=context,
                 filter=f"{original_contact_id} in receiver_ids",
                 return_ids_only=False,
@@ -1113,7 +1113,7 @@ class TranscriptManager(BaseTranscriptManager):
 
                 # Only write when the list actually changed
                 if deduped_rids != rids:
-                    unify.update_logs(
+                    unisdk.update_logs(
                         logs=lg.id if hasattr(lg, "id") else lg,
                         context=context,
                         entries={"receiver_ids": deduped_rids},
@@ -1142,13 +1142,13 @@ class TranscriptManager(BaseTranscriptManager):
             context = self._transcripts_context_for_destination(destination)
         except ToolErrorException as exc:
             return exc.payload  # type: ignore[return-value]
-        log_ids = unify.get_logs(
+        log_ids = unisdk.get_logs(
             context=context,
             filter=f"message_id == {message_id}",
             return_ids_only=True,
         )
         if log_ids:
-            unify.update_logs(
+            unisdk.update_logs(
                 logs=log_ids,
                 context=context,
                 entries={"images": images},
@@ -1380,7 +1380,7 @@ class TranscriptManager(BaseTranscriptManager):
             contexts = [self._exchanges_context_for_destination(destination)]
         rows = []
         for context in contexts:
-            rows = unify.get_logs(
+            rows = unisdk.get_logs(
                 context=context,
                 filter=f"exchange_id == {int(exchange_id)}",
                 limit=1,
@@ -1415,13 +1415,13 @@ class TranscriptManager(BaseTranscriptManager):
         except ToolErrorException as exc:
             return exc.payload  # type: ignore[return-value]
         # Try update first
-        row_ids = unify.get_logs(
+        row_ids = unisdk.get_logs(
             context=context,
             filter=f"exchange_id == {int(exchange_id)}",
             return_ids_only=True,
         )
         if row_ids:
-            unify.update_logs(
+            unisdk.update_logs(
                 logs=row_ids,
                 context=context,
                 entries={"metadata": dict(metadata or {})},
@@ -1455,7 +1455,7 @@ class TranscriptManager(BaseTranscriptManager):
         fetch_limit = (offset + limit) if limit is not None else 1000
         for context in self._read_exchange_contexts():
             logs.extend(
-                unify.get_logs(
+                unisdk.get_logs(
                     context=context,
                     filter=normalized,
                     offset=0,
@@ -1631,7 +1631,7 @@ class TranscriptManager(BaseTranscriptManager):
         source_context = self._context_for_root(source_root, table_name)
         target_context = self._context_for_root(target_root, table_name)
 
-        rows = unify.get_logs(
+        rows = unisdk.get_logs(
             context=source_context,
             filter=f"{id_field} == {int(row_id)}",
             limit=2,
@@ -1650,7 +1650,7 @@ class TranscriptManager(BaseTranscriptManager):
             payload = record.to_post_json()
         else:
             payload = record.model_dump(mode="json")
-        target_ids = unify.get_logs(
+        target_ids = unisdk.get_logs(
             context=target_context,
             filter=f"{id_field} == {int(row_id)}",
             return_ids_only=True,
@@ -1661,7 +1661,7 @@ class TranscriptManager(BaseTranscriptManager):
                 f"Multiple {table_name} rows found with {id_field}={int(row_id)} in {target_context}.",
             )
         if target_ids:
-            unify.update_logs(
+            unisdk.update_logs(
                 context=target_context,
                 logs=[target_ids[0]],
                 entries=payload,
@@ -1675,7 +1675,7 @@ class TranscriptManager(BaseTranscriptManager):
                 mutable=True,
             )
 
-        unify.delete_logs(context=source_context, logs=rows[0].id)
+        unisdk.delete_logs(context=source_context, logs=rows[0].id)
         return {
             "outcome": f"{table_name} row moved",
             "details": {
@@ -1741,7 +1741,7 @@ class TranscriptManager(BaseTranscriptManager):
 
     # Misc small utilities (kept last)
     @classmethod
-    def _get_logger(cls) -> unify.AsyncLoggerManager:
+    def _get_logger(cls) -> unisdk.AsyncLoggerManager:
         return cls._LOGGER
 
     @staticmethod

--- a/uv.lock
+++ b/uv.lock
@@ -9330,7 +9330,45 @@ wheels = [
 ]
 
 [[package]]
-name = "unify"
+name = "unillm"
+version = "0.0.0"
+source = { editable = "../unillm" }
+dependencies = [
+    { name = "litellm" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "unisdk" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "litellm", specifier = "==1.88.0" },
+    { name = "pydantic", specifier = ">=2.12.5" },
+    { name = "pydantic-settings", specifier = ">=2.12.0" },
+    { name = "unisdk", editable = "../unisdk" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "autoflake", specifier = ">=2.3.1" },
+    { name = "black", specifier = "==26.5.1" },
+    { name = "opentelemetry-api", specifier = ">=1.20.0" },
+    { name = "opentelemetry-exporter-otlp", specifier = ">=1.20.0" },
+    { name = "opentelemetry-sdk", specifier = ">=1.20.0" },
+    { name = "pre-commit", specifier = ">=4.0.1" },
+    { name = "pytest", specifier = ">=8.4.2" },
+    { name = "pytest-asyncio", specifier = ">=0.24.0" },
+    { name = "pytest-dotenv", specifier = ">=0.5.2" },
+    { name = "pytest-timeout", specifier = ">=2.3.1" },
+    { name = "ruff", specifier = ">=0.15.16" },
+]
+lint = [
+    { name = "autoflake", specifier = ">=2.3.1" },
+    { name = "black", specifier = "==26.5.1" },
+]
+
+[[package]]
+name = "unisdk"
 version = "0.0.0"
 source = { editable = "../unisdk" }
 dependencies = [
@@ -9369,44 +9407,6 @@ lint = [
     { name = "autoflake", specifier = ">=1.6.1" },
     { name = "black", specifier = "==26.5.1" },
     { name = "isort", specifier = ">=5.11.4" },
-]
-
-[[package]]
-name = "unillm"
-version = "0.0.0"
-source = { editable = "../unillm" }
-dependencies = [
-    { name = "litellm" },
-    { name = "pydantic" },
-    { name = "pydantic-settings" },
-    { name = "unify" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "litellm", specifier = "==1.88.0" },
-    { name = "pydantic", specifier = ">=2.12.5" },
-    { name = "pydantic-settings", specifier = ">=2.12.0" },
-    { name = "unify", editable = "../unisdk" },
-]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "autoflake", specifier = ">=2.3.1" },
-    { name = "black", specifier = "==26.5.1" },
-    { name = "opentelemetry-api", specifier = ">=1.20.0" },
-    { name = "opentelemetry-exporter-otlp", specifier = ">=1.20.0" },
-    { name = "opentelemetry-sdk", specifier = ">=1.20.0" },
-    { name = "pre-commit", specifier = ">=4.0.1" },
-    { name = "pytest", specifier = ">=8.4.2" },
-    { name = "pytest-asyncio", specifier = ">=0.24.0" },
-    { name = "pytest-dotenv", specifier = ">=0.5.2" },
-    { name = "pytest-timeout", specifier = ">=2.3.1" },
-    { name = "ruff", specifier = ">=0.15.16" },
-]
-lint = [
-    { name = "autoflake", specifier = ">=2.3.1" },
-    { name = "black", specifier = "==26.5.1" },
 ]
 
 [[package]]
@@ -9463,8 +9463,8 @@ dependencies = [
     { name = "textual-dev" },
     { name = "tiktoken" },
     { name = "twilio" },
-    { name = "unify" },
     { name = "unillm" },
+    { name = "unisdk" },
     { name = "uvicorn", extra = ["standard"] },
     { name = "websockify" },
 ]
@@ -9546,8 +9546,8 @@ requires-dist = [
     { name = "textual-dev", specifier = ">=1.2.0" },
     { name = "tiktoken", specifier = ">=0.11.0" },
     { name = "twilio", specifier = ">=8.0.0" },
-    { name = "unify", editable = "../unisdk" },
     { name = "unillm", editable = "../unillm" },
+    { name = "unisdk", editable = "../unisdk" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.24.0" },
     { name = "websockify", specifier = ">=0.13.0" },
 ]


### PR DESCRIPTION
## Summary
- Consume the renamed SDK package as `unisdk` (was `unify`): imports, patch targets, dependency name + uv source key, lockfile, CI, Dockerfiles.
- Rename the SDK-config env vars `UNIFY_*` -> `UNISDK_*` (keeping `UNIFY_KEY`, product vars, `api.unify.ai`).

## Test plan
- [x] Staging CI green