### PR TITLE
Fall back to Field Signal for coordinators with missing voice at call time

### DIFF
--- a/tests/test_coordinator_voice.py
+++ b/tests/test_coordinator_voice.py
@@ -1,0 +1,15 @@
+from unify.coordinator_voice import (
+    COORDINATOR_DEFAULT_VOICE_ID,
+    COORDINATOR_DEFAULT_VOICE_PROVIDER,
+    resolve_runtime_voice,
+)
+
+
+def test_resolve_runtime_voice_uses_coordinator_default_when_missing():
+    provider, voice_id = resolve_runtime_voice(
+        is_coordinator=True,
+        voice_provider="",
+        voice_id="",
+    )
+    assert provider == COORDINATOR_DEFAULT_VOICE_PROVIDER
+    assert voice_id == COORDINATOR_DEFAULT_VOICE_ID

--- a/unify/conversation_manager/conversation_manager.py
+++ b/unify/conversation_manager/conversation_manager.py
@@ -10,6 +10,7 @@ from unify.common.hierarchical_logger import DEFAULT_ICON
 from unify.common.startup_timing import log_startup_timing
 from unify.common.diagnostic_logging import staging_diagnostics_enabled
 from unify.session_details import SESSION_DETAILS
+from unify.coordinator_voice import resolve_runtime_voice
 from unify.settings import SETTINGS
 from unify.manager_registry import SingletonABCMeta
 from unify.common.async_tool_loop import SteerableToolHandle
@@ -2693,6 +2694,11 @@ class ConversationManager(metaclass=SingletonABCMeta):
             self.voice_provider or SESSION_DETAILS.voice.provider or "cartesia"
         )
         voice_id = self.voice_id or SESSION_DETAILS.voice.id or ""
+        voice_provider, voice_id = resolve_runtime_voice(
+            is_coordinator=SESSION_DETAILS.is_coordinator,
+            voice_provider=voice_provider,
+            voice_id=voice_id,
+        )
         return CallConfig(
             assistant_id=self.assistant_id,
             user_id=self.user_id,

--- a/unify/conversation_manager/medium_scripts/call.py
+++ b/unify/conversation_manager/medium_scripts/call.py
@@ -1137,6 +1137,17 @@ async def entrypoint(ctx: agents.JobContext):
             os.environ.get("OPENING_CONFIG"),
         )
 
+    from unify.coordinator_voice import resolve_runtime_voice
+
+    is_coordinator = (
+        bool(meta.get("is_coordinator")) if meta else SESSION_DETAILS.is_coordinator
+    )
+    voice_provider, voice_id = resolve_runtime_voice(
+        is_coordinator=is_coordinator,
+        voice_provider=voice_provider,
+        voice_id=voice_id,
+    )
+
     # Browser-meet diarization config (Google Meet / Teams Meet)
     meet_session_id: str = ""
     call_session_id: str = ""

--- a/unify/coordinator_voice.py
+++ b/unify/coordinator_voice.py
@@ -1,0 +1,24 @@
+"""Coordinator default voice resolution for Unity runtime."""
+
+from __future__ import annotations
+
+COORDINATOR_DEFAULT_VOICE_PROVIDER = "elevenlabs"
+COORDINATOR_DEFAULT_VOICE_ID = "iP95p4xoKVk53GoZ742B"
+
+
+def _normalize(value: object | None) -> str:
+    return "" if value is None else str(value).strip()
+
+
+def resolve_runtime_voice(
+    *,
+    is_coordinator: bool,
+    voice_provider: object | None,
+    voice_id: object | None,
+) -> tuple[str, str]:
+    """Return the TTS provider and voice id to use for one assistant session."""
+    provider = _normalize(voice_provider)
+    voice = _normalize(voice_id)
+    if is_coordinator and not voice:
+        return COORDINATOR_DEFAULT_VOICE_PROVIDER, COORDINATOR_DEFAULT_VOICE_ID
+    return provider or "cartesia", voice


### PR DESCRIPTION
## Summary
- Fix T-W1N coordinator default voice (Field Signal / ElevenLabs) when Orchestra rows have null voice_id
- Prevents onboarding calls from falling back to Cartesia female voice

## Test plan
- [x] Unit tests for coordinator voice resolution
- [ ] Staging onboarding call uses male Field Signal voice after deploy + migration