### PR TITLE
Promote staging to main: rename SDK log-dir path values to unisdk

### DIFF
--- a/.cursor/rules/log-directory-navigation.mdc
+++ b/.cursor/rules/log-directory-navigation.mdc
@@ -1,5 +1,5 @@
 ---
-description: How to navigate and read log files (logs/pytest/, logs/unity/, logs/unillm/, logs/unify/, logs/orchestra/, logs/all/)
+description: How to navigate and read log files (logs/pytest/, logs/unity/, logs/unillm/, logs/unisdk/, logs/orchestra/, logs/all/)
 globs: ["**/*"]
 alwaysApply: true
 ---
@@ -25,7 +25,7 @@ The `logs/` directory is gitignored, which affects tool availability:
 | `logs/pytest/` | Test output logs (datetime-prefixed subdirs per run) |
 | `logs/unity/` | Unity LOGGER output (async tool loop, managers) |
 | `logs/unillm/` | Raw LLM request/response traces |
-| `logs/unify/` | Unify SDK HTTP traces |
+| `logs/unisdk/` | Unify SDK HTTP traces |
 | `logs/orchestra/` | Orchestra session logs with per-request API traces |
 | `logs/all/` | Cross-repo OTEL traces |
 

--- a/conftest.py
+++ b/conftest.py
@@ -481,14 +481,14 @@ def pytest_sessionstart(session):
     subdir = _get_log_subdir()
 
     # Unify SDK file logging
-    unify_log_dir = root_path / "logs" / "unify" / subdir
-    unify_log_dir.mkdir(parents=True, exist_ok=True)
+    unisdk_log_dir = root_path / "logs" / "unify" / subdir
+    unisdk_log_dir.mkdir(parents=True, exist_ok=True)
     try:
-        from unisdk.utils.http import configure_log_dir as configure_unify_log_dir
+        from unisdk.utils.http import configure_log_dir as configure_unisdk_log_dir
 
-        configure_unify_log_dir(str(unify_log_dir))
+        configure_unisdk_log_dir(str(unisdk_log_dir))
     except ImportError:
-        os.environ["UNISDK_LOG_DIR"] = str(unify_log_dir)
+        os.environ["UNISDK_LOG_DIR"] = str(unisdk_log_dir)
 
     # Unillm LLM I/O file logging (raw request/response traces)
     unillm_log_dir = root_path / "logs" / "unillm" / subdir

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -143,7 +143,7 @@ ENV UNITY_TERMINAL_LOG=true
 ENV UNISDK_TERMINAL_LOG=false
 ENV UNILLM_TERMINAL_LOG=false
 ENV UNITY_LOG_DIR=/var/log/unity
-ENV UNISDK_LOG_DIR=/var/log/unify
+ENV UNISDK_LOG_DIR=/var/log/unisdk
 ENV UNILLM_LOG_DIR=/var/log/unillm
 ENV MAGNITUDE_LOG_DIR=/var/log/magnitude
 ENV MAGNITUDE_DEBUG=true
@@ -155,10 +155,10 @@ RUN mkdir -p /root/.vnc && chmod 777 /root /root/.vnc && \
 
 # Create non-root user for runtime
 RUN useradd -m -u 1000 unity && \
-    mkdir -p /var/log/unity /var/log/unify /var/log/unillm /var/log/magnitude /home/unity/.cache /home/unity/.config && \
+    mkdir -p /var/log/unity /var/log/unisdk /var/log/unillm /var/log/magnitude /home/unity/.cache /home/unity/.config && \
     mkdir -p /run/dbus && chmod 777 /run/dbus && \
     mkdir -p /tmp/runtime-unity && chown unity:unity /tmp/runtime-unity && chmod 700 /tmp/runtime-unity && \
-    chown -R unity:unity /app /var/log/unity /var/log/unify /var/log/unillm /var/log/magnitude && \
+    chown -R unity:unity /app /var/log/unity /var/log/unisdk /var/log/unillm /var/log/magnitude && \
     cp -r /root/.config/xfce4 /home/unity/.config/xfce4 2>/dev/null || true && \
     chown -R unity:unity /home/unity
 

