### PR TITLE
Release: staging → main

### DIFF
--- a/.github/workflows/trigger-selfhost-images.yml
+++ b/.github/workflows/trigger-selfhost-images.yml
@@ -1,6 +1,6 @@
 name: Trigger self-host image publish
 
-# Dispatches unifyai/unity-deploy's Publish self-host images workflow when
+# Dispatches unifyai/unify-deploy's Publish self-host images workflow when
 # Unity sources that ship in those images change on staging/main.
 on:
   push:
@@ -26,7 +26,7 @@ jobs:
   dispatch:
     runs-on: ubuntu-latest
     steps:
-    - name: Trigger unifyai/unity-deploy Publish self-host images
+      - name: Trigger unifyai/unify-deploy Publish self-host images
       env:
         GH_TOKEN: ${{ secrets.CLONE_TOKEN }}
         UNITY_REF: ${{ github.ref_name }}
@@ -34,19 +34,19 @@ jobs:
       run: |
         set -euo pipefail
         if [[ -z "${GH_TOKEN}" ]]; then
-          echo "::error::CLONE_TOKEN secret is not configured on unity."
-          echo "It must be a PAT that can dispatch workflows on unifyai/unity-deploy."
-          exit 1
-        fi
-        gh api repos/unifyai/unity-deploy/dispatches \
-          --method POST \
-          --input - <<EOF
-        {
-          "event_type": "publish-selfhost-images",
-          "client_payload": {
-            "unity_ref": "${UNITY_REF}",
-            "unity_sha": "${UNITY_SHA}"
+            echo "::error::CLONE_TOKEN secret is not configured on unity."
+            echo "It must be a PAT that can dispatch workflows on unifyai/unify-deploy."
+            exit 1
+          fi
+          gh api repos/unifyai/unify-deploy/dispatches \
+            --method POST \
+            --input - <<EOF
+          {
+            "event_type": "publish-selfhost-images",
+            "client_payload": {
+              "unity_ref": "${UNITY_REF}",
+              "unity_sha": "${UNITY_SHA}"
+            }
           }
-        }
-        EOF
-        echo "Dispatched publish-selfhost-images to unity-deploy (ref=${UNITY_REF} sha=${UNITY_SHA})"
+          EOF
+          echo "Dispatched publish-selfhost-images to unify-deploy (ref=${UNITY_REF} sha=${UNITY_SHA})"

--- a/.github/workflows/trigger-selfhost-images.yml
+++ b/.github/workflows/trigger-selfhost-images.yml
@@ -26,7 +26,7 @@ jobs:
   dispatch:
     runs-on: ubuntu-latest
     steps:
-      - name: Trigger unifyai/unify-deploy Publish self-host images
+    - name: Trigger unifyai/unify-deploy Publish self-host images
       env:
         GH_TOKEN: ${{ secrets.CLONE_TOKEN }}
         UNITY_REF: ${{ github.ref_name }}
@@ -34,19 +34,19 @@ jobs:
       run: |
         set -euo pipefail
         if [[ -z "${GH_TOKEN}" ]]; then
-            echo "::error::CLONE_TOKEN secret is not configured on unity."
-            echo "It must be a PAT that can dispatch workflows on unifyai/unify-deploy."
-            exit 1
-          fi
-          gh api repos/unifyai/unify-deploy/dispatches \
-            --method POST \
-            --input - <<EOF
-          {
-            "event_type": "publish-selfhost-images",
-            "client_payload": {
-              "unity_ref": "${UNITY_REF}",
-              "unity_sha": "${UNITY_SHA}"
-            }
+          echo "::error::CLONE_TOKEN secret is not configured on unity."
+          echo "It must be a PAT that can dispatch workflows on unifyai/unify-deploy."
+          exit 1
+        fi
+        gh api repos/unifyai/unify-deploy/dispatches \
+          --method POST \
+          --input - <<EOF
+        {
+          "event_type": "publish-selfhost-images",
+          "client_payload": {
+            "unity_ref": "${UNITY_REF}",
+            "unity_sha": "${UNITY_SHA}"
           }
-          EOF
-          echo "Dispatched publish-selfhost-images to unify-deploy (ref=${UNITY_REF} sha=${UNITY_SHA})"
+        }
+        EOF
+        echo "Dispatched publish-selfhost-images to unify-deploy (ref=${UNITY_REF} sha=${UNITY_SHA})"

--- a/.github/workflows/trigger-selfhost-images.yml
+++ b/.github/workflows/trigger-selfhost-images.yml
@@ -1,0 +1,52 @@
+name: Trigger self-host image publish
+
+# Dispatches unifyai/unity-deploy's Publish self-host images workflow when
+# Unity sources that ship in those images change on staging/main.
+on:
+  push:
+    branches: [staging, main]
+    paths:
+    - 'unify/**'
+    - 'agent-service/**'
+    - 'scripts/**'
+    - 'deploy/**'
+    - 'pyproject.toml'
+    - 'uv.lock'
+    - '.github/workflows/trigger-selfhost-images.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: trigger-selfhost-images-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Trigger unifyai/unity-deploy Publish self-host images
+      env:
+        GH_TOKEN: ${{ secrets.CLONE_TOKEN }}
+        UNITY_REF: ${{ github.ref_name }}
+        UNITY_SHA: ${{ github.sha }}
+      run: |
+        set -euo pipefail
+        if [[ -z "${GH_TOKEN}" ]]; then
+          echo "::error::CLONE_TOKEN secret is not configured on unity."
+          echo "It must be a PAT that can dispatch workflows on unifyai/unity-deploy."
+          exit 1
+        fi
+        gh api repos/unifyai/unity-deploy/dispatches \
+          --method POST \
+          --input - <<EOF
+        {
+          "event_type": "publish-selfhost-images",
+          "client_payload": {
+            "unity_ref": "${UNITY_REF}",
+            "unity_sha": "${UNITY_SHA}"
+          }
+        }
+        EOF
+        echo "Dispatched publish-selfhost-images to unity-deploy (ref=${UNITY_REF} sha=${UNITY_SHA})"

--- a/tests/comms/test_sms_reply_note.py
+++ b/tests/comms/test_sms_reply_note.py
@@ -1,0 +1,63 @@
+"""Short-code reply-to note appended to the opening SMS of a thread.
+
+In A2P-regulated destinations Twilio can override the outbound sender with a
+short code / alphanumeric sender ID the recipient cannot reply to. To keep a
+working reply path, ``CommsPrimitives.send_sms`` embeds the assistant's real
+inbound number in the body of the first SMS to a contact. These tests pin that
+behaviour on the helper that carries the logic.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+from unify.comms.primitives import CommsPrimitives
+from unify.conversation_manager.cm_types import Medium
+
+NUMBER = "+16592575615"
+
+
+def _make_primitives(*, assistant_number: str = NUMBER, prior_sms=None):
+    cm = MagicMock()
+    cm.assistant_number = assistant_number
+    cm.contact_index.get_messages_for_contact.return_value = list(prior_sms or [])
+    return CommsPrimitives(conversation_manager=cm, event_broker=AsyncMock()), cm
+
+
+def test_reply_note_appended_on_first_sms():
+    primitives, _ = _make_primitives()
+    out = primitives._apply_sms_reply_note("Hi there", 5)
+    assert out.startswith("Hi there")
+    assert NUMBER in out
+    assert "short code" in out.lower()
+
+
+def test_reply_note_not_repeated_for_same_contact():
+    primitives, _ = _make_primitives()
+    first = primitives._apply_sms_reply_note("first", 5)
+    assert NUMBER in first
+    second = primitives._apply_sms_reply_note("second", 5)
+    assert second == "second"
+
+
+def test_reply_note_skipped_when_number_already_present():
+    primitives, _ = _make_primitives()
+    body = f"reach me at {NUMBER} any time"
+    assert primitives._apply_sms_reply_note(body, 5) == body
+
+
+def test_reply_note_skipped_without_assistant_number():
+    primitives, _ = _make_primitives(assistant_number="")
+    assert primitives._apply_sms_reply_note("hello", 5) == "hello"
+
+
+def test_reply_note_skipped_when_prior_sms_exists():
+    primitives, cm = _make_primitives(prior_sms=[MagicMock()])
+    assert primitives._apply_sms_reply_note("hello", 5) == "hello"
+    cm.contact_index.get_messages_for_contact.assert_called_once_with(
+        5,
+        medium=Medium.SMS_MESSAGE,
+    )
+
+
+def test_offline_path_without_cm_treats_send_as_first():
+    primitives = CommsPrimitives(event_broker=AsyncMock())
+    assert primitives._is_first_sms_to_contact(9) is True

--- a/tests/conversation_manager/core/test_comms_utils.py
+++ b/tests/conversation_manager/core/test_comms_utils.py
@@ -651,6 +651,54 @@ class TestLocalCommsBackends:
             assert publish_kwargs.get("thread") == "unify_message_outbound"
 
     @pytest.mark.asyncio
+    async def test_publish_assistant_desktop_ready_mirrors_to_local_outbox_and_pubsub(
+        self,
+    ):
+        """Local-comms mode mirrors desktop-ready into the local outbox but
+        still publishes to Pub/Sub so Console SSE can unlock liveview.
+        """
+        mock_publisher = MagicMock()
+        mock_publisher.topic_path.return_value = "projects/p/topics/unity-1"
+        mock_future = MagicMock()
+        mock_future.result.return_value = "desktop-ready-1"
+        mock_publisher.publish.return_value = mock_future
+
+        with (
+            patch(
+                "unify.conversation_manager.domains.comms_utils._use_local_comms",
+                return_value=True,
+            ),
+            patch(
+                "unify.conversation_manager.domains.comms_utils._publish_local_outbox_async",
+                new=AsyncMock(return_value=True),
+            ) as mock_outbox,
+            patch(
+                "unify.conversation_manager.domains.comms_utils._get_publisher",
+                return_value=mock_publisher,
+            ),
+        ):
+            await comms_utils.publish_assistant_desktop_ready(
+                "binding-1",
+                "http://127.0.0.1:8090",
+                "http://127.0.0.1:8090/desktop/custom.html",
+                "ubuntu",
+            )
+
+            mock_outbox.assert_awaited_once()
+            outbox_payload = mock_outbox.await_args.args[0]
+            assert outbox_payload["thread"] == "assistant_desktop_ready"
+            assert outbox_payload["event"]["binding_id"] == "binding-1"
+            assert outbox_payload["event"]["desktop_url"] == "http://127.0.0.1:8090"
+            assert (
+                outbox_payload["event"]["liveview_url"]
+                == "http://127.0.0.1:8090/desktop/custom.html"
+            )
+            assert outbox_payload["event"]["vm_type"] == "ubuntu"
+            mock_publisher.publish.assert_called_once()
+            _, publish_kwargs = mock_publisher.publish.call_args
+            assert publish_kwargs.get("thread") == "assistant_desktop_ready"
+
+    @pytest.mark.asyncio
     async def test_send_unify_meet_ring_publishes_incoming_thread(self):
         """The Meet ring publishes a ``unify_meet_incoming`` frame carrying the
         call session id and reason so the Console can show the Answer window."""

--- a/tests/conversation_manager/voice/test_persistent_worker.py
+++ b/tests/conversation_manager/voice/test_persistent_worker.py
@@ -806,6 +806,35 @@ class TestEntrypointMetadata:
         assert _voice_call_channel_defers_desktop_binding("whatsapp_call")
         assert not _voice_call_channel_defers_desktop_binding("email")
 
+    def test_call_module_has_no_stale_desktop_session_import(self):
+        # The deferred-binding guard in ``call.py`` lazily imports its desktop
+        # entitlement check. When ``domains/desktop_session.py`` was deleted the
+        # lazy import was missed, so every voice call crashed at connect time
+        # with ModuleNotFoundError (invisible to CI because it is import-on-call).
+        # Guard against that whole class of dangling reference resurfacing.
+        import inspect
+
+        from unify.conversation_manager.medium_scripts import call as call_module
+
+        assert "domains.desktop_session" not in inspect.getsource(call_module)
+
+    def test_assistant_has_managed_desktop_gate(self):
+        # The deferred-binding guard relies on this entitlement accessor; keep it
+        # gating on desktop mode, active status, and an assigned VM URL.
+        from unify.session_details import AssistantDetails
+
+        assert AssistantDetails(
+            desktop_mode="ubuntu",
+            managed_desktop_status="active",
+            desktop_url="https://vm.example/api",
+        ).has_managed_desktop
+        assert not AssistantDetails().has_managed_desktop
+        assert not AssistantDetails(
+            desktop_mode="ubuntu",
+            managed_desktop_status="active",
+            desktop_url=None,
+        ).has_managed_desktop
+
 
 # ---------------------------------------------------------------------------
 # IPC socket initialisation from metadata

--- a/tests/task_scheduler/test_custom_tasks.py
+++ b/tests/task_scheduler/test_custom_tasks.py
@@ -173,6 +173,7 @@ async def test_sync_custom_tasks_inserts_new_entries(
     assert "Daily check" in names
     assert "On inbound email" in names
     assert "Draft task" not in names
+    assert all(row.enabled is False for row in rows)
 
 
 @_handle_project

--- a/unify/common/single_shot.py
+++ b/unify/common/single_shot.py
@@ -317,11 +317,26 @@ async def single_shot_tool_decision(
         spec = normalised[fn_name]
         fn = spec.fn
 
-        # Execute (handle both sync and async callables)
-        if asyncio.iscoroutinefunction(fn) or inspect.iscoroutinefunction(fn):
-            result = await fn(**fn_args)
-        else:
-            result = fn(**fn_args)
+        # Execute (handle both sync and async callables). A malformed call
+        # (missing/extra/wrong-typed arguments) is an expected, recoverable
+        # event in an LLM tool loop, so surface it back to the model as an
+        # error result — the same shape used for rejected calls — instead of
+        # letting one bad call abort the whole concurrent batch.
+        try:
+            if asyncio.iscoroutinefunction(fn) or inspect.iscoroutinefunction(fn):
+                result = await fn(**fn_args)
+            else:
+                result = fn(**fn_args)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            _ss_logger.warning(
+                "⏱️ [single_shot] tool %s raised %s: %s",
+                fn_name,
+                type(exc).__name__,
+                exc,
+            )
+            result = {"error": f"{type(exc).__name__}: {exc}"}
 
         return ToolExecution(
             name=fn_name,

--- a/unify/comms/primitives.py
+++ b/unify/comms/primitives.py
@@ -143,6 +143,7 @@ class CommsPrimitives:
     ) -> None:
         self._cm = conversation_manager
         self._event_broker = event_broker or get_event_broker()
+        self._sms_reply_note_sent_contacts: set[int] = set()
 
     async def _publish_comms_event(self, topic: str, event) -> None:
         if slow_brain_direct_outbound_active():
@@ -153,6 +154,46 @@ class CommsPrimitives:
         if self._cm is not None:
             return getattr(self._cm, "assistant_number", "") or ""
         return SESSION_DETAILS.assistant.number or ""
+
+    def _is_first_sms_to_contact(self, contact_id: int) -> bool:
+        """True when no SMS with *contact_id* is visible in loaded history.
+
+        Gates the short-code reply-to note so it is added only on the opening
+        SMS of a thread. The live session's ``global_thread`` is hydrated from
+        the durable transcript at startup, so this catches both same-session
+        and recently-persisted prior SMS. Offline/``act`` runs have no contact
+        index and always treat the send as first (worst case: a rare duplicate
+        note).
+        """
+        if contact_id in self._sms_reply_note_sent_contacts:
+            return False
+        if self._cm is None:
+            return True
+        prior = self._cm.contact_index.get_messages_for_contact(
+            contact_id,
+            medium=Medium.SMS_MESSAGE,
+        )
+        return not prior
+
+    def _apply_sms_reply_note(self, content: str, contact_id: int) -> str:
+        """Embed the assistant's inbound number on the first SMS of a thread.
+
+        In A2P-regulated destinations Twilio can override the outbound sender
+        with a short code or alphanumeric sender ID the recipient cannot reply
+        to, so the real inbound number is written into the body as a reliable
+        reply path. Added once per contact (per loaded history) and never when
+        the number is already present in the body.
+        """
+        number = self._assistant_number()
+        if not number or number in content:
+            return content
+        if not self._is_first_sms_to_contact(contact_id):
+            return content
+        self._sms_reply_note_sent_contacts.add(contact_id)
+        return (
+            f"{content}\n\n(If this reached you from a short code/sender ID "
+            f"due to local carrier rules, text me directly at {number}.)"
+        )
 
     def _assistant_email(self) -> str:
         if self._cm is not None:
@@ -800,6 +841,11 @@ class CommsPrimitives:
                     "contact_display_name": _get_contact_display_name(contact),
                 },
             )
+
+        content = self._apply_sms_reply_note(
+            content,
+            (contact or {}).get("contact_id") or contact_id,
+        )
 
         offline_reservation, offline_response = self._reserve_offline_operation(
             method_name="send_sms",

--- a/unify/conversation_manager/domains/brain_action_tools.py
+++ b/unify/conversation_manager/domains/brain_action_tools.py
@@ -307,7 +307,11 @@ class ConversationManagerBrainActionTools:
         Parameters
         ----------
         content : str
-            Message body to send to my boss.
+            The full message body to send to my boss. Required on every call:
+            I author the complete text myself and pass it here, and never
+            invoke this tool without it. When the body is something I make up
+            on the spot (e.g. an onboarding sci-fi quiz clue), I write it out
+            in full in this argument rather than leaving it empty.
         """
         return await self._comms.send_sms(
             contact_id=self._boss_contact_id(),

--- a/unify/conversation_manager/domains/comms_utils.py
+++ b/unify/conversation_manager/domains/comms_utils.py
@@ -634,35 +634,32 @@ async def publish_assistant_desktop_ready(
     The Console subscribes to this thread to update the liveview iframe.
     """
     agent_id = SESSION_DETAILS.assistant.agent_id
+    event_data = {
+        "binding_id": binding_id,
+        "desktop_url": desktop_url,
+        "liveview_url": liveview_url,
+        "vm_type": vm_type,
+    }
+    message_data = {
+        "thread": "assistant_desktop_ready",
+        "event": event_data,
+    }
+
+    # Console always reads from the assistant's Pub/Sub topic, even in
+    # LOCAL_COMMS_MODE=local; the local outbox is a best-effort mirror.
     if _use_local_comms():
         try:
-            await _publish_local_outbox_async(
-                {
-                    "thread": "assistant_desktop_ready",
-                    "event": {
-                        "binding_id": binding_id,
-                        "desktop_url": desktop_url,
-                        "liveview_url": liveview_url,
-                        "vm_type": vm_type,
-                    },
-                },
-            )
+            await _publish_local_outbox_async(message_data)
         except Exception as e:
-            LOGGER.error(
-                f"{ICONS['comms_outbound']} Error publishing assistant_desktop_ready: {e}",
+            LOGGER.debug(
+                f"{ICONS['comms_outbound']} Local outbox mirror failed (non-fatal): {e}",
             )
-        return
 
     try:
         _publish_to_assistant_topic(
             agent_id=agent_id,
             thread="assistant_desktop_ready",
-            event={
-                "binding_id": binding_id,
-                "desktop_url": desktop_url,
-                "liveview_url": liveview_url,
-                "vm_type": vm_type,
-            },
+            event=event_data,
         )
         env_suffix = SETTINGS.ENV_SUFFIX if agent_id is not None else ""
         LOGGER.debug(

--- a/unify/conversation_manager/domains/coordinator_onboarding.py
+++ b/unify/conversation_manager/domains/coordinator_onboarding.py
@@ -419,7 +419,10 @@ def _coordinator_onboarding_notification_text(
             "no supplied clue or answer, and I keep the answer to myself. "
             "User-facing lines stay minimal (one sentence that we're testing "
             "the channel with a quick sci-fi quiz); I never list genres or "
-            "franchises."
+            "franchises. I write the full clue text out myself and pass it as "
+            "the outbound tool's message body (for the SMS/text tool that is "
+            "the required `content` argument) — I never call the send tool "
+            "with an empty body."
         )
         framing_note = f" Section framing: {framing}" if framing else ""
         interaction_note = (

--- a/unify/conversation_manager/medium_scripts/call.py
+++ b/unify/conversation_manager/medium_scripts/call.py
@@ -3695,11 +3695,7 @@ async def entrypoint(ctx: agents.JobContext):
     def _schedule_deferred_desktop_binding() -> None:
         if not _voice_call_channel_defers_desktop_binding(channel):
             return
-        from unify.conversation_manager.domains.desktop_session import (
-            has_managed_desktop_runtime,
-        )
-
-        if not has_managed_desktop_runtime():
+        if not SESSION_DETAILS.assistant.has_managed_desktop:
             return
         agent_id = SESSION_DETAILS.assistant.agent_id
         if agent_id is None:

--- a/unify/gateway/adapters/ms_teams_bot.py
+++ b/unify/gateway/adapters/ms_teams_bot.py
@@ -32,6 +32,7 @@ from unify.gateway.adapters.ms_teams_bot_auth import (
     BotFrameworkAuthError,
     verify_bot_framework_token,
 )
+from unify.gateway.channels.ms_teams_bot.views import _mint_connector_token
 from unify.gateway.context import GatewayContext, get_gateway_context
 from unify.settings import SETTINGS
 
@@ -103,19 +104,21 @@ def _normalize_attachments(raw: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return attachments
 
 
-async def _ensure_pending_install(activity: dict[str, Any]) -> None:
+async def _ensure_pending_install(activity: dict[str, Any]) -> dict[str, Any] | None:
     """Record a pending (unbound) install when the bot is added to a tenant.
 
     Captures the ``serviceUrl`` (needed for every future outbound call) so
     the tenant-to-org bind handshake can complete later without another
-    inbound round-trip.
+    inbound round-trip. Returns Orchestra's install response (carrying
+    ``bind_nonce`` + a one-click ``connect_url``) so the caller can DM the
+    installer the connect link.
     """
     channel_data = activity.get("channelData") or {}
     tenant_id = (channel_data.get("tenant") or {}).get("id") or ""
     if not tenant_id:
-        return
+        return None
     installer = activity.get("from") or {}
-    await _post_orchestra(
+    return await _post_orchestra(
         "/admin/ms-teams-bot/pending-install",
         {
             "tenant_id": tenant_id,
@@ -124,6 +127,97 @@ async def _ensure_pending_install(activity: dict[str, Any]) -> None:
             "installer_aad_object_id": installer.get("aadObjectId") or "",
         },
     )
+
+
+def _install_welcome_card(connect_url: str) -> dict[str, Any]:
+    """Adaptive Card attachment: a one-tap "Connect to Unify" button."""
+    return {
+        "contentType": "application/vnd.microsoft.card.adaptive",
+        "content": {
+            "type": "AdaptiveCard",
+            "version": "1.4",
+            "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+            "body": [
+                {
+                    "type": "TextBlock",
+                    "size": "Medium",
+                    "weight": "Bolder",
+                    "text": "Thanks for adding Unify to Teams",
+                },
+                {
+                    "type": "TextBlock",
+                    "wrap": True,
+                    "text": (
+                        "One more step: connect this Teams tenant to your "
+                        "Unify account or organization. Tap Connect below and "
+                        "finish in Console — you only do this once."
+                    ),
+                },
+            ],
+            "actions": [
+                {
+                    "type": "Action.OpenUrl",
+                    "title": "Connect to Unify",
+                    "url": connect_url,
+                },
+            ],
+        },
+    }
+
+
+async def _send_install_welcome(
+    activity: dict[str, Any],
+    install: dict[str, Any] | None,
+) -> None:
+    """Proactively DM the installer a one-click connect link (best-effort).
+
+    Mints a Bot Connector token via the shared ``/send`` machinery and posts
+    an Adaptive Card into the install conversation. Any missing piece (an
+    already-bound install with no ``connect_url``, no ``service_url``, no
+    token, or a send failure) is logged and swallowed so it never breaks the
+    webhook.
+    """
+    if not install:
+        return
+    connect_url = install.get("connect_url") or ""
+    if not connect_url:
+        return
+    conversation = activity.get("conversation") or {}
+    conversation_id = conversation.get("id") or ""
+    service_url = (
+        activity.get("serviceUrl") or install.get("service_url") or ""
+    ).rstrip("/")
+    if not conversation_id or not service_url:
+        logger.warning(
+            "ms_teams_bot: welcome DM skipped — missing conversation_id or "
+            "service_url",
+        )
+        return
+    try:
+        token = await _mint_connector_token()
+    except Exception:
+        logger.exception("ms_teams_bot: connector token mint failed")
+        return
+    message = {"type": "message", "attachments": [_install_welcome_card(connect_url)]}
+    try:
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            resp = await client.post(
+                f"{service_url}/v3/conversations/{conversation_id}/activities",
+                json=message,
+                headers={
+                    "Authorization": f"Bearer {token}",
+                    "Content-Type": "application/json",
+                },
+            )
+    except Exception:
+        logger.exception("ms_teams_bot: welcome DM send transport error")
+        return
+    if resp.status_code >= 400:
+        logger.error(
+            "ms_teams_bot: welcome DM send failed: %s %s",
+            resp.status_code,
+            resp.text,
+        )
 
 
 async def resolve_ms_teams_bot_inbound(
@@ -201,6 +295,22 @@ async def ms_teams_bot_messages_webhook(
         members_added = activity.get("membersAdded") or []
         recipient_id = (activity.get("recipient") or {}).get("id") or ""
         if any(member.get("id") == recipient_id for member in members_added):
+            # Personal-scope add fires with a live 1:1 conversation reference,
+            # so record the install and DM the installer a one-click connect
+            # link (no code to copy).
+            install = await _ensure_pending_install(activity)
+            await _send_install_welcome(activity, install)
+        return {"status": 200}
+
+    # ``installationUpdate`` fires for app install/uninstall across scopes.
+    # ``add`` for an org-wide/admin-center install registers the tenant so the
+    # owner can bind it; we do NOT DM here because a personal add already emits
+    # the ``conversationUpdate`` above (avoids a double-DM) and an org install
+    # may have no personal 1:1 to message. ``remove``/``remove-upgrade`` are
+    # teardown signals the local mirror does not act on (no per-tenant token to
+    # revoke at Microsoft).
+    if activity_type == "installationUpdate":
+        if (activity.get("action") or "") == "add":
             await _ensure_pending_install(activity)
         return {"status": 200}
 

--- a/unify/task_scheduler/task_scheduler.py
+++ b/unify/task_scheduler/task_scheduler.py
@@ -2437,6 +2437,7 @@ class TaskScheduler(BaseTaskScheduler):
                 response_policy=response_policy,
                 entrypoint=entrypoint,
                 offline=offline,
+                enabled=False,
                 destination=destination_arg,
                 _root_applied=True,
             )


### PR DESCRIPTION
## Summary
- Plant custom `tasks.jsonl` rows with `enabled=False` so the dispatcher stays disarmed until an operator explicitly enables each Task.
- Test asserts inserted custom rows have `enabled is False`.

## Test plan
- [x] Unit test updated for custom insert `enabled=False`
- [x] Live prod `Teams/11/Tasks` already set to `enabled=False` (29/29)