### PR TITLE
Promote staging to main

### DIFF
--- a/tests/gateway/channels/drive/test_views.py
+++ b/tests/gateway/channels/drive/test_views.py
@@ -29,6 +29,16 @@ def _fake_drive_service() -> MagicMock:
     return service
 
 
+def _drive_service_with_files(files: list[dict]) -> MagicMock:
+    """A Drive service whose ``files().list().execute()`` returns *files*."""
+    service = _fake_drive_service()
+    service.files.return_value.list.return_value.execute.return_value = {
+        "files": files,
+        "nextPageToken": None,
+    }
+    return service
+
+
 def test_roots_resolves_by_assistant_id_when_provided(client: TestClient) -> None:
     assistant = {"secrets": {"GOOGLE_ACCESS_TOKEN": "tok"}}
     by_id = AsyncMock(return_value=assistant)
@@ -80,3 +90,75 @@ def test_roots_409_when_no_connected_token(client: TestClient) -> None:
     ):
         resp = client.get("/drive/roots", params={"assistant_id": "123"})
     assert resp.status_code == 409
+
+
+def test_children_lists_my_drive_root(client: TestClient) -> None:
+    """My Drive root children use the ``root`` alias and the personal drive space.
+
+    This is the Drive analogue of the SharePoint root-children listing: it
+    exercises the actual ``files().list`` query/kwargs the picker depends on,
+    rather than only mocking a happy-path return.
+    """
+    files = [
+        {
+            "id": "f1",
+            "name": "Folder",
+            "mimeType": "application/vnd.google-apps.folder",
+            "parents": ["root"],
+        },
+        {
+            "id": "f2",
+            "name": "notes.txt",
+            "mimeType": "text/plain",
+            "parents": ["root"],
+        },
+    ]
+    service = _drive_service_with_files(files)
+    assistant = {"secrets": {"GOOGLE_ACCESS_TOKEN": "tok"}}
+    with (
+        patch(
+            "unify.gateway.channels.drive.views.lookup_assistant_by_id",
+            new=AsyncMock(return_value=assistant),
+        ),
+        patch("unify.gateway.channels.drive.views.build", return_value=service),
+    ):
+        resp = client.get(
+            "/drive/children",
+            params={"assistant_id": "123", "drive_id": "my-drive", "item_id": "root"},
+        )
+    assert resp.status_code == 200, resp.text
+    items = resp.json()["items"]
+    assert [i["kind"] for i in items] == ["folder", "file"]
+    assert all(i["drive_id"] == "my-drive" for i in items)
+    kwargs = service.files.return_value.list.call_args.kwargs
+    assert kwargs["q"] == "'root' in parents and trashed = false"
+    assert kwargs["spaces"] == "drive"
+    assert "driveId" not in kwargs
+
+
+def test_children_scopes_query_to_shared_drive(client: TestClient) -> None:
+    """A shared drive scopes the query with corpora/driveId + all-drives flags."""
+    service = _drive_service_with_files([])
+    assistant = {"secrets": {"GOOGLE_ACCESS_TOKEN": "tok"}}
+    with (
+        patch(
+            "unify.gateway.channels.drive.views.lookup_assistant_by_id",
+            new=AsyncMock(return_value=assistant),
+        ),
+        patch("unify.gateway.channels.drive.views.build", return_value=service),
+    ):
+        resp = client.get(
+            "/drive/children",
+            params={
+                "assistant_id": "123",
+                "drive_id": "shared-1",
+                "item_id": "folder-9",
+            },
+        )
+    assert resp.status_code == 200, resp.text
+    kwargs = service.files.return_value.list.call_args.kwargs
+    assert kwargs["q"] == "'folder-9' in parents and trashed = false"
+    assert kwargs["driveId"] == "shared-1"
+    assert kwargs["corpora"] == "drive"
+    assert kwargs["includeItemsFromAllDrives"] is True
+    assert kwargs["supportsAllDrives"] is True

--- a/tests/gateway/channels/sharepoint/test_views.py
+++ b/tests/gateway/channels/sharepoint/test_views.py
@@ -34,9 +34,23 @@ def client(app: FastAPI) -> TestClient:
     return TestClient(app)
 
 
