### PR TITLE
ci(diag): register Cancel Smoke workflow on main

### DIFF
--- a/.github/workflows/cancel-smoke.yml
+++ b/.github/workflows/cancel-smoke.yml
@@ -1,0 +1,137 @@
+# Diagnostic only — not part of the normal test matrix.
+# Purpose: empirically measure GitHub cancel latency under patterns that
+# mirror (or isolate) our Tests "Run tests" step, so we can pick a fix
+# we know works before changing tests.yml / parallel_run.sh.
+#
+# Experiments:
+#   A — bare `sleep` (GitHub cancel baseline)
+#   B — detached tmux + wait loop, no trap (does kill-tree reap tmux?)
+#   C — same as B, but trap runs `tmux kill-server` (hard cleanup)
+#   D — parallel_run-style trap (TERM pane pgid → kill-session, no kill-server)
+#   E — bare sleep + `if: always()` 120s step (post-cancel wind-down cost)
+#
+# Procedure: dispatch → wait until Hang steps are in_progress →
+# `gh run cancel` → measure time-to-cancelled per job from logs/API.
+name: Cancel Smoke
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: write
+
+concurrency:
+  group: cancel-smoke-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  A_baseline_sleep:
+    name: "A: baseline sleep"
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+    - name: Hang
+      run: |
+        set -u
+        echo "SMOKE_A start $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+        # Heartbeat so logs prove the step was alive pre-cancel
+        while true; do
+          echo "SMOKE_A heartbeat $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          sleep 10
+        done
+
+  B_tmux_no_trap:
+    name: "B: tmux wait, no trap"
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+    - name: Hang
+      run: |
+        set -u
+        echo "SMOKE_B start $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+        tmux new-session -d -s smoke_b "bash -c 'while true; do echo tmux_b \$(date -u +%H:%M:%S); sleep 10; done'"
+        # Parent waits on the session — mirrors parallel_run's wait loop
+        while tmux has-session -t smoke_b 2>/dev/null; do
+          echo "SMOKE_B heartbeat $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          sleep 5
+        done
+        echo "SMOKE_B session ended unexpectedly"
+
+  C_tmux_kill_server_trap:
+    name: "C: tmux + kill-server trap"
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+    - name: Hang
+      run: |
+        set -u
+        cleanup() {
+          echo "SMOKE_C caught signal $(date -u +%Y-%m-%dT%H:%M:%SZ) — kill-server"
+          tmux kill-server 2>/dev/null || true
+          exit 143
+        }
+        trap cleanup INT TERM
+        echo "SMOKE_C start $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+        tmux new-session -d -s smoke_c "bash -c 'while true; do echo tmux_c \$(date -u +%H:%M:%S); sleep 10; done'"
+        while tmux has-session -t smoke_c 2>/dev/null; do
+          echo "SMOKE_C heartbeat $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          sleep 5
+        done
+        echo "SMOKE_C session ended unexpectedly"
+
+  D_parallel_run_style_trap:
+    name: "D: parallel_run-style trap"
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+    - name: Hang
+      run: |
+        set -u
+        # Mirrors tests/parallel_run.sh _cleanup_sessions (TERM pane pgid,
+        # brief sleep, kill-session) — does NOT kill-server.
+        cleanup() {
+          local sig="${1:-TERM}"
+          echo "SMOKE_D caught signal ${sig} $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          tmux list-panes -t smoke_d -F '#{pane_pid}' 2>/dev/null | while read -r pid; do
+            if [[ -n "$pid" ]]; then
+              kill -TERM "-$pid" 2>/dev/null || true
+            fi
+          done
+          sleep 0.1
+          tmux kill-session -t smoke_d 2>/dev/null || true
+          echo "SMOKE_D cleanup complete $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          exit 143
+        }
+        trap 'cleanup INT' INT
+        trap 'cleanup TERM' TERM
+        echo "SMOKE_D start $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+        tmux new-session -d -s smoke_d "bash -c 'while true; do echo tmux_d \$(date -u +%H:%M:%S); sleep 10; done'"
+        while tmux has-session -t smoke_d 2>/dev/null; do
+          echo "SMOKE_D heartbeat $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          sleep 5
+        done
+        echo "SMOKE_D session ended unexpectedly"
+
+  E_always_slow_cleanup:
+    name: "E: always() 120s after hang"
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+    - name: Hang
+      run: |
+        set -u
+        echo "SMOKE_E hang start $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+        while true; do
+          echo "SMOKE_E heartbeat $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          sleep 10
+        done
+    - name: Slow always cleanup
+      if: always()
+      run: |
+        echo "SMOKE_E always-start $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+        sleep 120
+        echo "SMOKE_E always-done $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    - name: Cancel-only cleanup
+      if: cancelled()
+      run: echo "SMOKE_E cancelled-cleanup $(date -u +%Y-%m-%dT%H:%M:%SZ)"

