### PR TITLE
Release: staging → main (filter hard-cut)

### DIFF
--- a/tests/data_manager/test_filter_wire_names.py
+++ b/tests/data_manager/test_filter_wire_names.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from unify.common import join_utils
+from unify.data_manager.ops import join_ops, plot_ops, table_view_ops
+
+
+def test_join_tables_uses_filter_in_pair_of_args(monkeypatch):
+    captured = {}
+
+    def fake_join_logs(**kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(join_ops.unisdk, "join_logs", fake_join_logs)
+
+    join_ops.join_tables_impl(
+        left_table="Data/left",
+        right_table="Data/right",
+        join_expr="Data/left.id == Data/right.id",
+        dest_table="Data/joined",
+        select={"Data/left.id": "id"},
+        left_where="active == True",
+        right_where="visible == True",
+    )
+
+    assert captured["pair_of_args"] == (
+        {"context": "Data/left", "filter": "active == True"},
+        {"context": "Data/right", "filter": "visible == True"},
+    )
+
+
+def test_common_create_join_uses_filter_in_pair_of_args(monkeypatch):
+    captured = {}
+
+    def fake_join_logs(**kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(join_utils.unisdk, "join_logs", fake_join_logs)
+
+    join_utils.create_join(
+        left_context="Data/left",
+        right_context="Data/right",
+        dest_context="Data/joined",
+        join_expr="Data/left.id == Data/right.id",
+        select={"Data/left.id": "id"},
+        left_where="active == True",
+    )
+
+    assert captured["pair_of_args"] == (
+        {"context": "Data/left", "filter": "active == True"},
+        {"context": "Data/right"},
+    )
+
+
+def test_filter_join_uses_filter_for_join_query(monkeypatch):
+    captured = {}
+
+    def fake_join_query(**kwargs):
+        captured.update(kwargs)
+        return {"logs": []}
+
+    monkeypatch.setattr(join_ops.unisdk, "join_query", fake_join_query)
+
+    assert (
+        join_ops.filter_join_impl(
+            tables=["Data/left", "Data/right"],
+            join_expr="Data/left.id == Data/right.id",
+            select={"Data/left.id": "id"},
+            left_where="active == True",
+            result_where="id > 1",
+        )
+        == []
+    )
+    assert captured["pair_of_args"] == (
+        {"context": "Data/left", "filter": "active == True"},
+        {"context": "Data/right"},
+    )
+    assert captured["filter"] == "id > 1"
+    assert "filter_expr" not in captured
+
+
+def test_table_view_project_config_uses_filter():
+    assert table_view_ops._build_project_config_dict(
+        project_name="Project",
+        context="Data/table",
+        filter="active == True",
+    ) == {
+        "project_name": "Project",
+        "context": "Data/table",
+        "filter": "active == True",
+    }
+
+
+def test_plot_project_config_uses_filter():
+    assert plot_ops._build_project_config_dict(
+        project_name="Project",
+        context="Data/table",
+        filter="active == True",
+    ) == {
+        "project_name": "Project",
+        "context": "Data/table",
+        "randomize": False,
+        "filter": "active == True",
+    }

--- a/unify/common/join_utils.py
+++ b/unify/common/join_utils.py
@@ -103,11 +103,11 @@ def create_join(
         pair_of_args=(
             {
                 "context": left_context,
-                **({} if left_where is None else {"filter_expr": left_where}),
+                **({} if left_where is None else {"filter": left_where}),
             },
             {
                 "context": right_context,
-                **({} if right_where is None else {"filter_expr": right_where}),
+                **({} if right_where is None else {"filter": right_where}),
             },
         ),
         join_expr=join_expr,

--- a/unify/conversation_manager/assistant_jobs_api.py
+++ b/unify/conversation_manager/assistant_jobs_api.py
@@ -48,17 +48,17 @@ def ensure_project_exists(api_key: str) -> None:
 
 def get_assistant_logs(
     api_key: str,
-    filter_expr: str,
+    filter: str,
     limit: int = 100,
 ) -> list:
-    """Fetch AssistantJobs log entries matching *filter_expr*.
+    """Fetch AssistantJobs log entries matching *filter*.
 
     Returns a list of ``unisdk.Log`` objects.
     """
     return unisdk.get_logs(
         project=PROJECT_NAME,
         context=CONTEXT,
-        filter=filter_expr,
+        filter=filter,
         limit=limit,
         api_key=api_key,
     )

--- a/unify/data_manager/ops/join_ops.py
+++ b/unify/data_manager/ops/join_ops.py
@@ -84,11 +84,11 @@ def join_tables_impl(
         pair_of_args=(
             {
                 "context": left_table,
-                **({} if left_where is None else {"filter_expr": left_where}),
+                **({} if left_where is None else {"filter": left_where}),
             },
             {
                 "context": right_table,
-                **({} if right_where is None else {"filter_expr": right_where}),
+                **({} if right_where is None else {"filter": right_where}),
             },
         ),
         join_expr=join_expr,
@@ -217,17 +217,17 @@ def filter_join_impl(
         pair_of_args=(
             {
                 "context": tables[0],
-                **({"filter_expr": left_where} if left_where else {}),
+                **({"filter": left_where} if left_where else {}),
             },
             {
                 "context": tables[1],
-                **({"filter_expr": right_where} if right_where else {}),
+                **({"filter": right_where} if right_where else {}),
             },
         ),
         join_expr=join_expr,
         mode=mode,
         columns=select,
-        filter_expr=result_where,
+        filter=result_where,
         limit=result_limit,
         offset=result_offset,
     )
@@ -308,11 +308,11 @@ def reduce_join_impl(
         pair_of_args=(
             {
                 "context": tables[0],
-                **({"filter_expr": left_where} if left_where else {}),
+                **({"filter": left_where} if left_where else {}),
             },
             {
                 "context": tables[1],
-                **({"filter_expr": right_where} if right_where else {}),
+                **({"filter": right_where} if right_where else {}),
             },
         ),
         join_expr=join_expr,
@@ -320,7 +320,7 @@ def reduce_join_impl(
         columns=select,
         metric=metric,
         key=columns,
-        filter_expr=result_where,
+        filter=result_where,
         group_by=group_by,
     )
 

--- a/unify/data_manager/ops/plot_ops.py
+++ b/unify/data_manager/ops/plot_ops.py
@@ -88,7 +88,7 @@ def _build_project_config_dict(
     *,
     project_name: str,
     context: str,
-    filter_expr: Optional[str] = None,
+    filter: Optional[str] = None,
     randomize: bool = False,
     exclude_fields: Optional[List[str]] = None,
     group_by: Optional[str] = None,
@@ -102,8 +102,8 @@ def _build_project_config_dict(
         "randomize": randomize,
     }
 
-    if filter_expr is not None:
-        result["filter_expr"] = filter_expr
+    if filter is not None:
+        result["filter"] = filter
     if exclude_fields is not None:
         result["exclude_fields"] = exclude_fields
     if group_by is not None:
@@ -184,7 +184,7 @@ def generate_plot(
     *,
     config: PlotConfig,
     context: str,
-    filter_expr: Optional[str] = None,
+    filter: Optional[str] = None,
     project_name: Optional[str] = None,
     randomize: bool = False,
     exclude_fields: Optional[List[str]] = None,
@@ -203,7 +203,7 @@ def generate_plot(
         PlotConfig defining the visualization parameters.
     context : str
         Fully-qualified table context path.
-    filter_expr : str | None
+    filter : str | None
         Optional filter expression.
     project_name : str | None
         Unify project name. If None, uses the active project.
@@ -241,7 +241,7 @@ def generate_plot(
     project_config_dict = _build_project_config_dict(
         project_name=project_name,
         context=context,
-        filter_expr=filter_expr,
+        filter=filter,
         randomize=randomize,
         exclude_fields=exclude_fields,
         group_by=project_group_by,
@@ -314,7 +314,7 @@ def generate_plots_batch(
     *,
     contexts: List[str],
     config: PlotConfig,
-    filter_expr: Optional[str] = None,
+    filter: Optional[str] = None,
     project_name: Optional[str] = None,
     randomize: bool = False,
     exclude_fields: Optional[List[str]] = None,
@@ -333,7 +333,7 @@ def generate_plots_batch(
         List of fully-qualified context paths.
     config : PlotConfig
         PlotConfig defining the visualization parameters.
-    filter_expr : str | None
+    filter : str | None
         Optional filter expression.
     project_name : str | None
         Unify project name. If None, uses the active project.
@@ -374,7 +374,7 @@ def generate_plots_batch(
         result = generate_plot(
             config=config,
             context=context,
-            filter_expr=filter_expr,
+            filter=filter,
             project_name=project_name,
             randomize=randomize,
             exclude_fields=exclude_fields,

--- a/unify/data_manager/ops/table_view_ops.py
+++ b/unify/data_manager/ops/table_view_ops.py
@@ -81,7 +81,7 @@ def _build_project_config_dict(
     *,
     project_name: str,
     context: str,
-    filter_expr: Optional[str] = None,
+    filter: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Build the project_config dictionary for the API request."""
     result: Dict[str, Any] = {
@@ -89,8 +89,8 @@ def _build_project_config_dict(
         "context": context,
     }
 
-    if filter_expr is not None:
-        result["filter_expr"] = filter_expr
+    if filter is not None:
+        result["filter"] = filter
 
     return result
 
@@ -162,7 +162,7 @@ def generate_table_view(
     *,
     config: TableViewConfig,
     context: str,
-    filter_expr: Optional[str] = None,
+    filter: Optional[str] = None,
     project_name: Optional[str] = None,
     title: Optional[str] = None,
     title_suffix: Optional[str] = None,
@@ -176,7 +176,7 @@ def generate_table_view(
         Configuration defining columns, sorting, and row limits.
     context : str
         Fully-qualified table context path.
-    filter_expr : str | None
+    filter : str | None
         Optional filter expression.
     project_name : str | None
         Unify project name. If None, uses the active project.
@@ -207,7 +207,7 @@ def generate_table_view(
     project_config_dict = _build_project_config_dict(
         project_name=project_name,
         context=context,
-        filter_expr=filter_expr,
+        filter=filter,
     )
 
     request_body: Dict[str, Any] = {
@@ -277,7 +277,7 @@ def generate_table_views_batch(
     *,
     contexts: List[str],
     config: TableViewConfig,
-    filter_expr: Optional[str] = None,
+    filter: Optional[str] = None,
     project_name: Optional[str] = None,
     title: Optional[str] = None,
 ) -> List[TableViewResult]:
@@ -290,7 +290,7 @@ def generate_table_views_batch(
         List of fully-qualified context paths.
     config : TableViewConfig
         Configuration defining columns, sorting, and row limits.
-    filter_expr : str | None
+    filter : str | None
         Optional filter expression.
     project_name : str | None
         Unify project name. If None, uses the active project.
@@ -322,7 +322,7 @@ def generate_table_views_batch(
         result = generate_table_view(
             config=config,
             context=context,
-            filter_expr=filter_expr,
+            filter=filter,
             project_name=project_name,
             title=title,
             title_suffix=table_label if len(contexts) > 1 else None,

--- a/unify/file_manager/managers/utils/ops.py
+++ b/unify/file_manager/managers/utils/ops.py
@@ -251,7 +251,7 @@ def delete_file_table_rows(
     *,
     storage_id: str,
     table: str,
-    filter_expr: Optional[str],
+    filter: Optional[str],
 ) -> int:
     """Delete rows from a table context using storage_id.
 
@@ -262,11 +262,11 @@ def delete_file_table_rows(
     dm = file_manager._data_manager
     ctx = _ctx_for_table(file_manager, storage_id=storage_id, table=table)
 
-    if filter_expr is None:
+    if filter is None:
         # Delete all rows via a filter that matches everything
         return dm.delete_rows(context=ctx, filter="1 == 1")
     else:
-        return dm.delete_rows(context=ctx, filter=filter_expr)
+        return dm.delete_rows(context=ctx, filter=filter)
 
 
 def batch_insert_file_table_rows(
@@ -298,7 +298,7 @@ def delete_file_content_rows(
     file_manager: "FileManager",
     *,
     storage_id: str,
-    filter_expr: Optional[str],
+    filter: Optional[str],
 ) -> int:
     """Delete rows from a Content context using storage_id.
 
@@ -309,11 +309,11 @@ def delete_file_content_rows(
     dm = file_manager._data_manager
     ctx = _ctx_for_content(file_manager, storage_id=storage_id)
 
-    if filter_expr is None:
+    if filter is None:
         # Delete all rows
         return dm.delete_rows(context=ctx, filter="1 == 1")
     else:
-        return dm.delete_rows(context=ctx, filter=filter_expr)
+        return dm.delete_rows(context=ctx, filter=filter)
 
 
 # ---------- High-level create helpers (ensure + insert) ------------------------

--- a/unify/file_manager/managers/utils/task_functions.py
+++ b/unify/file_manager/managers/utils/task_functions.py
@@ -411,13 +411,13 @@ def execute_ingest_content(
                 delete_file_content_rows(
                     file_manager,
                     storage_id=storage_id,
-                    filter_expr=f"file_id == {file_id}",
+                    filter=f"file_id == {file_id}",
                 )
             else:
                 delete_file_content_rows(
                     file_manager,
                     storage_id=storage_id,
-                    filter_expr=None,
+                    filter=None,
                 )
         except Exception as e:
             logger.warning(f"[TaskFn] Failed to delete existing rows: {e}")


### PR DESCRIPTION
## Summary
- Hard-cut Orchestra log query/body field `filter_expr` → `filter` (and matching consumer updates).
- Legacy top-level `filter_expr` returns 400.
- Persisted derived-template nested `filter_expr` keys unchanged.

## Test plan
- [ ] Staging CI green
- [ ] Smoke: `GET /logs?filter_expr=...` → 400; `filter=` accepted