-def _make_graph_mock() -> MagicMock:
-    """Build a Graph SDK client mock with common surface configured."""
-    return MagicMock()
+def _make_graph_mock(me_drive_id: str = "me-drive-id") -> MagicMock:
+    """Graph client mock matching the real SDK's navigation surface.
+
+    ``graph.me.drive`` (DriveRequestBuilder) only supports ``get`` -- it has no
+    item/root navigation -- and ``drive.root`` (RootRequestBuilder) only supports
+    ``get``/``content``. Restricting both with ``spec`` means code that reverts to
+    the removed navigations (``me.drive.items``, ``drive.root.children``,
+    ``drive.root.item_with_path``, ``drive.root.search_with_q``) raises here rather
+    than only blowing up against real Graph. ``request_adapter.base_url`` is a real
+    string so path-addressed ``with_url`` targets can be asserted exactly.
+    """
+    graph = MagicMock()
+    graph.request_adapter.base_url = "https://graph.microsoft.com/v1.0"
+    graph.me.drive = MagicMock(spec=["get"])
+    graph.me.drive.get = AsyncMock(return_value=MagicMock(id=me_drive_id))
+    graph.drives.by_drive_id.return_value.root = MagicMock(spec=["get", "content"])
+    return graph
 
 
 # ---------------------------------------------------------------------------