--- a/scripts/dev/run_cancel_smoke.sh
+++ b/scripts/dev/run_cancel_smoke.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Drive the Cancel Smoke workflow: dispatch → wait → cancel → report timings.
+# Usage: bash scripts/dev/run_cancel_smoke.sh
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+echo "Dispatching Cancel Smoke on staging..."
+gh workflow run cancel-smoke.yml --ref staging
+
+# Resolve the new run id
+sleep 3
+RUN_ID="$(gh run list --workflow=cancel-smoke.yml --branch=staging --limit 1 --json databaseId,status --jq '.[0].databaseId')"
+echo "Run: https://github.com/unifyai/unify/actions/runs/${RUN_ID}"
+
+echo "Waiting until all Hang steps are in_progress..."
+for _ in $(seq 1 60); do
+  payload="$(gh run view "$RUN_ID" --json status,jobs)"
+  ready="$(python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+jobs=[j for j in d['jobs'] if j['name'].startswith(('A:','B:','C:','D:','E:'))]
+if len(jobs) < 5:
+    print('0'); sys.exit(0)
+n=0
+for j in jobs:
+    for s in j.get('steps') or []:
+        if s.get('name') in ('Hang',) and s.get('status')=='in_progress':
+            n+=1
+print(n)
+" <<<"$payload")"
+  echo "  hang_in_progress=${ready}/5  run=$(echo "$payload" | python3 -c 'import json,sys; print(json.load(sys.stdin)["status"])')"
+  if [[ "$ready" == "5" ]]; then
+    break
+  fi
+  sleep 5
+done
+
+if [[ "$ready" != "5" ]]; then
+  echo "ERROR: timed out waiting for Hang steps" >&2
+  exit 1
+fi
+
+CANCEL_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+echo "Cancelling at ${CANCEL_AT}..."
+gh run cancel "$RUN_ID"
+echo "$CANCEL_AT" > /tmp/cancel_smoke_cancel_at.txt
+echo "$RUN_ID" > /tmp/cancel_smoke_run_id.txt
+
+echo "Polling until run completes..."
+for _ in $(seq 1 120); do
+  st="$(gh run view "$RUN_ID" --json status,conclusion --jq '.status + "/" + (.conclusion // "-")')"
+  echo "  ${st}"
+  if [[ "$st" != in_progress/* && "$st" != pending/* && "$st" != queued/* ]]; then
+    break
+  fi
+  sleep 5
+done
+
+DONE_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+echo "Done at ${DONE_AT}. Analysing..."
+
+python3 - <<PY
+import json, subprocess
+from datetime import datetime, timezone
+
+run_id = open("/tmp/cancel_smoke_run_id.txt").read().strip()
+cancel_at = datetime.fromisoformat(open("/tmp/cancel_smoke_cancel_at.txt").read().strip().replace("Z","+00:00"))
+
+raw = subprocess.check_output(["gh","run","view",run_id,"--json","status,conclusion,jobs,url"], text=True)
+d = json.loads(raw)
+print(f"\\nRun {run_id}: {d['status']}/{d.get('conclusion')}  {d['url']}")
+print(f"Cancel requested at: {cancel_at.isoformat()}")
+print()
+print(f"{'job':40} {'conclusion':12} {'hang_end_lag':>12} {'job_end_lag':>12} {'always_ran':>10} {'cancel_step':>11}")
+print("-"*100)
+
+def parse(ts):
+    if not ts or ts.startswith("0001"):
+        return None
+    return datetime.fromisoformat(ts.replace("Z","+00:00"))
+
+for j in sorted(d["jobs"], key=lambda x: x["name"]):
+    hang_end = None
+    always = False
+    cancel_cleanup = False
+    for s in j.get("steps") or []:
+        if s.get("name") == "Hang":
+            hang_end = parse(s.get("completedAt"))
+        if s.get("name") == "Slow always cleanup" and s.get("conclusion") not in (None, "skipped", ""):
+            always = True
+        if s.get("name") == "Cancel-only cleanup" and s.get("conclusion") == "success":
+            cancel_cleanup = True
+    job_end = parse(j.get("completedAt"))
+    hang_lag = f"{(hang_end-cancel_at).total_seconds():.0f}s" if hang_end else "—"
+    job_lag = f"{(job_end-cancel_at).total_seconds():.0f}s" if job_end else "—"
+    print(f"{j['name'][:40]:40} {str(j.get('conclusion') or j['status']):12} {hang_lag:>12} {job_lag:>12} {str(always):>10} {str(cancel_cleanup):>11}")
+PY


### PR DESCRIPTION
## Summary
- Registers diagnostic-only `Cancel Smoke` workflow on `main` so `workflow_dispatch` works (GitHub only lists new workflows from the default branch).
- No production test or cancel-path changes — experiments A–E only.

## Test plan
- [x] Dispatch Cancel Smoke, cancel mid-flight, record per-job death times
- [ ] Delete workflow after diagnosis if desired