### PR TITLE
Promote staging to main

### DIFF
--- a/tests/conversation_manager/voice/test_fast_brain_context_window.py
+++ b/tests/conversation_manager/voice/test_fast_brain_context_window.py
@@ -12,7 +12,6 @@ Covers:
 All tests are symbolic — unisdk.get_logs is mocked to return synthetic log rows.
 """
 
-import json
 from datetime import datetime, timezone, timedelta
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -74,7 +73,11 @@ ASSISTANT_NAME = "Alex"
 
 
 def _make_log_rows(cm_events):
-    """Convert CM events to unisdk.Log-shaped rows in descending order (newest first)."""
+    """Convert CM events to unisdk.Log-shaped rows in descending order (newest first).
+
+    Events live in their per-type context (``Events/Comms``) with payload fields
+    spread into top-level columns, so the mock rows mirror that schema.
+    """
     rows = []
     for ev in cm_events:
         payload = ev.to_dict()["payload"]
@@ -82,9 +85,8 @@ def _make_log_rows(cm_events):
         rows.append(
             SimpleNamespace(
                 entries={
-                    "type": "Comms",
                     "payload_cls": ev.__class__.__name__,
-                    "payload_json": json.dumps(payload),
+                    **payload,
                 },
             ),
         )
@@ -526,8 +528,7 @@ class TestHydrateFastBrainHistory:
             await hydrate_fast_brain_history({2}, False, ASSISTANT_NAME, limit=25)
 
         mock_get_logs.assert_called_once_with(
-            context="test_user/test_assistant/Events",
-            filter='type == "Comms"',
+            context="test_user/test_assistant/Events/Comms",
             sorting={"timestamp": "descending"},
             limit=25,
         )
@@ -539,9 +540,8 @@ class TestHydrateFastBrainHistory:
         log_rows = _make_log_rows([good])
         bad_row = SimpleNamespace(
             entries={
-                "type": "Comms",
                 "payload_cls": "NonExistentEvent",
-                "payload_json": json.dumps({"broken": True}),
+                "broken": True,
             },
         )
         log_rows.insert(0, bad_row)

--- a/tests/event_bus/test_global_vs_specific_schema.py
+++ b/tests/event_bus/test_global_vs_specific_schema.py
@@ -1,19 +1,17 @@
-"""Tests verifying the distinct schema strategies for global vs type-specific contexts.
+"""Tests for the per-type Event storage schema.
 
-Global context (`Events`): Stores payload as single `payload_json` column to avoid
-cross-type schema conflicts when different event types have same field names with
-different types.
-
-Type-specific contexts (`Events/ToolLoop`, etc.): Spreads payload fields for
-queryability within a homogeneous event type.
+Events are stored only in their type-specific context (`Events/ToolLoop`,
+`Events/ManagerMethod`, ...), with payload fields spread into top-level columns
+for queryability. The base `Events` context is retained purely as the naming
+parent (and for `_callbacks`); it no longer receives event rows.
 """
 
-import json
 import pytest
 import datetime as dt
 
 import unisdk
 
+from unify.common.log_utils import payload_from_log_entries
 from unify.events.event_bus import EventBus, Event
 from unify.events.types.manager_method import ManagerMethodPayload
 from unify.events.types.tool_loop import ToolLoopPayload, ToolLoopKind
@@ -22,13 +20,10 @@ from tests.helpers import _handle_project
 
 @pytest.mark.asyncio
 @_handle_project
-async def test_global_context_stores_payload_json():
-    """Global context should store payload as a single payload_json column,
-    not spread individual payload fields.
-    """
+async def test_base_events_context_receives_no_event_rows():
+    """Publishing writes only to the per-type context, not the base `Events`."""
     bus = EventBus()
 