@@ -195,18 +209,16 @@ def _mock_drive_item(
 
 
 def test_list_items_root_default(client: TestClient) -> None:
-    """No path / no item_id -> list root children via the ``root`` drive-item.
+    """No path / no item_id -> list root children via the reserved ``root`` id.
 
-    ``drive.root`` (RootRequestBuilder) has no ``children`` navigation, so the
-    endpoint must go through ``items.by_drive_item_id("root").children``. The
-    ``root`` mock is spec-restricted to the real surface (``get``/``content``)
-    so a regression back to ``drive.root.children`` raises here instead of only
-    blowing up in production.
+    Also exercises ``me`` resolution: ``graph.me.drive`` can't navigate items, so
+    the endpoint resolves the personal drive id and goes through
+    ``graph.drives.by_drive_id(...)``.
     """
     item = _mock_drive_item()
-    fake_graph = _make_graph_mock()
-    fake_graph.me.drive.root = MagicMock(spec=["get", "content"])
-    fake_graph.me.drive.items.by_drive_item_id.return_value.children.get = AsyncMock(
+    fake_graph = _make_graph_mock(me_drive_id="me-drive-id")
+    drive = fake_graph.drives.by_drive_id.return_value
+    drive.items.by_drive_item_id.return_value.children.get = AsyncMock(
         return_value=MagicMock(value=[item]),
     )
     with patch(
@@ -219,18 +231,19 @@ def test_list_items_root_default(client: TestClient) -> None:
         )
     assert resp.status_code == 200
     assert resp.json()["items"][0]["type"] == "file"
-    fake_graph.me.drive.items.by_drive_item_id.assert_called_with("root")
+    fake_graph.me.drive.get.assert_awaited()  # me resolved to a real drive id
+    fake_graph.drives.by_drive_id.assert_called_with("me-drive-id")
+    drive.items.by_drive_item_id.assert_called_with("root")
 
 
 def test_list_items_explicit_drive_id_uses_drives_by_id(
     client: TestClient,
 ) -> None:
-    """drive_id != 'me' -> graph.drives.by_drive_id, then root children."""
+    """drive_id != 'me' -> graph.drives.by_drive_id directly (no me-resolution)."""
     item = _mock_drive_item(name="other.txt")
     fake_graph = _make_graph_mock()
-    drive_ref = fake_graph.drives.by_drive_id.return_value
-    drive_ref.root = MagicMock(spec=["get", "content"])
-    drive_ref.items.by_drive_item_id.return_value.children.get = AsyncMock(
+    drive = fake_graph.drives.by_drive_id.return_value
+    drive.items.by_drive_item_id.return_value.children.get = AsyncMock(
         return_value=MagicMock(value=[item]),
     )
     with patch(
@@ -242,14 +255,22 @@ def test_list_items_explicit_drive_id_uses_drives_by_id(
             params={"user_email": "u@x.com"},
         )
     assert resp.status_code == 200
+    fake_graph.me.drive.get.assert_not_awaited()
     fake_graph.drives.by_drive_id.assert_called_with("external-drive-1")
-    drive_ref.items.by_drive_item_id.assert_called_with("root")
+    drive.items.by_drive_item_id.assert_called_with("root")
 
 
 def test_list_items_by_path(client: TestClient) -> None:
+    """A ``path`` lists children of the path-addressed folder via ``with_url``.
+
+    ``drive.root.item_with_path`` no longer exists, so children are listed by
+    binding the ``/root:/{path}:/children`` URL onto the children builder.
+    """
     item = _mock_drive_item(is_folder=True, name="Reports")
-    fake_graph = _make_graph_mock()
-    fake_graph.me.drive.root.item_with_path.return_value.children.get = AsyncMock(
+    fake_graph = _make_graph_mock(me_drive_id="me-drive-id")
+    drive = fake_graph.drives.by_drive_id.return_value
+    children = drive.items.by_drive_item_id.return_value.children
+    children.with_url.return_value.get = AsyncMock(
         return_value=MagicMock(value=[item]),
     )
     with patch(
@@ -261,17 +282,18 @@ def test_list_items_by_path(client: TestClient) -> None:
             params={"user_email": "u@x.com", "path": "Documents/Reports"},
         )
     assert resp.status_code == 200
-    fake_graph.me.drive.root.item_with_path.assert_called_with("Documents/Reports")
-    body = resp.json()
-    assert body["items"][0]["type"] == "folder"
+    assert resp.json()["items"][0]["type"] == "folder"
+    children.with_url.assert_called_with(
+        "https://graph.microsoft.com/v1.0/drives/me-drive-id"
+        "/root:/Documents/Reports:/children",
+    )
 
 
 def test_get_item(client: TestClient) -> None:
     item = _mock_drive_item(id_="x-1")
     fake_graph = _make_graph_mock()
-    fake_graph.me.drive.items.by_drive_item_id.return_value.get = AsyncMock(
-        return_value=item,
-    )
+    drive = fake_graph.drives.by_drive_id.return_value
+    drive.items.by_drive_item_id.return_value.get = AsyncMock(return_value=item)
     with patch(
         "unify.gateway.channels.sharepoint.views.get_graph_client",
         new=AsyncMock(return_value=fake_graph),
@@ -282,14 +304,14 @@ def test_get_item(client: TestClient) -> None:
         )
     assert resp.status_code == 200
     assert resp.json()["id"] == "x-1"
+    drive.items.by_drive_item_id.assert_called_with("x-1")
 
 
 def test_download_folder_returns_400(client: TestClient) -> None:
     item = _mock_drive_item(is_folder=True)
     fake_graph = _make_graph_mock()
-    fake_graph.me.drive.items.by_drive_item_id.return_value.get = AsyncMock(
-        return_value=item,
-    )
+    drive = fake_graph.drives.by_drive_id.return_value
+    drive.items.by_drive_item_id.return_value.get = AsyncMock(return_value=item)
     with patch(
         "unify.gateway.channels.sharepoint.views.get_graph_client",
         new=AsyncMock(return_value=fake_graph),
@@ -304,10 +326,9 @@ def test_download_folder_returns_400(client: TestClient) -> None:
 def test_download_file_returns_bytes_with_content_type(client: TestClient) -> None:
     item = _mock_drive_item()
     fake_graph = _make_graph_mock()
-    fake_graph.me.drive.items.by_drive_item_id.return_value.get = AsyncMock(
-        return_value=item,
-    )
-    fake_graph.me.drive.items.by_drive_item_id.return_value.content.get = AsyncMock(
+    drive = fake_graph.drives.by_drive_id.return_value
+    drive.items.by_drive_item_id.return_value.get = AsyncMock(return_value=item)
+    drive.items.by_drive_item_id.return_value.content.get = AsyncMock(
         return_value=b"file-content",
     )
     with patch(
@@ -342,11 +363,10 @@ def test_upload_decodes_base64_content(client: TestClient) -> None:
     file_bytes = b"hello world"
     content_b64 = base64.b64encode(file_bytes).decode("utf-8")
 
-    fake_graph = _make_graph_mock()
+    fake_graph = _make_graph_mock(me_drive_id="me-drive-id")
     uploaded = MagicMock(id="u-1", name="x.txt", web_url="x", size=11)
-    fake_graph.me.drive.root.item_with_path.return_value.content.put = AsyncMock(
-        return_value=uploaded,
-    )
+    drive = fake_graph.drives.by_drive_id.return_value
+    content = drive.items.by_drive_item_id.return_value.content
 
     captured: dict = {}
 
@@ -354,7 +374,7 @@ def test_upload_decodes_base64_content(client: TestClient) -> None:
         captured["bytes"] = payload
         return uploaded
 
-    fake_graph.me.drive.root.item_with_path.return_value.content.put = _capture
+    content.with_url.return_value.put = _capture
 
     with patch(
         "unify.gateway.channels.sharepoint.views.get_graph_client",
@@ -368,6 +388,9 @@ def test_upload_decodes_base64_content(client: TestClient) -> None:
 
     assert resp.status_code == 200
     assert captured["bytes"] == file_bytes
+    content.with_url.assert_called_with(
+        "https://graph.microsoft.com/v1.0/drives/me-drive-id/root:/x.txt:/content",
+    )
 
 
 def test_upload_falls_back_to_plain_text_when_not_base64(
@@ -382,7 +405,10 @@ def test_upload_falls_back_to_plain_text_when_not_base64(
         captured["bytes"] = payload
         return uploaded
 
-    fake_graph.me.drive.root.item_with_path.return_value.content.put = _capture
+    content = (
+        fake_graph.drives.by_drive_id.return_value.items.by_drive_item_id.return_value.content
+    )  # noqa: E501
+    content.with_url.return_value.put = _capture
 
     with patch(
         "unify.gateway.channels.sharepoint.views.get_graph_client",
@@ -416,7 +442,10 @@ def test_create_folder_missing_name_returns_400(client: TestClient) -> None:
 def test_create_folder_at_root(client: TestClient) -> None:
     fake_graph = _make_graph_mock()
     new_folder = MagicMock(id="f-1", name="New", web_url="x")
-    fake_graph.me.drive.root.children.post = AsyncMock(return_value=new_folder)
+    drive = fake_graph.drives.by_drive_id.return_value
+    drive.items.by_drive_item_id.return_value.children.post = AsyncMock(
+        return_value=new_folder,
+    )
     with patch(
         "unify.gateway.channels.sharepoint.views.get_graph_client",
         new=AsyncMock(return_value=fake_graph),
@@ -428,14 +457,15 @@ def test_create_folder_at_root(client: TestClient) -> None:
         )
     assert resp.status_code == 200
     assert resp.json()["id"] == "f-1"
+    drive.items.by_drive_item_id.assert_called_with("root")
 
 
 def test_create_folder_with_parent_path(client: TestClient) -> None:
-    fake_graph = _make_graph_mock()
+    fake_graph = _make_graph_mock(me_drive_id="me-drive-id")
     new_folder = MagicMock(id="f-1", name="Sub", web_url="x")
-    fake_graph.me.drive.root.item_with_path.return_value.children.post = AsyncMock(
-        return_value=new_folder,
-    )
+    drive = fake_graph.drives.by_drive_id.return_value
+    children = drive.items.by_drive_item_id.return_value.children
+    children.with_url.return_value.post = AsyncMock(return_value=new_folder)
     with patch(
         "unify.gateway.channels.sharepoint.views.get_graph_client",
         new=AsyncMock(return_value=fake_graph),
@@ -446,12 +476,16 @@ def test_create_folder_with_parent_path(client: TestClient) -> None:
             json={"name": "Sub", "parent_path": "Documents/Project"},
         )
     assert resp.status_code == 200
-    fake_graph.me.drive.root.item_with_path.assert_called_with("Documents/Project")
+    children.with_url.assert_called_with(
+        "https://graph.microsoft.com/v1.0/drives/me-drive-id"
+        "/root:/Documents/Project:/children",
+    )
 
 
 def test_delete_item_me_drive(client: TestClient) -> None:
-    fake_graph = _make_graph_mock()
-    fake_graph.me.drive.items.by_drive_item_id.return_value.delete = AsyncMock()
+    fake_graph = _make_graph_mock(me_drive_id="me-drive-id")
+    drive = fake_graph.drives.by_drive_id.return_value
+    drive.items.by_drive_item_id.return_value.delete = AsyncMock()
     with patch(
         "unify.gateway.channels.sharepoint.views.get_graph_client",
         new=AsyncMock(return_value=fake_graph),
@@ -463,6 +497,8 @@ def test_delete_item_me_drive(client: TestClient) -> None:
         )
     assert resp.status_code == 200
     assert resp.json() == {"success": True}
+    fake_graph.me.drive.get.assert_awaited()
+    fake_graph.drives.by_drive_id.assert_called_with("me-drive-id")
 
 
 def test_delete_item_explicit_drive(client: TestClient) -> None:
@@ -480,6 +516,7 @@ def test_delete_item_explicit_drive(client: TestClient) -> None:
             params={"user_email": "u@x.com"},
         )
     assert resp.status_code == 200
+    fake_graph.me.drive.get.assert_not_awaited()
     fake_graph.drives.by_drive_id.assert_called_with("external")
 
 
@@ -491,7 +528,8 @@ def test_delete_item_explicit_drive(client: TestClient) -> None:
 def test_search_returns_matching_items(client: TestClient) -> None:
     item = _mock_drive_item(name="quarterly.pdf")
     fake_graph = _make_graph_mock()
-    fake_graph.me.drive.root.search_with_q.return_value.get = AsyncMock(
+    drive = fake_graph.drives.by_drive_id.return_value
+    drive.search_with_q.return_value.get = AsyncMock(
         return_value=MagicMock(value=[item]),
     )
     with patch(
@@ -503,5 +541,5 @@ def test_search_returns_matching_items(client: TestClient) -> None:
             params={"user_email": "u@x.com", "q": "quarterly"},
         )
     assert resp.status_code == 200
-    fake_graph.me.drive.root.search_with_q.assert_called_with("quarterly")
+    drive.search_with_q.assert_called_with("quarterly")
     assert resp.json()["results"][0]["name"] == "quarterly.pdf"

--- a/tests/gateway/channels/sharepoint/test_views.py
+++ b/tests/gateway/channels/sharepoint/test_views.py
@@ -195,10 +195,18 @@ def _mock_drive_item(
 
 
 def test_list_items_root_default(client: TestClient) -> None:
-    """No path / no item_id -> root.children.get."""
+    """No path / no item_id -> list root children via the ``root`` drive-item.
+
+    ``drive.root`` (RootRequestBuilder) has no ``children`` navigation, so the
+    endpoint must go through ``items.by_drive_item_id("root").children``. The
+    ``root`` mock is spec-restricted to the real surface (``get``/``content``)
+    so a regression back to ``drive.root.children`` raises here instead of only
+    blowing up in production.
+    """
     item = _mock_drive_item()
     fake_graph = _make_graph_mock()
-    fake_graph.me.drive.root.children.get = AsyncMock(
+    fake_graph.me.drive.root = MagicMock(spec=["get", "content"])
+    fake_graph.me.drive.items.by_drive_item_id.return_value.children.get = AsyncMock(
         return_value=MagicMock(value=[item]),
     )
     with patch(
@@ -211,15 +219,18 @@ def test_list_items_root_default(client: TestClient) -> None:
         )
     assert resp.status_code == 200
     assert resp.json()["items"][0]["type"] == "file"
+    fake_graph.me.drive.items.by_drive_item_id.assert_called_with("root")
 
 
 def test_list_items_explicit_drive_id_uses_drives_by_id(
     client: TestClient,
 ) -> None:
-    """drive_id != 'me' -> graph.drives.by_drive_id."""
+    """drive_id != 'me' -> graph.drives.by_drive_id, then root children."""
     item = _mock_drive_item(name="other.txt")
     fake_graph = _make_graph_mock()
-    fake_graph.drives.by_drive_id.return_value.root.children.get = AsyncMock(
+    drive_ref = fake_graph.drives.by_drive_id.return_value
+    drive_ref.root = MagicMock(spec=["get", "content"])
+    drive_ref.items.by_drive_item_id.return_value.children.get = AsyncMock(
         return_value=MagicMock(value=[item]),
     )
     with patch(
@@ -232,6 +243,7 @@ def test_list_items_explicit_drive_id_uses_drives_by_id(
         )
     assert resp.status_code == 200
     fake_graph.drives.by_drive_id.assert_called_with("external-drive-1")
+    drive_ref.items.by_drive_item_id.assert_called_with("root")
 
 
 def test_list_items_by_path(client: TestClient) -> None:

--- a/tests/gateway/channels/teams/test_views.py
+++ b/tests/gateway/channels/teams/test_views.py
@@ -717,3 +717,53 @@ class TestCreateMeeting:
                 json={"assistant_email": "alice@unify.ai", "mode": "instant"},
             )
         assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# OneDrive attachment upload
+# ---------------------------------------------------------------------------
+
+
+def test_upload_and_build_attachments_puts_by_path() -> None:
+    """Attachments upload to OneDrive by resolving the me-drive id + path URL.
+
+    ``graph.me.drive`` (DriveRequestBuilder) can't navigate items and
+    ``drive.root.item_with_path`` no longer exists, so the upload resolves the
+    personal drive id and binds the ``/root:/Teams Attachments/<name>:/content``
+    URL onto the content builder via ``with_url``. The ``me.drive`` mock is
+    spec-restricted to ``get`` so a revert to the old navigation raises here.
+    """
+    import asyncio
+    import base64
+
+    from unify.gateway.channels.teams.views import _upload_and_build_attachments
+
+    graph = MagicMock()
+    graph.request_adapter.base_url = "https://graph.microsoft.com/v1.0"
+    graph.me.drive = MagicMock(spec=["get"])
+    graph.me.drive.get = AsyncMock(return_value=MagicMock(id="me-drive-id"))
+    drive = graph.drives.by_drive_id.return_value
+    content = drive.items.by_drive_item_id.return_value.content
+    put_mock = AsyncMock(return_value=MagicMock(web_url="https://od/report"))
+    content.with_url.return_value.put = put_mock
+
+    payload = base64.b64encode(b"hello").decode()
+    out = asyncio.run(
+        _upload_and_build_attachments(
+            graph,
+            [{"filename": "report.pdf", "content_base64": payload}],
+        ),
+    )
+
+    assert len(out) == 1
+    assert out[0].name == "report.pdf"
+    assert out[0].content_url == "https://od/report"
+    graph.me.drive.get.assert_awaited_once()
+    graph.drives.by_drive_id.assert_called_with("me-drive-id")
+    put_mock.assert_awaited_once_with(b"hello")
+    url = content.with_url.call_args.args[0]
+    assert url.startswith(
+        "https://graph.microsoft.com/v1.0/drives/me-drive-id"
+        "/root:/Teams%20Attachments/",
+    )
+    assert url.endswith("_report.pdf:/content")

--- a/unify/gateway/channels/sharepoint/views.py
+++ b/unify/gateway/channels/sharepoint/views.py
@@ -184,7 +184,10 @@ async def list_items(
         elif path:
             items = await drive.root.item_with_path(path).children.get()
         else:
-            items = await drive.root.children.get()
+            # ``drive.root`` (RootRequestBuilder) exposes only ``get``/``content``
+            # -- it has no ``children`` navigation. List the root's children via
+            # the drive-item builder using Graph's reserved ``root`` item id.
+            items = await drive.items.by_drive_item_id("root").children.get()
 
         return {
             "items": [

--- a/unify/gateway/channels/sharepoint/views.py
+++ b/unify/gateway/channels/sharepoint/views.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import base64
 import logging
 from typing import Optional
+from urllib.parse import quote
 
 from fastapi import APIRouter, HTTPException, Request, Response
 from msgraph.generated.models.drive_item import DriveItem
@@ -159,11 +160,32 @@ async def list_site_drives(user_email: str, site_id: str):
 # ---------------------------------------------------------------------------
 
 
-def _drive_ref(graph, drive_id: str):
-    """Return the Graph drive request builder for ``drive_id`` (or ``me``)."""
+async def _drive_ref(graph, drive_id: str):
+    """Resolve a drive to ``(drive_id, DriveItemRequestBuilder)``.
+
+    The SDK's ``graph.me.drive`` (DriveRequestBuilder) only supports fetching the
+    drive itself -- it exposes no item/root navigation -- so every item operation
+    must go through ``graph.drives.by_drive_id(...)``. Resolve the personal
+    drive's real id first when ``me`` is requested, then return the id alongside
+    the builder (the id is needed to build path-addressed URLs below).
+    """
     if drive_id == "me":
-        return graph.me.drive
-    return graph.drives.by_drive_id(drive_id)
+        me_drive = await graph.me.drive.get()
+        drive_id = me_drive.id
+    return drive_id, graph.drives.by_drive_id(drive_id)
+
+
+def _path_item_url(graph, drive_id: str, path: str, suffix: str) -> str:
+    """Absolute Graph URL for a path-addressed drive-item navigation.
+
+    ``drive.root`` no longer exposes ``item_with_path`` in the SDK, so build the
+    ``/drives/{id}/root:/{path}:/{suffix}`` URL explicitly and bind it onto the
+    matching request builder via ``with_url``. Path separators stay literal so
+    the colon-addressing hierarchy is preserved.
+    """
+    base = graph.request_adapter.base_url.rstrip("/")
+    encoded = quote(path, safe="/")
+    return f"{base}/drives/{drive_id}/root:/{encoded}:/{suffix}"
 
 
 @router.get("/drives/{drive_id}/items")
@@ -177,16 +199,20 @@ async def list_items(
     """List files and folders in a drive (by root, by path, or by item_id)."""
     try:
         graph = await get_graph_client(user_email, assistant_id=assistant_id)
-        drive = _drive_ref(graph, drive_id)
+        drive_id, drive = await _drive_ref(graph, drive_id)
 
         if item_id:
             items = await drive.items.by_drive_item_id(item_id).children.get()
         elif path:
-            items = await drive.root.item_with_path(path).children.get()
+            items = (
+                await drive.items.by_drive_item_id("root")
+                .children.with_url(_path_item_url(graph, drive_id, path, "children"))
+                .get()
+            )
         else:
-            # ``drive.root`` (RootRequestBuilder) exposes only ``get``/``content``
-            # -- it has no ``children`` navigation. List the root's children via
-            # the drive-item builder using Graph's reserved ``root`` item id.
+            # The root's children are reached via the drive-item builder using
+            # Graph's reserved ``root`` item id -- ``drive.root`` has no
+            # ``children`` navigation in the SDK.
             items = await drive.items.by_drive_item_id("root").children.get()
 
         return {
@@ -222,15 +248,9 @@ async def get_item(user_email: str, drive_id: str, item_id: str):
     """Get metadata for a specific file or folder."""
     try:
         graph = await get_graph_client(user_email)
+        _, drive = await _drive_ref(graph, drive_id)
 
-        if drive_id == "me":
-            item = await graph.me.drive.items.by_drive_item_id(item_id).get()
-        else:
-            item = (
-                await graph.drives.by_drive_id(drive_id)
-                .items.by_drive_item_id(item_id)
-                .get()
-            )
+        item = await drive.items.by_drive_item_id(item_id).get()
 
         return {
             "id": item.id,
@@ -261,7 +281,7 @@ async def download_file(user_email: str, drive_id: str, item_id: str):
     """Download a file's content."""
     try:
         graph = await get_graph_client(user_email)
-        drive = _drive_ref(graph, drive_id)
+        _, drive = await _drive_ref(graph, drive_id)
 
         item = await drive.items.by_drive_item_id(item_id).get()
         if item.folder:
@@ -302,14 +322,18 @@ async def upload_file(request: Request, user_email: str, drive_id: str):
             )
 
         graph = await get_graph_client(user_email)
