### PR TITLE
Release: staging → main (offline task_due CM lane + repair-path fixes)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -259,7 +259,7 @@
         "filename": "tests/conversation_manager/core/test_event_handlers.py",
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_verified": false,
-        "line_number": 3476
+        "line_number": 3557
       }
     ],
     "tests/conversation_manager/core/test_event_logging.py": [
@@ -543,5 +543,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-12T23:18:11Z"
+  "generated_at": "2026-07-13T04:15:16Z"
 }

--- a/tests/conversation_manager/core/test_event_handlers.py
+++ b/tests/conversation_manager/core/test_event_handlers.py
@@ -2538,6 +2538,87 @@ class TestTaskDueEventHandlers:
         mock_cm.request_llm_run.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_explicit_offline_task_due_parses_and_dispatches_in_pod(
+        self,
+        mock_cm,
+    ):
+        """REST-fired offline task_due wake reasons must reach the in-pod runner.
+
+        Communication delivers these with ``source_type=explicit`` and an
+        empty ``scheduled_for`` plus the control-plane ``run_key``; the CM
+        must parse the payload, validate against the offline activation, and
+        dispatch with the same run_key so create-or-adopt reuses the run row.
+        """
+
+        from unify.conversation_manager.domains.task_activation import (
+            _handle_task_due_event,
+            _task_due_event_from_wake_reason,
+        )
+
+        wake_reason = {
+            "type": "task_due",
+            "task_id": 9,
+            "source_task_log_id": 555,
+            "activation_revision": "rev-1",
+            "scheduled_for": "",
+            "destination": None,
+            "execution_mode": "offline",
+            "source_type": "explicit",
+            "task_label": "GTM stargazer poll",
+            "run_key": "offline:explicit:42:9:abc:api-def",
+            "headless_offline": True,
+        }
+        event = _task_due_event_from_wake_reason(wake_reason)
+        assert event is not None, "explicit offline wake reason must parse"
+        assert event.execution_mode == "offline"
+        assert event.source_type == "explicit"
+        assert event.run_key == "offline:explicit:42:9:abc:api-def"
+
+        activation = TaskActivationSnapshot(
+            assistant_id="42",
+            activation_key="42:9",
+            task_id=9,
+            source_task_log_id=555,
+            activation_kind="scheduled",
+            execution_mode="offline",
+            activation_revision="rev-1",
+        )
+        fake_dispatcher = MagicMock()
+        fake_dispatcher.dispatch = AsyncMock()
+        mock_cm._offline_dispatcher = fake_dispatcher
+
+        with patch(
+            "unify.conversation_manager.domains.task_activation.validate_task_due_activation",
+            return_value=(activation, None),
+        ):
+            should_request_llm = await _handle_task_due_event(event, mock_cm)
+
+        assert should_request_llm is False
+        fake_dispatcher.dispatch.assert_awaited_once()
+        _, dispatch_kwargs = fake_dispatcher.dispatch.await_args
+        assert dispatch_kwargs["source_type"] == "explicit"
+        assert dispatch_kwargs["run_key"] == "offline:explicit:42:9:abc:api-def"
+
+    @pytest.mark.asyncio
+    async def test_scheduled_task_due_still_requires_scheduled_for(self):
+        """Clock-fired deliveries keep scheduled_for as part of their identity."""
+
+        from unify.conversation_manager.domains.task_activation import (
+            _task_due_event_from_wake_reason,
+        )
+
+        wake_reason = {
+            "type": "task_due",
+            "task_id": 9,
+            "source_task_log_id": 555,
+            "activation_revision": "rev-1",
+            "scheduled_for": "",
+            "execution_mode": "offline",
+            "source_type": "scheduled",
+        }
+        assert _task_due_event_from_wake_reason(wake_reason) is None
+
+    @pytest.mark.asyncio
     async def test_task_due_start_executes_scheduler_with_scheduled_reason(
         self,
         mock_cm,

--- a/tests/function_manager/core/test_callable_return.py
+++ b/tests/function_manager/core/test_callable_return.py
@@ -125,6 +125,37 @@ def test_search_return_callable_also_returns_metadata():
 
 
 @_handle_project
+def test_fresh_namespace_does_not_shadow_builtin_annotation_names():
+    """Callable injection into a fresh ``{}`` namespace (the symbolic-entrypoint
+    repair snapshot path) must not shadow builtins referenced in annotations.
+
+    A placeholder class named ``dict`` breaks ``dict[str, Any]`` evaluation at
+    def time with ``TypeError: type 'dict' is not subscriptable``.
+    """
+    fm = FunctionManager()
+    fm.add_functions(
+        implementations=(
+            "async def tick(**params: Any) -> dict[str, Any]:\n" "    return {}\n"
+        ),
+    )
+
+    ns: dict = {}
+    res = fm.filter_functions(
+        filter="name == 'tick'",
+        limit=1,
+        _return_callable=True,
+        _namespace=ns,
+        _also_return_metadata=True,
+    )
+
+    assert len(res["callables"]) == 1
+    assert callable(ns["tick"])
+    # Builtins must resolve to the real types, never injected placeholders.
+    assert ns.get("dict", dict) is dict
+    assert ns.get("str", str) is str
+
+
+@_handle_project
 def test_circular_dependency_injection_does_not_loop():
     fm = FunctionManager()
 

--- a/tests/task_scheduler/test_machine_state.py
+++ b/tests/task_scheduler/test_machine_state.py
@@ -91,6 +91,98 @@ def test_validate_task_due_activation_rejects_invalid_destination():
     assert stale_reason == "invalid_destination"
 
 
+def test_validate_task_due_activation_accepts_offline_execution_mode(monkeypatch):
+    activation = TaskActivationSnapshot(
+        assistant_id="42",
+        activation_key="42:101",
+        task_id=101,
+        source_task_log_id=555,
+        activation_kind="scheduled",
+        execution_mode="offline",
+        next_due_at="2026-04-10T09:00:00+00:00",
+        activation_revision="rev-1",
+    )
+    monkeypatch.setattr(
+        machine_state,
+        "get_task_activation",
+        lambda **_: activation,
+    )
+
+    current_activation, stale_reason = validate_task_due_activation(
+        assistant_id="42",
+        task_id=101,
+        activation_revision="rev-1",
+        source_task_log_id=555,
+        scheduled_for="2026-04-10T09:00:00+00:00",
+        execution_mode="offline",
+    )
+
+    assert current_activation == activation
+    assert stale_reason is None
+
+
+def test_validate_task_due_activation_explicit_skips_scheduled_for(monkeypatch):
+    """Explicit REST-fired deliveries run ahead of the projected occurrence."""
+
+    activation = TaskActivationSnapshot(
+        assistant_id="42",
+        activation_key="42:101",
+        task_id=101,
+        source_task_log_id=555,
+        activation_kind="scheduled",
+        execution_mode="offline",
+        next_due_at="2026-08-31T10:00:00+00:00",
+        activation_revision="rev-1",
+    )
+    monkeypatch.setattr(
+        machine_state,
+        "get_task_activation",
+        lambda **_: activation,
+    )
+
+    current_activation, stale_reason = validate_task_due_activation(
+        assistant_id="42",
+        task_id=101,
+        activation_revision="rev-1",
+        source_task_log_id=555,
+        scheduled_for="",
+        execution_mode="offline",
+        source_type="explicit",
+    )
+
+    assert current_activation == activation
+    assert stale_reason is None
+
+
+def test_validate_task_due_activation_rejects_mode_mismatch(monkeypatch):
+    activation = TaskActivationSnapshot(
+        assistant_id="42",
+        activation_key="42:101",
+        task_id=101,
+        source_task_log_id=555,
+        activation_kind="scheduled",
+        execution_mode="offline",
+        next_due_at="2026-04-10T09:00:00+00:00",
+        activation_revision="rev-1",
+    )
+    monkeypatch.setattr(
+        machine_state,
+        "get_task_activation",
+        lambda **_: activation,
+    )
+
+    current_activation, stale_reason = validate_task_due_activation(
+        assistant_id="42",
+        task_id=101,
+        activation_revision="rev-1",
+        source_task_log_id=555,
+        scheduled_for="2026-04-10T09:00:00+00:00",
+    )
+
+    assert current_activation is None
+    assert stale_reason == "execution_mode_changed"
+
+
 def test_build_activation_key_ignores_invalid_destination_labels():
     assert (
         build_activation_key(

--- a/unify/conversation_manager/domains/call_manager.py
+++ b/unify/conversation_manager/domains/call_manager.py
@@ -27,7 +27,10 @@ from unify.helpers import (
 if TYPE_CHECKING:
     from unify.conversation_manager.in_memory_event_broker import InMemoryEventBroker
 
-from unify.conversation_manager.medium_scripts.common import _resolve_agent_service_url
+from unify.conversation_manager.medium_scripts.common import (
+    _POD_LOCAL_AGENT_SERVICE_URL,
+    _resolve_agent_service_url,
+)
 
 
 def make_room_name(assistant_id: str, medium: str) -> str:
@@ -973,7 +976,13 @@ class LivekitCallManager:
 
         from unify.session_details import SESSION_DETAILS
 
-        base_url = _resolve_agent_service_url()
+        # Browser meets must run on the pod-local agent-service: the fast-brain
+        # voice worker and its MeetAudioBridge open the pod's default PulseAudio
+        # devices (meet_mic/agent_sink from device.sh), so the browser has to
+        # share that same PulseAudio server. Resolving to a managed-desktop VM
+        # here splits browser audio from the bridge and the assistant joins deaf
+        # and mute.
+        base_url = _POD_LOCAL_AGENT_SERVICE_URL
         auth_key = SESSION_DETAILS.unify_key
 
         room_name = make_room_name(self.assistant_id, room_suffix)
@@ -1019,7 +1028,7 @@ class LivekitCallManager:
             "meet_session_id": "",
             "meet_url": meet_url,
             "meet_display_name": display_name,
-            "agent_service_url": _resolve_agent_service_url(),
+            "agent_service_url": _POD_LOCAL_AGENT_SERVICE_URL,
         }
         if meet_opening_config:
             meet_extra["opening_config"] = meet_opening_config
@@ -1110,7 +1119,7 @@ class LivekitCallManager:
         if session_id:
             from unify.session_details import SESSION_DETAILS
 
-            base_url = _resolve_agent_service_url()
+            base_url = _POD_LOCAL_AGENT_SERVICE_URL
             auth_key = SESSION_DETAILS.unify_key
             try:
                 async with aiohttp.ClientSession() as session:
@@ -1156,7 +1165,7 @@ class LivekitCallManager:
         )
 
         meet_path = self._MEET_PATHS[channel]["path"]
-        base_url = _resolve_agent_service_url()
+        base_url = _POD_LOCAL_AGENT_SERVICE_URL
         auth_key = SESSION_DETAILS.unify_key
         try:
             async with aiohttp.ClientSession() as session:
@@ -1190,7 +1199,7 @@ class LivekitCallManager:
         from unify.session_details import SESSION_DETAILS
 
         meet_path = self._MEET_PATHS[channel]["path"]
-        base_url = _resolve_agent_service_url()
+        base_url = _POD_LOCAL_AGENT_SERVICE_URL
         auth_key = SESSION_DETAILS.unify_key
         try:
             async with aiohttp.ClientSession() as session:

--- a/unify/conversation_manager/domains/event_handlers.py
+++ b/unify/conversation_manager/domains/event_handlers.py
@@ -2724,10 +2724,12 @@ async def _(event: StartupEvent, cm: "ConversationManager", *args, **kwargs):
         cm.set_details(payload)
 
         # Restart agent-service with the user's API key.
-        # The agent-service is a sibling Node.js process started by entrypoint.sh
-        # with the container's original UNIFY_KEY. set_details() + export_to_env()
-        # update os.environ in this Python process, but the Node.js process still
-        # has the old key. Kill and respawn so auth and LLM billing use the user's key.
+        # The agent-service is a sibling Node.js process the CM spawns in-pod on
+        # localhost:3000 (entrypoint.sh only owns its teardown via
+        # stop_agent_service). It first comes up with the container's original
+        # UNIFY_KEY. set_details() + export_to_env() update os.environ in this
+        # Python process, but the Node.js process still has the old key. Kill and
+        # respawn so auth and LLM billing use the user's key.
         asyncio.create_task(
             asyncio.to_thread(
                 _restart_agent_service_with_key,

--- a/unify/conversation_manager/domains/task_activation.py
+++ b/unify/conversation_manager/domains/task_activation.py
@@ -485,6 +485,7 @@ async def _handle_task_due_event(event: TaskDue, cm: "ConversationManager") -> b
     """Validate and surface one due-task event to the notification bar."""
 
     assistant_id = _current_task_assistant_id()
+    execution_mode = str(getattr(event, "execution_mode", "") or "live").lower()
     activation, stale_reason = validate_task_due_activation(
         assistant_id=assistant_id,
         task_id=event.task_id,
@@ -492,6 +493,8 @@ async def _handle_task_due_event(event: TaskDue, cm: "ConversationManager") -> b
         source_task_log_id=event.source_task_log_id,
         scheduled_for=event.scheduled_for,
         destination=event.destination,
+        execution_mode=execution_mode,
+        source_type=str(event.source_type or "scheduled"),
     )
     if stale_reason is not None:
         cm._session_logger.info(
@@ -505,9 +508,7 @@ async def _handle_task_due_event(event: TaskDue, cm: "ConversationManager") -> b
 
     # Offline due tasks stay disconnected from the CM→act chat loop: spawn the
     # offline_runner subprocess on this same pod (LocalOfflineDispatcher).
-    if str(getattr(event, "execution_mode", "") or "").lower() == "offline" or (
-        activation is not None and activation.execution_mode == "offline"
-    ):
+    if execution_mode == "offline" or activation.execution_mode == "offline":
         return await _handle_offline_scheduled_due(
             event,
             cm,
@@ -586,7 +587,13 @@ async def _handle_offline_scheduled_due(
         cm._offline_dispatcher = dispatcher
 
     try:
-        await dispatcher.dispatch(activation, source_type="scheduled")
+        # Reuse the dispatcher-provided run_key when present so the in-pod
+        # runner adopts the task-run row the control plane already created.
+        await dispatcher.dispatch(
+            activation,
+            source_type=str(event.source_type or "scheduled"),
+            run_key=event.run_key or None,
+        )
     except Exception as exc:
         error_message = (
             f"Offline scheduled task '{_task_due_label(event, activation)}' failed "

--- a/unify/conversation_manager/events.py
+++ b/unify/conversation_manager/events.py
@@ -1698,6 +1698,7 @@ class TaskDue(Event):
     task_summary: str = ""
     visibility_policy: str = "silent_by_default"
     recurrence_hint: str = "one_off"
+    run_key: str = ""
     reason: str = ""
 
     @classmethod
@@ -1736,9 +1737,16 @@ class TaskDue(Event):
         source_task_log_id = _coerce_int(payload.get("source_task_log_id"))
         activation_revision = str(payload.get("activation_revision") or "")
         scheduled_for = str(payload.get("scheduled_for") or "")
+        source_type = str(payload.get("source_type") or "scheduled")
         if task_id is None or source_task_log_id is None:
             return None
-        if not activation_revision or not scheduled_for:
+        if not activation_revision:
+            return None
+        # ``scheduled_for`` is part of the dedupe identity for clock-fired
+        # deliveries only. Explicit (REST-fired) deliveries of a scheduled
+        # task legitimately fire ahead of the projected occurrence and carry
+        # an empty scheduled_for.
+        if source_type == "scheduled" and not scheduled_for:
             return None
         try:
             destination = ContextRegistry.canonical_destination(
@@ -1759,13 +1767,14 @@ class TaskDue(Event):
             scheduled_for=scheduled_for,
             destination=destination,
             execution_mode=str(payload.get("execution_mode") or "live"),
-            source_type=str(payload.get("source_type") or "scheduled"),
+            source_type=source_type,
             task_label=task_label,
             task_summary=str(payload.get("task_summary") or ""),
             visibility_policy=str(
                 payload.get("visibility_policy") or "silent_by_default",
             ),
             recurrence_hint=str(payload.get("recurrence_hint") or "one_off"),
+            run_key=str(payload.get("run_key") or ""),
             reason=resolved_reason,
         )
 

--- a/unify/function_manager/function_manager.py
+++ b/unify/function_manager/function_manager.py
@@ -1,5 +1,6 @@
 import ast
 import asyncio
+import builtins
 import dataclasses
 import hashlib
 from contextlib import contextmanager
@@ -4588,11 +4589,17 @@ class FunctionManager(BaseFunctionManager):
         if not annotation_names:
             return
 
-        builtins_obj = namespace.get("__builtins__", {})
+        # exec() installs the real builtins module into the namespace, so real
+        # builtin names (dict, str, list, ...) are always resolvable even when
+        # the caller passes a fresh namespace without __builtins__. Shadowing
+        # them with placeholder classes breaks subscripted annotations like
+        # ``dict[str, Any]`` at def-evaluation time.
+        builtin_names = set(dir(builtins))
+        builtins_obj = namespace.get("__builtins__")
         if isinstance(builtins_obj, dict):
-            builtin_names = set(builtins_obj.keys())
-        else:
-            builtin_names = set(dir(builtins_obj))
+            builtin_names |= set(builtins_obj.keys())
+        elif builtins_obj is not None:
+            builtin_names |= set(dir(builtins_obj))
 
         typing_mod = namespace.get("typing")
         pydantic_mod = namespace.get("pydantic")

--- a/unify/task_scheduler/local_scheduler/offline_dispatcher.py
+++ b/unify/task_scheduler/local_scheduler/offline_dispatcher.py
@@ -44,16 +44,24 @@ class LocalOfflineDispatcher:
         snap: "TaskActivationSnapshot",
         *,
         source_type: str = "scheduled",
+        run_key: str | None = None,
     ) -> asyncio.subprocess.Process:
         """Spawn the offline runner subprocess and return the Process handle.
 
         Caller does not need to await the subprocess: a background watcher
         task is registered to log the exit code when it terminates. Returned
         ``Process`` is exposed so tests can interrogate the spawn arguments
-        and exit status synchronously.
+        and exit status synchronously. A caller-provided ``run_key`` (e.g.
+        from a hosted dispatch that already created the task-run row) takes
+        precedence over the locally derived key so create-or-adopt dedupes
+        onto the same run.
         """
 
-        env = _build_local_offline_runner_env(snap, source_type=source_type)
+        env = _build_local_offline_runner_env(
+            snap,
+            source_type=source_type,
+            run_key=run_key,
+        )
         merged_env = {**os.environ, **env}
         # PYTHONUNBUFFERED so subprocess prints reach our log on demand.
         merged_env.setdefault("PYTHONUNBUFFERED", "1")
@@ -142,6 +150,7 @@ def _build_local_offline_runner_env(
     snap: "TaskActivationSnapshot",
     *,
     source_type: str,
+    run_key: str | None = None,
     source_ref: str | None = None,
     source_medium: str | None = None,
     source_contact_id: int | None = None,
@@ -162,7 +171,7 @@ def _build_local_offline_runner_env(
     resolved_medium = source_medium or (
         str(snap.trigger_medium) if snap.trigger_medium else None
     )
-    run_key = _build_local_offline_run_key(
+    run_key = run_key or _build_local_offline_run_key(
         snap,
         source_type=source_type,
         source_ref=source_ref,

--- a/unify/task_scheduler/machine_state.py
+++ b/unify/task_scheduler/machine_state.py
@@ -820,8 +820,17 @@ def validate_task_due_activation(
     source_task_log_id: int,
     scheduled_for: str,
     destination: str | None = None,
+    execution_mode: str = "live",
+    source_type: str = "scheduled",
 ) -> tuple[TaskActivationSnapshot | None, str | None]:
-    """Validate that a scheduled due event still matches the current activation."""
+    """Validate that a due event still matches the current activation.
+
+    ``execution_mode`` is the delivery's expectation (live vs offline).
+    ``scheduled_for`` participates in the identity check only for clock-fired
+    (``source_type == "scheduled"``) deliveries: explicit REST-fired
+    deliveries of a scheduled activation legitimately run ahead of the
+    projected occurrence.
+    """
 
     try:
         normalized_destination = ContextRegistry.canonical_destination(destination)
@@ -836,7 +845,7 @@ def validate_task_due_activation(
         return None, "activation_missing"
     if activation.activation_kind != "scheduled":
         return None, "activation_kind_changed"
-    if activation.execution_mode != "live":
+    if activation.execution_mode != execution_mode:
         return None, "execution_mode_changed"
     if activation.activation_revision != activation_revision:
         return None, "activation_revision_mismatch"
@@ -849,9 +858,9 @@ def validate_task_due_activation(
         return None, "destination_membership_revoked"
     if activation.source_task_log_id != source_task_log_id:
         return None, "source_task_log_id_mismatch"
-    if _normalize_datetime_string(activation.next_due_at) != _normalize_datetime_string(
-        scheduled_for,
-    ):
+    if source_type == "scheduled" and _normalize_datetime_string(
+        activation.next_due_at,
+    ) != _normalize_datetime_string(scheduled_for):
         return None, "scheduled_for_mismatch"
     return activation, None
 


### PR DESCRIPTION
## Summary
- Accept explicit (REST-fired) offline `task_due` deliveries on the CM lane: parse empty `scheduled_for`, validate against the delivery's execution mode, and pass `source_type`/`run_key` through to the in-pod offline dispatcher. Production offline task triggers (e.g. `gtm.stargazer.poll` on brain operator 1406) were dropped as "unparseable startup wake reason".
- Fix builtin-name shadowing in the function-manager annotation placeholder injection (repair-path `TypeError: type 'dict' is not subscriptable` that masked real entrypoint failures).
- Pin browser-meet agent-service to pod-local joins (already on staging).

## Test plan
- [x] `tests/task_scheduler/test_machine_state.py`, `tests/task_scheduler/test_local_offline_dispatcher.py`, `tests/conversation_manager/core/test_event_handlers.py::TestTaskDueEventHandlers` (39 passed)
- [x] `tests/function_manager/core/test_callable_return.py` (12 passed)
- [ ] After deploy: `POST /v0/tasks/9/trigger` runs the stargazer poll headlessly on assistant 1406