### PR TITLE
Release: staging → main (team-owned Tasks routing)

### DIFF
--- a/tests/task_scheduler/test_team_owned_custom_tasks.py
+++ b/tests/task_scheduler/test_team_owned_custom_tasks.py
@@ -1,0 +1,96 @@
+"""Team-owned assistants must sync custom tasks onto the owning-team Tasks tree."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from unify.session_details import SESSION_DETAILS
+from unify.task_scheduler.task_scheduler import TaskScheduler
+
+
+@pytest.fixture
+def team_owned_session():
+    original_owner = SESSION_DETAILS.owner_team_id
+    original_agent = SESSION_DETAILS.assistant.agent_id
+    SESSION_DETAILS.owner_team_id = 11
+    SESSION_DETAILS.assistant.agent_id = 1406
+    try:
+        yield
+    finally:
+        SESSION_DETAILS.owner_team_id = original_owner
+        SESSION_DETAILS.assistant.agent_id = original_agent
+
+
+def test_task_context_personal_destination_uses_owner_team(team_owned_session):
+    scheduler = TaskScheduler.__new__(TaskScheduler)
+    with patch(
+        "unify.task_scheduler.task_scheduler.ContextRegistry.write_root",
+        return_value="Teams/11",
+    ) as write_root:
+        ctx = scheduler._task_context_for_destination("personal")
+    assert ctx == "Teams/11/Tasks"
+    write_root.assert_called_once()
+    assert write_root.call_args.kwargs["destination"] == "personal"
+
+
+def test_sync_custom_tasks_refuses_non_team_context_when_team_owned(
+    team_owned_session,
+    monkeypatch,
+):
+    scheduler = TaskScheduler.__new__(TaskScheduler)
+    monkeypatch.setattr(
+        scheduler,
+        "_sync_destination_contexts",
+        lambda destination: (
+            "cli3t/1406/Tasks",
+            "cli3t/1406/Tasks/Meta",
+            True,
+        ),
+    )
+    with pytest.raises(RuntimeError, match="Refusing custom-tasks sync"):
+        scheduler.sync_custom_tasks(source_tasks={})
+
+
+def test_sync_custom_tasks_allows_personal_label_when_resolved_to_team(
+    team_owned_session,
+    monkeypatch,
+):
+    scheduler = TaskScheduler.__new__(TaskScheduler)
+    monkeypatch.setattr(
+        scheduler,
+        "_sync_destination_contexts",
+        lambda destination: (
+            "Teams/11/Tasks",
+            "Teams/11/Tasks/Meta",
+            True,
+        ),
+    )
+
+    class _MetaCtx:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+    monkeypatch.setattr(
+        scheduler,
+        "_temporary_tasks_meta_context",
+        lambda ctx: _MetaCtx(),
+    )
+    monkeypatch.setattr(scheduler, "_get_stored_custom_tasks_hash", lambda: "same")
+    monkeypatch.setattr(
+        "unify.task_scheduler.task_scheduler.compute_custom_tasks_hash",
+        lambda **_: "same",
+    )
+    scheduler._custom_tasks_synced = False
+    scheduler._custom_tasks_synced_contexts = set()
+    scheduler._ctx = "Teams/11/Tasks"
+    scheduler._store = MagicMock()
+    scheduler._root_stores = {}
+    scheduler._active_task_root_context = None
+
+    # Must not raise: destination label 'personal' is fine when resolved under Teams/.
+    assert scheduler.sync_custom_tasks(source_tasks={}, destination=None) is False

--- a/unify/task_scheduler/task_scheduler.py
+++ b/unify/task_scheduler/task_scheduler.py
@@ -669,11 +669,16 @@ class TaskScheduler(BaseTaskScheduler):
         return store
 
     def _task_context_for_destination(self, destination: str | None) -> str:
-        """Resolve a write destination into a concrete Tasks context."""
+        """Resolve a write destination into a concrete Tasks context.
+
+        For team-owned assistants, ``personal`` / ``None`` is the owning-team
+        home (``Teams/{owner}/Tasks``), matching ContextRegistry shared-table
+        routing. Never short-circuit through a cached personal path — that
+        silently re-seeded ``{user}/{agent}/Tasks`` when session identity was
+        wrong at init time.
+        """
 
         destination = destination or os.environ.get("TASK_DESTINATION") or None
-        if destination in (None, PERSONAL_DESTINATION):
-            return self._personal_tasks_context
         root_context = ContextRegistry.write_root(
             self,
             "Tasks",
@@ -3391,11 +3396,20 @@ class TaskScheduler(BaseTaskScheduler):
             return False
 
         env_owner = (os.environ.get("OWNER_TEAM_ID") or "").strip()
-        if is_personal and env_owner:
+        if SESSION_DETAILS.team_owned:
+            owner_team_id = SESSION_DETAILS.owner_team_id
+            expected_prefix = f"Teams/{owner_team_id}/"
+            if not str(tasks_context).startswith(expected_prefix):
+                raise RuntimeError(
+                    "Refusing custom-tasks sync onto "
+                    f"{tasks_context!r} for team-owned assistant; expected under "
+                    f"Teams/{owner_team_id}/Tasks "
+                    "(destination 'personal' means the owning-team home).",
+                )
+        elif env_owner:
             raise RuntimeError(
-                "Refusing custom-tasks sync onto the personal Tasks root while "
-                f"OWNER_TEAM_ID={env_owner!r} is set; team-owned assistants must "
-                "materialize under Teams/{owner_team_id}/Tasks.",
+                "OWNER_TEAM_ID is set but SESSION_DETAILS.owner_team_id is missing; "
+                "refusing custom-tasks sync until team ownership is bound.",
             )
 
         previous_context = self._ctx


### PR DESCRIPTION
## Summary
- Route team-owned `destination=personal` Tasks sync through ContextRegistry home (`Teams/{owner}/Tasks`)
- Refuse sync only when the resolved context is outside the owning team tree
- Prevents re-seeding `{user}/{agent}/Tasks` for team-owned assistants such as brain_operator

## Test plan
- [x] `tests/task_scheduler/test_team_owned_custom_tasks.py` (3 passed)
- [ ] Staging CI green