-        drive = _drive_ref(graph, drive_id)
+        drive_id, drive = await _drive_ref(graph, drive_id)
 
         try:
             file_bytes = base64.b64decode(content)
         except Exception:
             file_bytes = content.encode("utf-8")
 
-        result = await drive.root.item_with_path(path).content.put(file_bytes)
+        result = (
+            await drive.items.by_drive_item_id("root")
+            .content.with_url(_path_item_url(graph, drive_id, path, "content"))
+            .put(file_bytes)
+        )
 
         return {
             "success": True,
@@ -337,16 +361,22 @@ async def create_folder(request: Request, user_email: str, drive_id: str):
             raise HTTPException(status_code=400, detail="Missing required field: name")
 
         graph = await get_graph_client(user_email)
-        drive = _drive_ref(graph, drive_id)
+        drive_id, drive = await _drive_ref(graph, drive_id)
 
         new_folder = DriveItem(name=folder_name, folder=Folder())
 
         if parent_path:
-            result = await drive.root.item_with_path(parent_path).children.post(
-                new_folder,
+            result = (
+                await drive.items.by_drive_item_id("root")
+                .children.with_url(
+                    _path_item_url(graph, drive_id, parent_path, "children"),
+                )
+                .post(new_folder)
             )
         else:
-            result = await drive.root.children.post(new_folder)
+            result = await drive.items.by_drive_item_id("root").children.post(
+                new_folder,
+            )
 
         return {
             "success": True,
@@ -366,15 +396,9 @@ async def delete_item(user_email: str, drive_id: str, item_id: str):
     """Delete a file or folder."""
     try:
         graph = await get_graph_client(user_email)
+        _, drive = await _drive_ref(graph, drive_id)
 
-        if drive_id == "me":
-            await graph.me.drive.items.by_drive_item_id(item_id).delete()
-        else:
-            await (
-                graph.drives.by_drive_id(drive_id)
-                .items.by_drive_item_id(item_id)
-                .delete()
-            )
+        await drive.items.by_drive_item_id(item_id).delete()
 
         return {"success": True}
     except Exception as exc:
@@ -392,13 +416,11 @@ async def search_files(user_email: str, drive_id: str, q: str):
     """Search for files in a drive."""
     try:
         graph = await get_graph_client(user_email)
+        _, drive = await _drive_ref(graph, drive_id)
 
-        if drive_id == "me":
-            results = await graph.me.drive.root.search_with_q(q).get()
-        else:
-            results = (
-                await graph.drives.by_drive_id(drive_id).root.search_with_q(q).get()
-            )
+        # ``search_with_q`` is a navigation on the drive builder, not on
+        # ``drive.root``.
+        results = await drive.search_with_q(q).get()
 
         return {
             "results": [

--- a/unify/gateway/channels/teams/views.py
+++ b/unify/gateway/channels/teams/views.py
@@ -27,6 +27,7 @@ import base64
 import logging
 import uuid
 from datetime import datetime, timedelta, timezone
+from urllib.parse import quote
 
 from fastapi import APIRouter, HTTPException, Request
 from msgraph.generated.models.aad_user_conversation_member import (
@@ -128,6 +129,17 @@ async def _upload_and_build_attachments(
 ) -> list[ChatMessageAttachment]:
     """Upload files to OneDrive and return Graph ChatMessageAttachment objects."""
     result: list[ChatMessageAttachment] = []
+    if not raw_attachments:
+        return result
+
+    # ``graph.me.drive`` (DriveRequestBuilder) only supports fetching the drive;
+    # item operations go through ``graph.drives.by_drive_id(...)``. Resolve the
+    # personal drive id once, then address uploads by path via ``with_url``
+    # (``drive.root.item_with_path`` no longer exists in the SDK).
+    me_drive = await graph.me.drive.get()
+    drive = graph.drives.by_drive_id(me_drive.id)
+    base_url = graph.request_adapter.base_url.rstrip("/")
+
     for att in raw_attachments:
         filename = att.get("filename", "attachment")
         content_b64 = att.get("content_base64", "")
@@ -136,9 +148,13 @@ async def _upload_and_build_attachments(
         file_bytes = base64.b64decode(content_b64)
 
         safe_name = f"{uuid.uuid4().hex[:8]}_{filename}"
-        drive_item = await graph.me.drive.root.item_with_path(
-            f"Teams Attachments/{safe_name}",
-        ).content.put(file_bytes)
+        encoded = quote(f"Teams Attachments/{safe_name}", safe="/")
+        content_url = f"{base_url}/drives/{me_drive.id}/root:/{encoded}:/content"
+        drive_item = (
+            await drive.items.by_drive_item_id("root")
+            .content.with_url(content_url)
+            .put(file_bytes)
+        )
 
         att_id = uuid.uuid4().hex
         result.append(


### PR DESCRIPTION
## Summary
Promotes the current `staging` branch to `main`.

## Changes
- fix(gateway): repair Drive/Teams item ops after msgraph SDK migration
- fix(gateway): list SharePoint/OneDrive root children via items builder

## Test plan
- [x] Validated on staging deployment