### PR TITLE
Release: staging → main (EventBus Orchestra allowlist)

### DIFF
--- a/.env.advanced.example
+++ b/.env.advanced.example
@@ -193,6 +193,22 @@ UNITY_TERMINAL_LOG=1
 UNITY_ASYNCIO_DEBUG=0
 
 # =============================================================================
+# OPTIONAL — EventBus (Orchestra Events/* + Live Actions)
+# =============================================================================
+# Master switch: publish events to in-memory bus / Orchestra / Pub/Sub paths.
+# EVENTBUS_PUBLISHING_ENABLED=false
+
+# Orchestra persistence when publishing is on:
+#   all       — write every event to Events/* (default, legacy behavior)
+#   allowlist — write only ManagerMethod/ToolLoop for listed tools
+# EVENTBUS_ORCHESTRA_PERSIST_MODE=all
+# EVENTBUS_ORCHESTRA_PERSIST_TOOLS=execute_code,execute_function
+
+# Stream ManagerMethod/ToolLoop to Pub/Sub for Console Live Actions (independent
+# of the Orchestra allowlist; stream_filters apply here only).
+# EVENTBUS_PUBSUB_STREAMING=false
+
+# =============================================================================
 # OPTIONAL — Third-Party APIs
 # =============================================================================
 

--- a/sandboxes/conversation_manager/README.md
+++ b/sandboxes/conversation_manager/README.md
@@ -84,6 +84,24 @@ All env vars are read from `~/.unity/unity/.env` (OSS install) or `.env` at the 
 
 For Event Tree and Manager Logs in the GUI/REPL, set `EVENTBUS_PUBLISHING_ENABLED=true`.
 
+### Orchestra-only execution logging (optional)
+
+To persist **only** `execute_code` / `execute_function` EventBus rows to Orchestra
+(while keeping Live Actions Pub/Sub at full fidelity when streaming is on):
+
+```bash
+export EVENTBUS_PUBLISHING_ENABLED=true
+export EVENTBUS_ORCHESTRA_PERSIST_MODE=allowlist
+export EVENTBUS_ORCHESTRA_PERSIST_TOOLS=execute_code,execute_function
+# optional Live Actions stream (unchanged by the allowlist):
+# export EVENTBUS_PUBSUB_STREAMING=true
+```
+
+`EVENTBUS_ORCHESTRA_PERSIST_MODE=all` (default) restores legacy “write every
+event to `Events/*`” behavior when publishing is enabled. Task-scoped runs
+annotate hierarchy with `Task.run(task_id=…,instance_id=…)` and payload fields
+`task_id` / `instance_id` / `run_key` for later diagnostics.
+
 ## Troubleshooting
 
 ### Event Tree is empty / Manager Logs show "(no logs)"