-    # Publish a ManagerMethod event
     payload = ManagerMethodPayload(
         manager="TestManager",
         method="test_method",
@@ -43,26 +38,21 @@ async def test_global_context_stores_payload_json():
     await bus.publish(event)
     bus.join_published()
 
-    # Query the global context directly to inspect raw schema
-    global_ctx = bus._global_ctx
-    logs = unisdk.get_logs(
+    # The base/global context must not receive the event row anymore.
+    global_logs = unisdk.get_logs(
         project=unisdk.active_project(),
-        context=global_ctx,
+        context=bus._global_ctx,
         filter=f"event_id == '{event.event_id}'",
     )
+    assert global_logs == []
 
-    assert len(logs) == 1
-    log_entry = logs[0].entries
-
-    # Should have payload_json as a single column
-    assert "payload_json" in log_entry
-    parsed = json.loads(log_entry["payload_json"])
-    assert parsed["manager"] == "TestManager"
-    assert parsed["method"] == "test_method"
-
-    # Should NOT have spread payload fields in global context
-    assert "manager" not in log_entry
-    assert "method" not in log_entry
+    # The per-type context holds exactly one spread row for the event.
+    specific_logs = unisdk.get_logs(
+        project=unisdk.active_project(),
+        context=bus._specific_ctxs["ManagerMethod"],
+        filter=f"event_id == '{event.event_id}'",
+    )
+    assert len(specific_logs) == 1
 
 
 @pytest.mark.asyncio
@@ -102,7 +92,7 @@ async def test_specific_context_spreads_payload():
     assert log_entry["method"] == "ask"
     assert log_entry["phase"] == "incoming"
 
-    # Should NOT have payload_json in specific context
+    # Should NOT have a payload_json blob column
     assert "payload_json" not in log_entry
 
 
@@ -169,10 +159,8 @@ async def test_toolloop_complex_message_no_type_conflict():
 
 @pytest.mark.asyncio
 @_handle_project
-async def test_rehydration_from_payload_json():
-    """Events retrieved via search() should correctly rehydrate payload from
-    payload_json column in global context.
-    """
+async def test_rehydration_from_spread_fields():
+    """search() should rehydrate the payload from the per-type spread columns."""
     bus = EventBus()
 
     # Publish a ToolLoop event with a complex message
@@ -192,7 +180,7 @@ async def test_rehydration_from_payload_json():
     await bus.publish(event)
     bus.join_published()
 
-    # Search for the event (uses global context read path)
+    # Search for the event (reads the per-type context spread schema)
     results = await bus.search(
         filter=f"event_id == '{event.event_id}'",
         limit=1,
@@ -206,3 +194,29 @@ async def test_rehydration_from_payload_json():
     assert retrieved.payload["hierarchy"] == ["level1", "level2"]
 
     assert retrieved.event_id == event.event_id
+
+
+def test_payload_from_log_entries_strips_metadata_and_private_fields():
+    """payload_from_log_entries recovers the original payload from a spread row."""
+    row = {
+        "row_id": 7,
+        "event_id": "abc",
+        "calling_id": "",
+        "event_timestamp": "2026-01-01T00:00:00+00:00",
+        "payload_cls": "unify.events.types.tool_loop.ToolLoopPayload",
+        "type": "ToolLoop",
+        "_user": "user-1",
+        "_user_id": "user-1",
+        "_assistant": "42",
+        "_assistant_id": 42,
+        "_org": None,
+        "_org_id": None,
+        "method": "act",
+        "hierarchy": ["root"],
+        "kind": "thought",
+    }
+    assert payload_from_log_entries(row) == {
+        "method": "act",
+        "hierarchy": ["root"],
+        "kind": "thought",
+    }

--- a/tests/event_bus/test_windows.py
+++ b/tests/event_bus/test_windows.py
@@ -54,13 +54,13 @@ async def test_cache_only_skips_backend():
     contents = [r.payload.get("content") for r in results]
     assert contents == ["4", "3", "2"]
 
-    # Verify no backend call was made for Message type specifically
-    # The filter arg starts with 'type == "Message"' when fetching Message events
-    # (Other types like ToolLoop/Comms may be fetched but won't match our filter)
+    # Verify no backend call was made against the Message per-type context
+    # (the deque/cache should have satisfied the search). Each type is read from
+    # its own ``Events/{Type}`` context, so a Message fetch targets that context.
     message_fetch_calls = [
         call
         for call in spy.call_args_list
-        if call.kwargs.get("filter", "").startswith('type == "Message"')
+        if str(call.kwargs.get("context", "")).endswith("Events/Message")
     ]
     assert (
         len(message_fetch_calls) == 0

--- a/unify/common/log_utils.py
+++ b/unify/common/log_utils.py
@@ -121,6 +121,27 @@ def _inject_private_fields(entries: Dict[str, Any]) -> Dict[str, Any]:
     return result
 
 
+# EventBus metadata columns stored alongside an event's spread payload fields.
+_EVENT_META_KEYS = frozenset(
+    {"row_id", "event_id", "calling_id", "event_timestamp", "payload_cls", "type"},
+)
+
+
+def payload_from_log_entries(entries: Dict[str, Any]) -> Dict[str, Any]:
+    """Reconstruct an event payload from a spread event log row.
+
+    Events are stored in their per-type context with payload fields spread into
+    top-level columns. This drops the EventBus metadata columns and the injected
+    private fields (all underscore-prefixed, see :func:`_inject_private_fields`)
+    so the result matches the payload dict that was originally published.
+    """
+    return {
+        key: value
+        for key, value in entries.items()
+        if key not in _EVENT_META_KEYS and not key.startswith("_")
+    }
+
+
 def log(
     context: str,
     *,

--- a/unify/conversation_manager/medium_scripts/common.py
+++ b/unify/conversation_manager/medium_scripts/common.py
@@ -79,6 +79,7 @@ from unify.conversation_manager.tracing import (
 from unify.session_details import SESSION_DETAILS
 from unify.logger import LOGGER
 from unify.common.hierarchical_logger import DEFAULT_ICON, ICONS
+from unify.common.log_utils import payload_from_log_entries
 
 # ─────────────────────────────────────────────────────────────────────────────
 # FastBrainLogger — mirrors the async tool loop's LoopLogger format so all
@@ -1539,14 +1540,14 @@ async def hydrate_fast_brain_history(
     import unisdk
 
     context = (
-        f"{SESSION_DETAILS.user_context}/" f"{SESSION_DETAILS.assistant_context}/Events"
+        f"{SESSION_DETAILS.user_context}/"
+        f"{SESSION_DETAILS.assistant_context}/Events/Comms"
     )
 
     try:
         logs = await asyncio.to_thread(
             unisdk.get_logs,
             context=context,
-            filter='type == "Comms"',
             sorting={"timestamp": "descending"},
             limit=limit,
         )
@@ -1565,12 +1566,11 @@ async def hydrate_fast_brain_history(
         if "." in payload_cls:
             payload_cls = payload_cls.rsplit(".", 1)[-1]
 
-        payload_json_str = entries.get("payload_json")
-        if not payload_json_str:
+        payload = payload_from_log_entries(entries)
+        if not payload:
             continue
 
         try:
-            payload = json.loads(payload_json_str)
             cm_event = Event.from_dict({"event_name": payload_cls, "payload": payload})
         except Exception:
             continue

--- a/unify/events/event_bus.py
+++ b/unify/events/event_bus.py
@@ -42,7 +42,7 @@ from uuid import uuid4
 
 __all__ = ["Event", "EventBus", "Subscription", "EVENT_BUS"]
 from ..common.global_docstrings import CLEAR_METHOD_DOCSTRING
-from ..common.log_utils import _inject_private_fields
+from ..common.log_utils import _inject_private_fields, payload_from_log_entries
 from ..common.model_to_fields import model_to_fields
 from ..logger import LOGGER
 from .stream_filters import is_streaming_noise
@@ -903,7 +903,7 @@ class EventBus:
             else Event._to_python(event.payload)
         )
 
-        # Base entries for both log calls (before private field injection)
+        # Base entries for the log write (before private field injection)
         base_entries = {
             "row_id": event.row_id,
             "event_id": event.event_id,
@@ -912,19 +912,15 @@ class EventBus:
             "payload_cls": event.payload_cls,
         }
 
-        # Buffer entries for deferred batch upload (flushed in flush()/clear())
-        global_entries = _inject_private_fields(
-            {
-                **base_entries,
-                "type": event.type,
-                "payload_json": json.dumps(payload_dict),
-            },
-        )
-        self._pending_writes.append((global_entries, self._global_ctx))
-
+        # Buffer entries for deferred batch upload (flushed in flush()/clear()).
+        # Events are stored only in their per-type context, with payload fields
+        # spread into columns for queryability. ``type`` is retained as a column
+        # (not just implied by the context name) so ``type``-predicated search
+        # filters resolve against the per-type context read path.
         specific_entries = _inject_private_fields(
             {
                 **base_entries,
+                "type": event.type,
                 **payload_dict,
             },
         )
@@ -1229,48 +1225,26 @@ class EventBus:
             need_backend[etype] = still_needed
 
         # ----------------------------------------------------------------------
-        # 3a. FAST-PATH: one backend call when we are in "global window" mode
-        #     *and* have no in-memory events yet (cold start). This avoids N
-        #     serial/parallel round-trips while staying trivial to reason about.
+        # Per-type backend fetches – concurrently. Each event type lives in its
+        # own context (``Events/{Type}``), so a fetch reads that context directly
+        # with no ``type`` predicate; the combined-window merge happens in the
+        # shaping step below.
         # ----------------------------------------------------------------------
-        if combined_window and all(len(dq) == 0 for dq in self._deques.values()):
-
-            if need_backend:  # only when something is actually missing
-                types_in = ", ".join(f'"{et}"' for et in need_backend)
-                global_limit = offset + limit
-                full_filter = f"type in ({types_in})"
-                if filter:
-                    full_filter += f" and ({filter})"
-
-                logs = await asyncio.to_thread(
-                    unisdk.get_logs,
-                    context=self._global_ctx,
-                    filter=full_filter,
-                    sorting={"timestamp": "descending"},
-                    offset=0,
-                    limit=global_limit,
-                )
-
-                for lg in logs:
-                    evt = self._row_to_event(lg.entries)
-                    in_memory.setdefault(evt.type, []).append(evt)
-
-                # We've satisfied the need; skip the per-type fetch branch
-                need_backend.clear()
-
-        # ----------------------------------------------------------------------
-        # 3b. Per-type backend fetches – concurrently (as before) --------------
         async def _fetch_one(etype: str, want: int) -> tuple[str, list[Event]]:
             """
             Run the blocking ``unisdk.get_logs`` call in a worker thread and
             re-wrap the raw log rows as :class:`Event` objects.
             """
-            full_filter = f'type == "{etype}"' + (f" and ({filter})" if filter else "")
+            context = self._specific_ctxs.get(etype)
+            if context is None:
+                # A type with an in-memory deque but no registered backend
+                # context has nothing to fetch from Orchestra.
+                return etype, []
 
             logs = await asyncio.to_thread(
                 unisdk.get_logs,
-                context=self._global_ctx,
-                filter=full_filter,
+                context=context,
+                filter=filter,
                 sorting={"timestamp": "descending"},
                 offset=backend_offsets[etype],
                 limit=want,
@@ -1736,14 +1710,16 @@ class EventBus:
         # Prefer non-flattened payload when available (newer schema)
         payload_json_str = entries.pop("payload_json", None)
 
-        # Determine the payload dict: prefer JSON blob when present
+        # Determine the payload dict. Legacy global-context rows carry the whole
+        # payload as a JSON blob; per-type rows spread it into columns, so strip
+        # the injected private fields to recover the original payload.
         if payload_json_str is not None:
             try:
                 payload_dict = json.loads(payload_json_str)
             except Exception:
-                payload_dict = entries
+                payload_dict = payload_from_log_entries(entries)
         else:
-            payload_dict = entries
+            payload_dict = payload_from_log_entries(entries)
 
         # Pass dict payload - Event validator handles validation and keeps as dict
         return Event(


### PR DESCRIPTION
## Summary
Promote current `staging` to `main`. Includes:
- perf(events): EventBus dual-write dedup -- writes each event once to its per-type `Events/{Type}` context (dropping the duplicate global `Events` blob); `search()` and `hydrate_fast_brain_history()` read the per-type contexts; payload reconstructed from spread fields via `log_utils.payload_from_log_entries()`.
- Pre-existing validated staging commits: coordinator task-beat/chip guidance, and two CI `OPENROUTER_API_KEY` fixes.

## Notes
- Backward-safe: per-type contexts already hold every historical event, so reads keep working after deploy; leftover global `Events` rows are simply no longer read (cleaned up separately by the Orchestra migration script).

## Test plan
- [x] staging CI green (Tests, Lint)
- [ ] after prod deploy, run Orchestra `scripts/delete_events_mirror.py --dry-run`, then throttled real run