--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -123,7 +123,7 @@ on_signal() {
 trap on_signal SIGTERM SIGINT
 
 # Create log directories for file-based traces in background
-mkdir -p /var/log/unity /var/log/unify /var/log/unillm &
+mkdir -p /var/log/unity /var/log/unisdk /var/log/unillm &
 
 # Announce where logs will be preserved after shutdown
 if [ ! -z "$UNITY_CONVERSATION_JOB_NAME" ]; then

--- a/deploy/scripts/upload_pod_logs.py
+++ b/deploy/scripts/upload_pod_logs.py
@@ -26,7 +26,12 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 BUCKET_NAME = os.environ.get("GCS_LOG_BUCKET", "unity-pod-logs")
-LOG_DIRS = ["/var/log/unity", "/var/log/unify", "/var/log/unillm", "/var/log/magnitude"]
+LOG_DIRS = [
+    "/var/log/unity",
+    "/var/log/unisdk",
+    "/var/log/unillm",
+    "/var/log/magnitude",
+]
 JOB_NAME = os.environ.get("UNITY_CONVERSATION_JOB_NAME", "")
 
 

--- a/logs/README.md
+++ b/logs/README.md
@@ -105,7 +105,7 @@ All logs are organized under `logs/` with seven main subdirectories:
 | `logs/pytest/` | Test output (stdout/stderr) | One `.txt` per test | Test-only |
 | `logs/unity/` | Unity LOGGER output (async tool loop, managers) | `unity.log` per session | `UNITY_LOG` + `UNITY_LOG_DIR` |
 | `logs/unillm/` | Raw LLM request/response traces | `.txt` files per request | `UNILLM_LOG_DIR` (+ `UNILLM_TERMINAL_LOG` for console) |
-| `logs/unify/` | Unify SDK HTTP traces | JSON files per request | `UNISDK_LOG_DIR` (+ `UNISDK_TERMINAL_LOG` for console) |
+| `logs/unisdk/` | Unify SDK HTTP traces | JSON files per request | `UNISDK_LOG_DIR` (+ `UNISDK_TERMINAL_LOG` for console) |
 | `logs/orchestra/` | Orchestra API traces | Per-request JSON with OpenTelemetry spans | `ORCHESTRA_LOG_DIR` |
 | `logs/magnitude/` | **Magnitude agent debug** (screenshots, act traces, coordinates) | Per-act bundles with PNGs | `MAGNITUDE_LOG_DIR` + `MAGNITUDE_DEBUG` |
 | `logs/all/` | **Cross-repo OTEL traces** | `{trace_id}.jsonl` per test | `*_OTEL` + `*_OTEL_LOG_DIR` |
@@ -203,12 +203,12 @@ logs/unity/
 
 ---
 
-## Unify Logs (`logs/unify/`)
+## Unify Logs (`logs/unisdk/`)
 
 Unify SDK HTTP traces capture all requests to the Orchestra API with OpenTelemetry trace correlation.
 
 ```
-logs/unify/
+logs/unisdk/
 ├── 2025-12-05T09-15-22_unity_dev_ttys042/
 │   ├── 14-26-27.611_POST_project-UnityTests-contexts_210ms_200_no-trace.json
 │   ├── 14-26-46.175_GET_logs_331ms_200_f124f0d3.json   # trace_id suffix!
@@ -661,7 +661,7 @@ logs/pytest/         →  [TRACE] TRACE_ID=...7be454fc test=test_ask
     ↓ (same session)
 logs/unity/          →  ➡️ [ContactManager.ask(ca3e)] Request: ...
     ↓ (same trace_id)
-logs/unify/          →  14-26-46.175_GET_logs_331ms_200_7be454fc.json
+logs/unisdk/          →  14-26-46.175_GET_logs_331ms_200_7be454fc.json
     ↓ (same trace_id)
 logs/orchestra/      →  2025-12-30T18-46-55.980_GET_projects_43ms_7be454fc.json
 ```
@@ -685,7 +685,7 @@ grep "TRACE_ID=" logs/pytest/2025-12-30T18-30-00_unity_dev_ttys042/contact_manag
 The last 8 characters of the trace_id appear in the filename:
 ```bash
 # trace_id=099b207f89222185695d25977be454fc → search for *7be454fc*
-ls logs/unify/2025-12-30T18-30-00_unity_dev_ttys042/*7be454fc*
+ls logs/unisdk/2025-12-30T18-30-00_unity_dev_ttys042/*7be454fc*
 ```
 
 **Step 3: Find matching Orchestra trace files**
@@ -698,7 +698,7 @@ ls logs/orchestra/2025-12-30T18-27-43/requests/*7be454fc*
 
 ```bash
 # Unify SDK request/response
-cat logs/unify/2025-12-30T18-30-00_unity_dev_ttys042/*7be454fc*.json | jq .
+cat logs/unisdk/2025-12-30T18-30-00_unity_dev_ttys042/*7be454fc*.json | jq .
 
 # Orchestra server-side trace
 cat logs/orchestra/2025-12-30T18-27-43/requests/*7be454fc*.json | jq .
@@ -715,7 +715,7 @@ grep TRACE_ID logs/pytest/2025-12-30T18-30-00_unity_dev/contact_manager-test_ask
 cat logs/unity/2025-12-30T18-30-00_unity_dev/unity.log | grep "ContactManager"
 
 # 3. Find Unify SDK HTTP calls with matching trace
-ls logs/unify/2025-12-30T18-30-00_unity_dev/*7be454fc*
+ls logs/unisdk/2025-12-30T18-30-00_unity_dev/*7be454fc*
 
 # 4. Find Orchestra server traces
 ls logs/orchestra/*/requests/*7be454fc*


### PR DESCRIPTION
Rename the SDK log-dir path values (logs/unify, /var/log/unify, pod_logs/unify, $LOGS_DIR/unify) to unisdk for consistency. Product /unify/* routes and other log dirs (unillm/unity/all) unchanged.