--- a/tests/event_bus/test_orchestra_persist_allowlist.py
+++ b/tests/event_bus/test_orchestra_persist_allowlist.py
@@ -1,0 +1,151 @@
+"""EventBus.publish Orchestra allowlist vs Pub/Sub independence."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from unify.events.event_bus import Event, EventBus
+from unify.events.types.manager_method import ManagerMethodPayload
+from unify.events.types.tool_loop import ToolLoopKind, ToolLoopPayload
+from tests.helpers import _handle_project
+
+
+@pytest.mark.asyncio
+@_handle_project
+async def test_allowlist_mode_only_buffers_matching_orchestra_writes(monkeypatch):
+    """Allowlisted ManagerMethod/ToolLoop rows hit Orchestra; others stay in-memory only."""
+
+    monkeypatch.setattr(
+        "unify.events.event_bus.EventBus._publishing_enabled",
+        True,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "unify.settings.SETTINGS.EVENTBUS_ORCHESTRA_PERSIST_MODE",
+        "allowlist",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "unify.settings.SETTINGS.EVENTBUS_ORCHESTRA_PERSIST_TOOLS",
+        "execute_code,execute_function",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "unify.events.event_bus.EventBus._pubsub_streaming_enabled",
+        False,
+        raising=False,
+    )
+
+    bus = EventBus()
+    bus._pending_writes.clear()
+
+    await bus.publish(
+        Event(
+            type="ManagerMethod",
+            payload=ManagerMethodPayload(
+                manager="CodeActActor",
+                method="execute_code",
+                phase="incoming",
+            ),
+        ),
+    )
+    await bus.publish(
+        Event(
+            type="ManagerMethod",
+            payload=ManagerMethodPayload(
+                manager="ContactManager",
+                method="ask",
+                phase="incoming",
+            ),
+        ),
+    )
+    await bus.publish(
+        Event(
+            type="ToolLoop",
+            payload=ToolLoopPayload(
+                kind=ToolLoopKind.TOOL_RESULT.value,
+                message={"role": "tool", "name": "execute_function", "content": "ok"},
+                method="CodeActActor.act",
+            ),
+        ),
+    )
+    await bus.publish(
+        Event(
+            type="ToolLoop",
+            payload=ToolLoopPayload(
+                kind=ToolLoopKind.THOUGHT.value,
+                message={"role": "assistant", "content": "hmm"},
+                method="CodeActActor.act",
+            ),
+        ),
+    )
+
+    # In-memory deques keep everything when publishing is enabled.
+    assert len(bus._deques.get("ManagerMethod", [])) >= 2
+    assert len(bus._deques.get("ToolLoop", [])) >= 2
+
+    buffered_methods = [
+        entries.get("method")
+        for entries, _ctx in bus._pending_writes
+        if entries.get("type") == "ManagerMethod"
+    ]
+    buffered_tool_names = [
+        (entries.get("message") or {}).get("name")
+        for entries, _ctx in bus._pending_writes
+        if entries.get("type") == "ToolLoop"
+    ]
+    assert buffered_methods == ["execute_code"]
+    assert buffered_tool_names == ["execute_function"]
+
+
+@pytest.mark.asyncio
+@_handle_project
+async def test_allowlist_does_not_block_pubsub_for_non_matching(monkeypatch):
+    """Pub/Sub still streams non-allowlisted ManagerMethod when streaming is on."""
+
+    monkeypatch.setattr(
+        "unify.events.event_bus.EventBus._publishing_enabled",
+        True,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "unify.settings.SETTINGS.EVENTBUS_ORCHESTRA_PERSIST_MODE",
+        "allowlist",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "unify.settings.SETTINGS.EVENTBUS_ORCHESTRA_PERSIST_TOOLS",
+        "execute_code,execute_function",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "unify.events.event_bus.EventBus._pubsub_streaming_enabled",
+        True,
+        raising=False,
+    )
+
+    bus = EventBus()
+    bus._pending_writes.clear()
+    streamed: list[str] = []
+
+    def _capture(event, base_entries, payload_dict):
+        streamed.append(payload_dict.get("method", ""))
+
+    bus._stream_action_to_pubsub = MagicMock(side_effect=_capture)  # type: ignore[method-assign]
+
+    await bus.publish(
+        Event(
+            type="ManagerMethod",
+            payload=ManagerMethodPayload(
+                manager="ContactManager",
+                method="ask",
+                phase="incoming",
+            ),
+        ),
+    )
+
+    assert bus._pending_writes == []
+    assert streamed == ["ask"]
+    bus._stream_action_to_pubsub.assert_called_once()

--- a/tests/event_bus/test_persist_filters.py
+++ b/tests/event_bus/test_persist_filters.py
@@ -1,0 +1,131 @@
+"""Unit tests for Orchestra EventBus persist allowlisting."""
+
+from __future__ import annotations
+
+from unify.events.persist_filters import (
+    parse_persist_tools,
+    should_persist_to_orchestra,
+)
+from unify.events.types.tool_loop import ToolLoopKind
+
+
+def test_parse_persist_tools_default_when_empty():
+    assert parse_persist_tools("") == frozenset({"execute_code", "execute_function"})
+    assert parse_persist_tools(None) == frozenset({"execute_code", "execute_function"})
+
+
+def test_parse_persist_tools_custom():
+    assert parse_persist_tools("execute_code, other_tool ") == frozenset(
+        {"execute_code", "other_tool"},
+    )
+
+
+def test_mode_all_persists_everything():
+    assert should_persist_to_orchestra(
+        "LLM",
+        {"model": "x"},
+        mode="all",
+        tools=frozenset({"execute_code"}),
+    )
+    assert should_persist_to_orchestra(
+        "ManagerMethod",
+        {"method": "ask", "manager": "ContactManager"},
+        mode="all",
+        tools=frozenset({"execute_code"}),
+    )
+
+
+def test_allowlist_manager_method_execute_tools_only():
+    tools = frozenset({"execute_code", "execute_function"})
+    assert should_persist_to_orchestra(
+        "ManagerMethod",
+        {"method": "execute_code", "manager": "CodeActActor"},
+        mode="allowlist",
+        tools=tools,
+    )
+    assert should_persist_to_orchestra(
+        "ManagerMethod",
+        {"method": "execute_function", "manager": "CodeActActor"},
+        mode="allowlist",
+        tools=tools,
+    )
+    assert not should_persist_to_orchestra(
+        "ManagerMethod",
+        {"method": "ask", "manager": "ContactManager"},
+        mode="allowlist",
+        tools=tools,
+    )
+    assert not should_persist_to_orchestra(
+        "ManagerMethod",
+        {"method": "act", "manager": "CodeActActor"},
+        mode="allowlist",
+        tools=tools,
+    )
+
+
+def test_allowlist_tool_loop_tool_result_and_tool_call():
+    tools = frozenset({"execute_code", "execute_function"})
+    assert should_persist_to_orchestra(
+        "ToolLoop",
+        {
+            "kind": ToolLoopKind.TOOL_RESULT.value,
+            "message": {"role": "tool", "name": "execute_code", "content": "ok"},
+        },
+        mode="allowlist",
+        tools=tools,
+    )
+    assert should_persist_to_orchestra(
+        "ToolLoop",
+        {
+            "kind": ToolLoopKind.TOOL_CALL.value,
+            "message": {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": "1",
+                        "function": {"name": "notify", "arguments": "{}"},
+                    },
+                    {
+                        "id": "2",
+                        "function": {"name": "execute_function", "arguments": "{}"},
+                    },
+                ],
+            },
+        },
+        mode="allowlist",
+        tools=tools,
+    )
+    assert not should_persist_to_orchestra(
+        "ToolLoop",
+        {
+            "kind": ToolLoopKind.TOOL_RESULT.value,
+            "message": {"role": "tool", "name": "notify", "content": "ok"},
+        },
+        mode="allowlist",
+        tools=tools,
+    )
+    assert not should_persist_to_orchestra(
+        "ToolLoop",
+        {
+            "kind": ToolLoopKind.THOUGHT.value,
+            "message": {"role": "assistant", "content": "thinking"},
+        },
+        mode="allowlist",
+        tools=tools,
+    )
+
+
+def test_allowlist_drops_other_event_types():
+    tools = frozenset({"execute_code"})
+    assert not should_persist_to_orchestra(
+        "LLM",
+        {"model": "gpt"},
+        mode="allowlist",
+        tools=tools,
+    )
+    assert not should_persist_to_orchestra(
+        "Message",
+        {"content": "hi"},
+        mode="allowlist",
+        tools=tools,
+    )

--- a/tests/event_bus/test_task_run_lineage.py
+++ b/tests/event_bus/test_task_run_lineage.py
@@ -1,0 +1,64 @@
+"""Unit tests for task-run EventBus lineage helpers."""
+
+from __future__ import annotations
+
+from unify.common._async_tool.loop_config import TOOL_LOOP_LINEAGE
+from unify.events.task_run_lineage import (
+    CURRENT_TASK_RUN_LINEAGE,
+    enrich_payload_with_task_run_lineage,
+    format_task_run_lineage_segment,
+    parse_task_run_lineage_segment,
+    push_task_run_lineage,
+    reset_task_run_lineage,
+    task_run_lineage_scope,
+)
+
+
+def test_format_and_parse_segment_roundtrip():
+    segment = format_task_run_lineage_segment(task_id=42, instance_id=7)
+    assert segment == "Task.run(task_id=42,instance_id=7)"
+    parsed = parse_task_run_lineage_segment(segment)
+    assert parsed is not None
+    assert parsed.task_id == 42
+    assert parsed.instance_id == 7
+    assert parsed.run_key is None
+
+    with_key = format_task_run_lineage_segment(
+        task_id=1,
+        instance_id=2,
+        run_key="rk-abc",
+    )
+    assert with_key == "Task.run(task_id=1,instance_id=2,run_key=rk-abc)"
+    parsed_key = parse_task_run_lineage_segment(with_key)
+    assert parsed_key is not None
+    assert parsed_key.run_key == "rk-abc"
+
+
+def test_push_sets_context_and_tool_loop_lineage():
+    tokens = push_task_run_lineage(task_id=9, instance_id=3, run_key="run-1")
+    try:
+        lineage = CURRENT_TASK_RUN_LINEAGE.get()
+        assert lineage is not None
+        assert lineage.task_id == 9
+        assert lineage.instance_id == 3
+        assert lineage.run_key == "run-1"
+        hierarchy = TOOL_LOOP_LINEAGE.get([])
+        assert hierarchy[-1] == "Task.run(task_id=9,instance_id=3,run_key=run-1)"
+    finally:
+        reset_task_run_lineage(tokens)
+    assert CURRENT_TASK_RUN_LINEAGE.get() is None
+
+
+def test_enrich_payload_adds_fields_and_hierarchy_segment():
+    with task_run_lineage_scope(task_id=5, instance_id=1, run_key="rk"):
+        payload = {
+            "method": "execute_code",
+            "hierarchy": ["CodeActActor.act(ab)", "execute_code(cd)"],
+            "hierarchy_label": "CodeActActor.act(ab)->execute_code(cd)",
+        }
+        enrich_payload_with_task_run_lineage(payload)
+        assert payload["task_id"] == 5
+        assert payload["instance_id"] == 1
+        assert payload["run_key"] == "rk"
+        assert payload["hierarchy"][0] == "Task.run(task_id=5,instance_id=1,run_key=rk)"
+        assert payload["hierarchy_label"].startswith("Task.run(")

--- a/unify/events/event_bus.py
+++ b/unify/events/event_bus.py
@@ -1,5 +1,10 @@
 """In‑process, asyncio‑friendly event stream **prefilled from Unify logs** and
 restricted to Pydantic payload types declared in *events/types/*.
+
+Orchestra persistence (``Events/*``) can be narrowed independently of Pub/Sub
+Live Actions via ``EVENTBUS_ORCHESTRA_PERSIST_MODE`` /
+``EVENTBUS_ORCHESTRA_PERSIST_TOOLS`` (see ``persist_filters``). Stream noise
+rules in ``stream_filters`` affect Pub/Sub only.
 """
 
 from __future__ import annotations
@@ -45,7 +50,9 @@ from ..common.global_docstrings import CLEAR_METHOD_DOCSTRING
 from ..common.log_utils import _inject_private_fields, payload_from_log_entries
 from ..common.model_to_fields import model_to_fields
 from ..logger import LOGGER
+from .persist_filters import should_persist_to_orchestra
 from .stream_filters import is_streaming_noise
+from .task_run_lineage import enrich_payload_with_task_run_lineage
 
 # ---------------------------------------------------------------------------
 # Context-variable to track the *root* sequence number of a callback cascade.
@@ -935,6 +942,8 @@ class EventBus:
             if isinstance(event.payload, BaseModel)
             else Event._to_python(event.payload)
         )
+        if isinstance(payload_dict, dict):
+            enrich_payload_with_task_run_lineage(payload_dict)
 
         # Base entries for the log write (before private field injection)
         base_entries = {
@@ -950,14 +959,21 @@ class EventBus:
         # spread into columns for queryability. ``type`` is retained as a column
         # (not just implied by the context name) so ``type``-predicated search
         # filters resolve against the per-type context read path.
-        specific_entries = _inject_private_fields(
-            {
-                **base_entries,
-                "type": event.type,
-                **payload_dict,
-            },
-        )
-        self._pending_writes.append((specific_entries, self._specific_ctxs[event.type]))
+        #
+        # Orchestra persistence can be narrowed via
+        # EVENTBUS_ORCHESTRA_PERSIST_MODE / EVENTBUS_ORCHESTRA_PERSIST_TOOLS
+        # without affecting in-memory deques or Pub/Sub Live Actions.
+        if should_persist_to_orchestra(event.type, payload_dict):
+            specific_entries = _inject_private_fields(
+                {
+                    **base_entries,
+                    "type": event.type,
+                    **payload_dict,
+                },
+            )
+            self._pending_writes.append(
+                (specific_entries, self._specific_ctxs[event.type]),
+            )
 
         # ── Stream action events to Pub/Sub for real-time frontend rendering ─
         if event.type in self._ACTION_EVENT_TYPES:

--- a/unify/events/persist_filters.py
+++ b/unify/events/persist_filters.py
@@ -1,0 +1,105 @@
+"""Orchestra persistence filters for EventBus.
+
+Unlike ``stream_filters`` (Pub/Sub / Live Actions only), these rules gate
+which events are written to Unify ``Events/*`` contexts. In-memory deques,
+subscriptions, and Pub/Sub streaming are unaffected.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from .types.tool_loop import ToolLoopKind
+
+_DEFAULT_ALLOWLIST_TOOLS: frozenset[str] = frozenset(
+    {"execute_code", "execute_function"},
+)
+_TOOL_LOOP_MATCH_KINDS: frozenset[str] = frozenset(
+    {
+        ToolLoopKind.TOOL_CALL.value,
+        ToolLoopKind.TOOL_RESULT.value,
+    },
+)
+
+
+def parse_persist_tools(raw: str | None) -> frozenset[str]:
+    """Parse a comma-separated tool/method allowlist."""
+
+    if not raw or not str(raw).strip():
+        return _DEFAULT_ALLOWLIST_TOOLS
+    names = {part.strip() for part in str(raw).split(",") if part.strip()}
+    return frozenset(names) if names else _DEFAULT_ALLOWLIST_TOOLS
+
+
+def _tool_names_from_tool_loop_message(message: Any) -> set[str]:
+    """Extract tool names from a ToolLoop message dict."""
+
+    if not isinstance(message, Mapping):
+        return set()
+    names: set[str] = set()
+    tool_name = message.get("name")
+    if isinstance(tool_name, str) and tool_name:
+        names.add(tool_name)
+    tool_calls = message.get("tool_calls") or []
+    if isinstance(tool_calls, list):
+        for call in tool_calls:
+            if not isinstance(call, Mapping):
+                continue
+            function = call.get("function") or {}
+            if not isinstance(function, Mapping):
+                continue
+            name = function.get("name")
+            if isinstance(name, str) and name:
+                names.add(name)
+    return names
+
+
+def should_persist_to_orchestra(
+    event_type: str,
+    payload_dict: Mapping[str, Any],
+    *,
+    mode: str | None = None,
+    tools: frozenset[str] | None = None,
+) -> bool:
+    """Return whether this event should be buffered for Orchestra ``Events/*``.
+
+    Parameters
+    ----------
+    event_type:
+        ``Event.type`` string (e.g. ``ManagerMethod``, ``ToolLoop``).
+    payload_dict:
+        Serialized payload fields.
+    mode:
+        ``all`` or ``allowlist``. When omitted, reads
+        ``SETTINGS.EVENTBUS_ORCHESTRA_PERSIST_MODE``.
+    tools:
+        Allowlisted tool/method names. When omitted, parses
+        ``SETTINGS.EVENTBUS_ORCHESTRA_PERSIST_TOOLS``.
+    """
+
+    if mode is None or tools is None:
+        from unify.settings import SETTINGS
+
+        if mode is None:
+            mode = SETTINGS.EVENTBUS_ORCHESTRA_PERSIST_MODE
+        if tools is None:
+            tools = parse_persist_tools(SETTINGS.EVENTBUS_ORCHESTRA_PERSIST_TOOLS)
+
+    normalized_mode = (mode or "all").strip().lower()
+    if normalized_mode != "allowlist":
+        return True
+
+    allow = tools if tools is not None else _DEFAULT_ALLOWLIST_TOOLS
+
+    if event_type == "ManagerMethod":
+        method = payload_dict.get("method")
+        return isinstance(method, str) and method in allow
+
+    if event_type == "ToolLoop":
+        kind = payload_dict.get("kind", "")
+        if kind not in _TOOL_LOOP_MATCH_KINDS:
+            return False
+        names = _tool_names_from_tool_loop_message(payload_dict.get("message"))
+        return bool(names & allow)
+
+    return False

--- a/unify/events/stream_filters.py
+++ b/unify/events/stream_filters.py
@@ -4,7 +4,8 @@ Rules that identify events which are internal bookkeeping artifacts and
 should be suppressed from the real-time Pub/Sub stream (and its SSE
 frontend feed) to save bandwidth and reduce UI clutter.
 
-Unify context logs remain **unfiltered** -- these rules only gate the
+Unify context (Orchestra) logs are gated separately by
+``persist_filters.should_persist_to_orchestra`` — these rules only gate the
 Pub/Sub publishing path in ``EventBus.publish()``.
 
 Two categories of filtering exist:

--- a/unify/events/task_run_lineage.py
+++ b/unify/events/task_run_lineage.py
@@ -1,0 +1,184 @@
+"""Task-run lineage for EventBus hierarchy and payload fields.
+
+When a ``TaskScheduler`` / ``ActiveTask`` run is in flight, push a
+``Task.run(task_id=…,instance_id=…[,run_key=…])`` segment onto
+``TOOL_LOOP_LINEAGE`` so nested ``execute_code`` / ``execute_function``
+events inherit a deterministic parent. Structured ids are also held in a
+ContextVar so Orchestra payloads can carry ``task_id`` / ``instance_id`` /
+``run_key`` without parsing hierarchy strings.
+"""
+
+from __future__ import annotations
+
+import re
+from contextlib import contextmanager
+from contextvars import ContextVar, Token
+from dataclasses import dataclass
+from typing import Any, Generator
+
+from unify.common._async_tool.loop_config import TOOL_LOOP_LINEAGE
+
+__all__ = [
+    "TaskRunLineage",
+    "CURRENT_TASK_RUN_LINEAGE",
+    "TASK_RUN_LINEAGE_SEGMENT_RE",
+    "format_task_run_lineage_segment",
+    "parse_task_run_lineage_segment",
+    "push_task_run_lineage",
+    "reset_task_run_lineage",
+    "task_run_lineage_scope",
+    "enrich_payload_with_task_run_lineage",
+]
+
+TASK_RUN_LINEAGE_SEGMENT_RE = re.compile(
+    r"^Task\.run\("
+    r"task_id=(?P<task_id>\d+),"
+    r"instance_id=(?P<instance_id>\d+)"
+    r"(?:,run_key=(?P<run_key>[^)]+))?"
+    r"\)$",
+)
+
+
+@dataclass(frozen=True)
+class TaskRunLineage:
+    """Structured ids for the currently executing durable task instance."""
+
+    task_id: int
+    instance_id: int
+    run_key: str | None = None
+
+    def as_payload_fields(self) -> dict[str, Any]:
+        fields: dict[str, Any] = {
+            "task_id": int(self.task_id),
+            "instance_id": int(self.instance_id),
+        }
+        if self.run_key:
+            fields["run_key"] = str(self.run_key)
+        return fields
+
+
+CURRENT_TASK_RUN_LINEAGE: ContextVar[TaskRunLineage | None] = ContextVar(
+    "CURRENT_TASK_RUN_LINEAGE",
+    default=None,
+)
+
+
+def format_task_run_lineage_segment(
+    *,
+    task_id: int,
+    instance_id: int,
+    run_key: str | None = None,
+) -> str:
+    """Return the canonical hierarchy segment for one task run."""
+
+    base = f"Task.run(task_id={int(task_id)},instance_id={int(instance_id)}"
+    if run_key:
+        return f"{base},run_key={run_key})"
+    return f"{base})"
+
+
+def parse_task_run_lineage_segment(segment: str) -> TaskRunLineage | None:
+    """Parse a ``Task.run(...)`` hierarchy segment, or return None."""
+
+    match = TASK_RUN_LINEAGE_SEGMENT_RE.match(segment or "")
+    if match is None:
+        return None
+    return TaskRunLineage(
+        task_id=int(match.group("task_id")),
+        instance_id=int(match.group("instance_id")),
+        run_key=match.group("run_key"),
+    )
+
+
+@dataclass
+class _TaskRunLineageTokens:
+    lineage_token: Token
+    tool_loop_token: Token
+
+
+def push_task_run_lineage(
+    *,
+    task_id: int,
+    instance_id: int,
+    run_key: str | None = None,
+) -> _TaskRunLineageTokens:
+    """Push task-run context onto lineage ContextVars; return reset tokens."""
+
+    lineage = TaskRunLineage(
+        task_id=int(task_id),
+        instance_id=int(instance_id),
+        run_key=str(run_key) if run_key else None,
+    )
+    segment = format_task_run_lineage_segment(
+        task_id=lineage.task_id,
+        instance_id=lineage.instance_id,
+        run_key=lineage.run_key,
+    )
+    parent = list(TOOL_LOOP_LINEAGE.get([]) or [])
+    if not any(parse_task_run_lineage_segment(str(s)) for s in parent):
+        parent = [*parent, segment]
+    return _TaskRunLineageTokens(
+        lineage_token=CURRENT_TASK_RUN_LINEAGE.set(lineage),
+        tool_loop_token=TOOL_LOOP_LINEAGE.set(parent),
+    )
+
+
+def reset_task_run_lineage(tokens: _TaskRunLineageTokens | None) -> None:
+    """Reset tokens from :func:`push_task_run_lineage`."""
+
+    if tokens is None:
+        return
+    TOOL_LOOP_LINEAGE.reset(tokens.tool_loop_token)
+    CURRENT_TASK_RUN_LINEAGE.reset(tokens.lineage_token)
+
+
+@contextmanager
+def task_run_lineage_scope(
+    *,
+    task_id: int,
+    instance_id: int,
+    run_key: str | None = None,
+) -> Generator[_TaskRunLineageTokens, None, None]:
+    """Context manager that pushes then resets task-run lineage."""
+
+    tokens = push_task_run_lineage(
+        task_id=task_id,
+        instance_id=instance_id,
+        run_key=run_key,
+    )
+    try:
+        yield tokens
+    finally:
+        reset_task_run_lineage(tokens)
+
+
+def enrich_payload_with_task_run_lineage(
+    payload_dict: dict[str, Any],
+) -> dict[str, Any]:
+    """Copy current task-run ids onto a payload dict when present.
+
+    Also ensures ``hierarchy`` includes the ``Task.run(...)`` segment when
+    the ContextVar is set but the list was built without it.
+    """
+
+    lineage = CURRENT_TASK_RUN_LINEAGE.get()
+    if lineage is None:
+        return payload_dict
+
+    payload_dict.update(lineage.as_payload_fields())
+
+    hierarchy = payload_dict.get("hierarchy")
+    if isinstance(hierarchy, list):
+        segment = format_task_run_lineage_segment(
+            task_id=lineage.task_id,
+            instance_id=lineage.instance_id,
+            run_key=lineage.run_key,
+        )
+        if not any(
+            parse_task_run_lineage_segment(str(s)) is not None for s in hierarchy
+        ):
+            payload_dict["hierarchy"] = [segment, *hierarchy]
+            payload_dict["hierarchy_label"] = "->".join(
+                str(s) for s in payload_dict["hierarchy"]
+            )
+    return payload_dict

--- a/unify/events/types/manager_method.py
+++ b/unify/events/types/manager_method.py
@@ -83,3 +83,17 @@ class ManagerMethodPayload(BaseModel):
         default=None,
         description="Truncated traceback (when status='error')",
     )
+
+    # Optional durable-task attribution (set when published under ActiveTask).
+    task_id: Optional[int] = Field(
+        default=None,
+        description="Owning TaskScheduler task_id when this call ran under a task",
+    )
+    instance_id: Optional[int] = Field(
+        default=None,
+        description="Owning TaskScheduler instance_id when this call ran under a task",
+    )
+    run_key: Optional[str] = Field(
+        default=None,
+        description="Owning Tasks/Runs run_key when known",
+    )

--- a/unify/events/types/tool_loop.py
+++ b/unify/events/types/tool_loop.py
@@ -145,3 +145,16 @@ class ToolLoopPayload(BaseModel):
         default=None,
         description="Sparse mapping of tool_name -> human-readable label for tool calls in this event only",
     )
+    # Optional durable-task attribution (set when published under ActiveTask).
+    task_id: Optional[int] = Field(
+        default=None,
+        description="Owning TaskScheduler task_id when this loop ran under a task",
+    )
+    instance_id: Optional[int] = Field(
+        default=None,
+        description="Owning TaskScheduler instance_id when this loop ran under a task",
+    )
+    run_key: Optional[str] = Field(
+        default=None,
+        description="Owning Tasks/Runs run_key when known",
+    )

--- a/unify/settings.py
+++ b/unify/settings.py
@@ -131,6 +131,17 @@ class ProductionSettings(BaseSettings):
     # reduce noise. Enable in production deployments.
     EVENTBUS_PUBLISHING_ENABLED: bool = False
 
+    # Orchestra ``Events/*`` persistence mode when publishing is enabled:
+    # - ``all``: write every published event to Orchestra (legacy behavior)
+    # - ``allowlist``: write only ManagerMethod/ToolLoop events whose method
+    #   or tool name is listed in EVENTBUS_ORCHESTRA_PERSIST_TOOLS
+    # Pub/Sub Live Actions streaming is independent (see EVENTBUS_PUBSUB_STREAMING).
+    EVENTBUS_ORCHESTRA_PERSIST_MODE: Literal["all", "allowlist"] = "all"
+
+    # Comma-separated tool/method names when EVENTBUS_ORCHESTRA_PERSIST_MODE
+    # is ``allowlist`` (default: CodeAct execution boundaries + tool results).
+    EVENTBUS_ORCHESTRA_PERSIST_TOOLS: str = "execute_code,execute_function"
+
     # ─────────────────────────────────────────────────────────────────────────
     # EventBus Pub/Sub Streaming (Live Actions)
     # ─────────────────────────────────────────────────────────────────────────
@@ -139,6 +150,7 @@ class ProductionSettings(BaseSettings):
     # This enables real-time frontend rendering of the agent's activity tree
     # without polling Orchestra. Requires GCP credentials and a provisioned
     # Pub/Sub topic. Disabled by default; enable in production deployments.
+    # Stream filters (stream_filters.py) apply here only — not to Orchestra.
     EVENTBUS_PUBSUB_STREAMING: bool = False
 
     # ─────────────────────────────────────────────────────────────────────────
@@ -254,6 +266,18 @@ class ProductionSettings(BaseSettings):
     @classmethod
     def parse_deploy_env_field(cls, v: Any) -> str:
         return _parse_deploy_env(v)
+
+    @field_validator("EVENTBUS_ORCHESTRA_PERSIST_MODE", mode="before")
+    @classmethod
+    def parse_orchestra_persist_mode(cls, v: Any) -> str:
+        if v is None or (isinstance(v, str) and not v.strip()):
+            return "all"
+        normalized = str(v).strip().lower()
+        if normalized not in {"all", "allowlist"}:
+            raise ValueError(
+                "EVENTBUS_ORCHESTRA_PERSIST_MODE must be 'all' or 'allowlist'",
+            )
+        return normalized
 
     model_config = SettingsConfigDict(
         env_file=".env",

--- a/unify/task_scheduler/active_task.py
+++ b/unify/task_scheduler/active_task.py
@@ -22,6 +22,10 @@ from unify.common.task_execution_context import (
     current_task_execution_delegate,
 )
 from unify.common._async_tool.messages import forward_handle_call
+from unify.events.task_run_lineage import (
+    push_task_run_lineage,
+    reset_task_run_lineage,
+)
 from .machine_state import (
     TaskRunProvenance,
     TaskRunReference,
@@ -147,6 +151,7 @@ class ActiveTask(BaseActiveTask, HandleWrapperMixin):
         self._was_stopped: bool = False
         self._last_intent: Optional[str] = None
         self._last_intent_reason: Optional[str] = None
+        self._task_run_lineage_tokens = None
 
         # Register the underlying actor handle for standardized wrapper discovery
         self._wrap_handle(actor_handle)
@@ -183,6 +188,20 @@ class ActiveTask(BaseActiveTask, HandleWrapperMixin):
         """
         delegate = current_task_execution_delegate.get()
         review_token = None
+        lineage_tokens = None
+        if task_id is not None and instance_id is not None:
+            run_key = None
+            if task_run_reference is not None:
+                run_key = task_run_reference.run_key
+            elif task_run_provenance is not None:
+                from .machine_state import build_task_run_key
+
+                run_key = build_task_run_key(task_run_provenance)
+            lineage_tokens = push_task_run_lineage(
+                task_id=int(task_id),
+                instance_id=int(instance_id),
+                run_key=str(run_key) if run_key else None,
+            )
         if task_entrypoint_review is not None:
             review_token = current_post_run_review_context.set(
                 PostRunReviewContext(
@@ -242,6 +261,8 @@ class ActiveTask(BaseActiveTask, HandleWrapperMixin):
                             ),
                         },
                     )
+                reset_task_run_lineage(lineage_tokens)
+                lineage_tokens = None
                 raise
         finally:
             if review_token is not None:
@@ -260,13 +281,15 @@ class ActiveTask(BaseActiveTask, HandleWrapperMixin):
                     task_id,
                     instance_id,
                 )
-        return cls(
+        instance = cls(
             actor_steerable_handle,  # type: ignore[arg-type]
             task_id=task_id,
             instance_id=instance_id,
             scheduler=scheduler,
             task_run_reference=materialized_task_run_reference,
         )
+        instance._task_run_lineage_tokens = lineage_tokens
+        return instance
 
     @functools.wraps(BaseActiveTask.ask, updated=())
     async def ask(
@@ -318,6 +341,8 @@ class ActiveTask(BaseActiveTask, HandleWrapperMixin):
                     result_summary=f"Task cancelled: {stop_reason}",
                 ),
             )
+            reset_task_run_lineage(self._task_run_lineage_tokens)
+            self._task_run_lineage_tokens = None
             return
 
         await self._actor_handle.interject(message)  # type: ignore[arg-type]
@@ -351,6 +376,8 @@ class ActiveTask(BaseActiveTask, HandleWrapperMixin):
             ),
         )
         asyncio.create_task(self._save_final_summary("cancelled"))
+        reset_task_run_lineage(self._task_run_lineage_tokens)
+        self._task_run_lineage_tokens = None
 
     @functools.wraps(BaseActiveTask.pause, updated=())
     async def pause(self) -> Optional[str]:
@@ -474,36 +501,40 @@ class ActiveTask(BaseActiveTask, HandleWrapperMixin):
                 )
 
         finally:
-            if (
-                final_status
-                and not self._was_stopped
-                and self._scheduler
-                and self._task_id is not None
-                and self._instance_id is not None
-            ):
-                self._scheduler._update_task_status_instance(  # type: ignore[attr-defined]
-                    task_id=self._task_id,
-                    instance_id=self._instance_id,
-                    new_status=final_status,
-                )
-                await self._persist_task_run_terminal_state(
-                    state=final_status,
-                    result_summary=ret,
-                    error=str(error) if error is not None else None,
-                )
+            try:
+                if (
+                    final_status
+                    and not self._was_stopped
+                    and self._scheduler
+                    and self._task_id is not None
+                    and self._instance_id is not None
+                ):
+                    self._scheduler._update_task_status_instance(  # type: ignore[attr-defined]
+                        task_id=self._task_id,
+                        instance_id=self._instance_id,
+                        new_status=final_status,
+                    )
+                    await self._persist_task_run_terminal_state(
+                        state=final_status,
+                        result_summary=ret,
+                        error=str(error) if error is not None else None,
+                    )
 
-                if not getattr(self, "_summary_scheduled", False):
-                    try:
-                        logger.info(
-                            "--- Scheduling save_final_summary for %s.%s with status: %s ---",
-                            self._task_id,
-                            self._instance_id,
-                            final_status,
-                        )
-                        asyncio.create_task(self._save_final_summary(final_status))
-                        self._summary_scheduled = True  # type: ignore[attr-defined]
-                    except Exception as summary_e:
-                        logger.error("Error creating summary task: %s", summary_e)
+                    if not getattr(self, "_summary_scheduled", False):
+                        try:
+                            logger.info(
+                                "--- Scheduling save_final_summary for %s.%s with status: %s ---",
+                                self._task_id,
+                                self._instance_id,
+                                final_status,
+                            )
+                            asyncio.create_task(self._save_final_summary(final_status))
+                            self._summary_scheduled = True  # type: ignore[attr-defined]
+                        except Exception as summary_e:
+                            logger.error("Error creating summary task: %s", summary_e)
+            finally:
+                reset_task_run_lineage(self._task_run_lineage_tokens)
+                self._task_run_lineage_tokens = None
 
         if error and final_status == "failed":
             raise error


### PR DESCRIPTION
## Summary
- EventBus Orchestra persistence can be narrowed via `EVENTBUS_ORCHESTRA_PERSIST_MODE=allowlist` to `execute_code` / `execute_function` only
- Task runs annotate lineage with `Task.run(task_id,instance_id)` plus payload fields for diagnostics
- Pub/Sub Live Actions streaming remains independent / full-fidelity

## Test plan
- [x] Unit tests for persist filters, lineage, Orchestra vs Pub/Sub gate
- [ ] Staging deploy green
- [ ] Prod smoke: new Job env has allowlist; execute_code Events rows carry task_id