### PR TITLE
Release: project the next occurrence as pending

### DIFF
--- a/.agents/shared.txt
+++ b/.agents/shared.txt
@@ -13,6 +13,8 @@ worktree-direct-commits.md
 git-history-for-context.md
 shared-agent-context.md
 
+openrouter-only-llm-access.md
+
 # --- specific to this repo ---
 python-formatting-and-pre-commit.md
 full-local-stack-first.md

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -259,7 +259,7 @@
         "filename": "tests/conversation_manager/core/test_event_handlers.py",
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_verified": false,
-        "line_number": 3872
+        "line_number": 3871
       }
     ],
     "tests/conversation_manager/core/test_event_logging.py": [
@@ -534,5 +534,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-29T10:37:56Z"
+  "generated_at": "2026-07-29T11:34:14Z"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1656,6 +1656,61 @@ Cite **user**, **tool**, **date**, and **path** so a human can open the same ses
 - Do not push/sync unless the user asked you to.
 - Do not grep `yours/` unless the user asked for local-only context.
 
+# OpenAI is reached only through OpenRouter
+
+Every LLM call in every repo routes through **OpenRouter**, using
+`OPENROUTER_API_KEY`. The company's direct OpenAI account is not active — it
+answers `429 billing_not_active` — so any code path that talks to OpenAI
+natively is dead code that fails slowly.
+
+## Canonical endpoint form
+
+```
+openai/<model-id>@openrouter      # openai/gpt-5.6-terra@openrouter
+```
+
+Never `<model-id>@openai`. In UniLLM, `@openai` and `@openrouter` are distinct
+providers (`unillm/endpoints/utils.py`): `@openrouter` resolves through the
+OpenRouter catalog, `@openai` resolves to a native OpenAI endpoint and litellm
+sends it straight to OpenAI with `OPENAI_API_KEY`.
+
+**The alias changed meaning.** `gpt-*@openai` used to be *transported* via
+OpenRouter inside UniLLM. It now means native OpenAI. Model strings written
+before that change did not move — they silently re-pointed at a dead account.
+The Orchestra migration `2026-08-13-00-00_openrouter_model_endpoints.py`
+rewrote stored assistant endpoints for exactly this reason; source code was not
+covered by it.
+
+## Why this fails slowly rather than loudly
+
+OpenAI reports the billing fault as **HTTP 429**, the same status as
+rate-limiting. UniLLM's `_is_retryable` classifies 429 as transient and retries
+`UNILLM_TRANSIENT_RETRY_COUNT` (default 6) times with 1/2/4/8/16/32s backoff —
+63s of sleeping per call, multiplied by litellm's own internal retries, before
+it finally raises. Under any concurrency this is indistinguishable from a hang,
+and scheduled jobs look stuck rather than broken. Do not "fix" such a stall by
+raising a timeout; check the endpoint's provider suffix first.
+
+## Hard rules
+
+- New LLM call sites use `openai/<id>@openrouter`. Non-OpenAI providers
+  (Anthropic, Google, …) are unaffected by this rule and keep their own routing.
+- Never read `OPENAI_API_KEY` directly, and never construct `openai.OpenAI()`
+  against it, in application code.
+- Env defaults and `.env.example` entries carry the `@openrouter` form, so a
+  fresh checkout cannot inherit a dead route.
+- When a provider call stalls for ~a minute and then fails, suspect a native
+  provider suffix before suspecting the network.
+
+## The one legitimate direct-OpenAI path
+
+Masked image edits (`images.edit` with `gpt-image-2`) have no OpenRouter
+equivalent — OpenRouter's unified Image API does not expose the mask parameter.
+That path may use a separately-named credential (`OPENAI_DIRECT_API_KEY`), must
+never fall back to reading `OPENAI_API_KEY`, and must degrade loudly when the
+credential is absent. It is the only exception; adding another needs an
+explicit reason, not convenience.
+
 # Orchestra / DataManager: Server-Side Queries First
 
 Orchestra is a Postgres-backed query engine. **DataManager** (and brain store

--- a/agent-service/src/egressPolicy.ts
+++ b/agent-service/src/egressPolicy.ts
@@ -129,6 +129,30 @@ export function acceptLanguage(locale: string): string {
  * ``cc-gb`` may ignore the geo-targeting rather than reject it, so traffic
  * exits from somewhere other than the region asked for and nothing errors.
  */
+/**
+ * The sticky handle actually sent to the provider, scoped by region.
+ *
+ * Verified against a live endpoint: a sticky session is pinned by its handle
+ * alone, so reusing one handle across two countries returns the *first*
+ * country's exit and silently ignores the second country parameter. Since a
+ * caller's natural handle is stable per identity (an assistant, a profile),
+ * changing its region would otherwise keep the old exit until the TTL lapsed —
+ * config saying one country while traffic left from another, with no error.
+ *
+ * Scoping the handle by region makes a region change a different session by
+ * construction.
+ */
+function sessionKeyFor(policy: EgressPolicy, region: string): string {
+  // Providers encode these usernames as dash-delimited key-value pairs, so a
+  // dash *inside* a value terminates it and silently discards everything after
+  // — verified live: a handle containing a dash lost both the country and the
+  // session-duration parameter, and two regions collapsed onto one exit. Strip
+  // anything that could be read as a delimiter, and separate with an
+  // underscore, which real accounts already use.
+  const base = (policy.sessionKey || 'default').replace(/[^A-Za-z0-9_]/g, '');
+  return `${base || 'default'}_${region}`;
+}
+
 function renderUsername(template: string, region: string, sessionKey: string): string {
   return template
     .replace(/\{region\}/g, region)
@@ -217,7 +241,7 @@ export function resolveEgress(
     proxy = {
       server,
       username: usernameTemplate
-        ? renderUsername(usernameTemplate, region, policy.sessionKey || 'default')
+        ? renderUsername(usernameTemplate, region, sessionKeyFor(policy, region))
         : undefined,
       password: env.UNITY_EGRESS_PROXY_PASSWORD || undefined,
     };

--- a/agent-service/tests/egressPolicy.test.ts
+++ b/agent-service/tests/egressPolicy.test.ts
@@ -52,7 +52,8 @@ run("a managed region resolves proxy, timezone, locale and Accept-Language toget
   assert.equal(resolved.proxy?.server, "http://gate.example.net:7777");
   // Geography and stickiness are encoded in the username, which is how
   // residential providers expose them — the caller never sees a credential.
-  assert.equal(resolved.proxy?.username, "acct-country-gb-session-abc123");
+  // The handle is region-scoped — see the sticky-session test below.
+  assert.equal(resolved.proxy?.username, "acct-country-gb-session-abc123_gb");
   assert.equal(resolved.proxy?.password, "s3cret");
   assert.equal(resolved.contextOptions.timezoneId, "Europe/London");
   assert.equal(resolved.contextOptions.locale, "en-GB");
@@ -191,7 +192,34 @@ run("the region placeholder is filled in either case", () => {
     { mode: "region", region: "gb", sessionKey: "s1" },
     { ...MANAGED_ENV, UNITY_EGRESS_PROXY_USERNAME: "customer-acme-cc-{REGION}-sessid-{session}" },
   );
-  assert.equal(resolved.proxy?.username, "customer-acme-cc-GB-sessid-s1");
+  assert.equal(resolved.proxy?.username, "customer-acme-cc-GB-sessid-s1_gb");
+});
+
+run("the sticky handle is scoped by region", () => {
+  // Verified against a live endpoint: a sticky session is pinned by its handle
+  // alone, so one handle reused across two countries returns the first
+  // country's exit and ignores the second country parameter entirely. A
+  // caller's handle is stable per identity, so without scoping, changing a
+  // region would keep the old exit until the TTL lapsed — silently.
+  const gb = resolveEgress({ mode: "region", region: "gb", sessionKey: "alice" }, MANAGED_ENV);
+  const us = resolveEgress({ mode: "region", region: "us", sessionKey: "alice" }, MANAGED_ENV);
+  assert.notEqual(gb.proxy?.username, us.proxy?.username);
+  assert.ok(gb.proxy?.username?.endsWith("_gb"));
+  assert.ok(us.proxy?.username?.endsWith("_us"));
+});
+
+run("delimiter characters are stripped from the sticky handle", () => {
+  // Verified live: these usernames are dash-delimited key-value pairs, so a
+  // dash inside a value terminates it and discards the rest — the country and
+  // session-duration parameters were both silently lost, collapsing two
+  // regions onto one exit. Profile keys like "reader-one" are the obvious way
+  // this reaches production.
+  const resolved = resolveEgress(
+    { mode: "region", region: "gb", sessionKey: "reader-one" },
+    { ...MANAGED_ENV, UNITY_EGRESS_PROXY_USERNAME: "customer-acme-cc-{REGION}-sessid-{session}-sesstime-30" },
+  );
+  assert.equal(resolved.proxy?.username, "customer-acme-cc-GB-sessid-readerone_gb-sesstime-30");
+  assert.ok(!resolved.proxy?.username?.includes("reader-one"));
 });
 
 run("only contracted regions are advertised", () => {

--- a/tests/actor/execution/test_expressive_logging.py
+++ b/tests/actor/execution/test_expressive_logging.py
@@ -106,7 +106,6 @@ def test_task_execute_doc_has_logging_antipatterns():
 def test_build_task_run_guidelines_point_at_logged_functions():
     task = Task(
         task_id=3,
-        instance_id=1,
         name="Invoice follow-up",
         description="Draft an invoice reply.",
         priority=Priority.normal,

--- a/tests/conversation_manager/core/test_event_handlers.py
+++ b/tests/conversation_manager/core/test_event_handlers.py
@@ -2830,7 +2830,6 @@ class TestTaskDueEventHandlers:
 
         rows = scheduler._filter_tasks(filter=f"task_id == {task_id}")
         assert len(rows) == 1
-        assert rows[0].instance_id == 0
         assert rows[0].status == Status.active
 
     @pytest.mark.asyncio

--- a/tests/fixtures/task_trigger_contract/task_run_key_contract.v1.json
+++ b/tests/fixtures/task_trigger_contract/task_run_key_contract.v1.json
@@ -1,0 +1,45 @@
+{
+  "description": "Run keys Orchestra and Unify must both produce byte-identically. The key is the create-or-adopt idempotency token: when the two sides disagree, the dispatcher cannot adopt the occurrence Orchestra projected and mints a second execution for the same slot. Two rows read as concurrency, and an overlap guard then skips every tick — the campaign runtime halted this way with no error anywhere.",
+  "cases": [
+    {
+      "name": "team destination and an offset timestamp are both normalized",
+      "inputs": {
+        "delivery": "offline",
+        "wake": "scheduled",
+        "assistant_id": "1406",
+        "destination": "team:11",
+        "task_id": 12,
+        "revision": "r1",
+        "due_at": "2026-07-29T16:50:00+00:00"
+      },
+      "run_key": "offline:scheduled:1406:team-11:12:82f3e9c695dc:20260729T165000Z"
+    },
+    {
+      "name": "a Z-suffixed timestamp normalizes to the same fragment",
+      "inputs": {
+        "delivery": "offline",
+        "wake": "scheduled",
+        "assistant_id": "1406",
+        "destination": "team:11",
+        "task_id": 12,
+        "revision": "r1",
+        "due_at": "2026-07-29T16:50:00Z"
+      },
+      "run_key": "offline:scheduled:1406:team-11:12:82f3e9c695dc:20260729T165000Z"
+    },
+    {
+      "name": "no destination omits the segment entirely",
+      "inputs": {
+        "delivery": "live",
+        "wake": "scheduled",
+        "assistant_id": "42",
+        "destination": null,
+        "task_id": 7,
+        "revision": "rev-a",
+        "due_at": "2026-04-10T09:00:00+00:00"
+      },
+      "run_key": "live:scheduled:42:7:162af81f5de4:20260410T090000Z"
+    }
+  ],
+  "known_divergence": "A triggered wake with no due time tails on 'arm' here and 'once' in Unify. That is the same drift on the trigger path and is deliberately not asserted as agreed contract until the trigger lane is verified end to end."
+}

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -10,7 +10,6 @@ from typing import TYPE_CHECKING, Any, Callable, List
 
 if TYPE_CHECKING:
     from unify.contact_manager.contact_manager import ContactManager
-    from unify.task_scheduler.task_scheduler import TaskScheduler
 from unify.events.event_bus import EVENT_BUS
 from unify.session_details import UNASSIGNED_ASSISTANT_CONTEXT, UNASSIGNED_USER_CONTEXT
 
@@ -936,60 +935,3 @@ def mutation_test_lock(lock_name: str, timeout: float | None = None):
     finally:
         _unlock_file(lock_file)
         lock_file.close()
-
-
-# --------------------------------------------------------------------------
-# TaskScheduler scenario helpers
-# --------------------------------------------------------------------------
-
-
-def is_task_scenario_seeded(ts: "TaskScheduler", task_defs: list[dict]) -> bool:
-    """
-    Check if task scenario data already exists (seeded by another process).
-
-    Args:
-        ts: TaskScheduler instance to query
-        task_defs: List of task definitions to check (each has 'name' key)
-
-    Returns:
-        True if all expected tasks exist
-    """
-    if not task_defs:
-        return False
-
-    # Check if at least one expected task exists
-    first_task_name = task_defs[0]["name"]
-    try:
-        existing = ts._filter_tasks(filter=f"name == {first_task_name!r}", limit=1)
-        return len(existing) > 0
-    except Exception:
-        return False
-
-
-def rebuild_task_id_mapping(
-    ts: "TaskScheduler",
-    task_defs: list[dict],
-) -> list[int]:
-    """
-    Rebuild task ID list from existing shared scenario data.
-
-    Used when scenario was seeded by another parallel process and we need
-    to reconstruct the local ID list.
-
-    Args:
-        ts: TaskScheduler instance to query
-        task_defs: List of task definitions (each has 'name' key)
-
-    Returns:
-        List of task IDs in the same order as task_defs
-    """
-    id_list: list[int] = []
-    for task_data in task_defs:
-        name = task_data["name"]
-        try:
-            existing = ts._filter_tasks(filter=f"name == {name!r}", limit=1)
-            if existing:
-                id_list.append(existing[0].task_id)
-        except Exception:
-            pass
-    return id_list

--- a/tests/task_scheduler/conftest.py
+++ b/tests/task_scheduler/conftest.py
@@ -11,11 +11,10 @@ import pytest_asyncio
 import unisdk
 
 from unify.task_scheduler.task_scheduler import TaskScheduler
+from unify.task_scheduler.types.task import Task
 from unify.manager_registry import ManagerRegistry
 from unify.common.context_registry import ContextRegistry
 from tests.helpers import (
-    is_task_scenario_seeded,
-    rebuild_task_id_mapping,
     scenario_file_lock,
     mutation_test_lock,
     restore_scenario_context,
@@ -26,39 +25,64 @@ _READ_SCENARIO_COMMIT_HASHES: Dict[str, Any] = {}
 _MUTATION_SCENARIO_COMMIT_HASHES: Dict[str, Any] = {}
 
 
-# Task data for seeding (shared by both scenarios)
-_TASKS_DATA: List[Dict[str, str]] = [
+# Task data for seeding (shared by both scenarios). The arming split is load
+# bearing: read-only tests count armed against paused tasks, so a scenario where
+# every task carries the same `enabled` value cannot tell a correct answer from a
+# uniform one.
+_TASKS_DATA: List[Dict[str, Any]] = [
     {
         "name": "Write quarterly report",
         "description": "Draft the Q2 report (send email to finance).",
+        "enabled": True,
     },
     {
         "name": "Prepare slide deck",
         "description": "Create slides for the board meeting. Email once done.",
+        "enabled": True,
     },
     {
         "name": "Client follow-up email",
         "description": "Send email to prospective client about proposal.",
+        "enabled": False,
     },
 ]
 
 
-def _seed_tasks(ts: TaskScheduler) -> List[int]:
-    """Create tasks if they don't exist. Returns list of task IDs in order."""
+def _declared_drift(task: Task, declared: Dict[str, Any]) -> Dict[str, Any]:
+    """Return the declared fields whose stored values no longer match."""
+
+    return {
+        field: value
+        for field, value in declared.items()
+        if field != "name" and getattr(task, field) != value
+    }
+
+
+def _seed_tasks(ts: TaskScheduler) -> Tuple[List[int], bool]:
+    """Reconcile the scenario against _TASKS_DATA.
+
+    Returns the task IDs in declaration order, plus whether anything was
+    written. Tasks are matched by name and updated in place when a declared
+    field has drifted, so editing _TASKS_DATA converges an already-seeded
+    context instead of being silently ignored.
+    """
+
     task_ids: List[int] = []
+    changed = False
     for task_data in _TASKS_DATA:
         name = task_data["name"]
-        try:
-            existing = ts._filter_tasks(filter=f"name == {name!r}", limit=1)
-            if existing:
-                task_id = existing[0].task_id
-            else:
-                result = ts._create_task(**task_data)
-                task_id = result["details"]["task_id"]
-            task_ids.append(task_id)
-        except Exception as e:
-            print(f"Warning: Could not create/find task '{name}': {e}")
-    return task_ids
+        existing = ts._filter_tasks(filter=f"name == {name!r}", limit=1)
+        if existing:
+            task_id = existing[0].task_id
+            drift = _declared_drift(existing[0], task_data)
+            if drift:
+                ts._update_task(task_id=task_id, **drift)
+                changed = True
+        else:
+            task_id = ts._create_task(**task_data)["details"]["task_id"]
+            changed = True
+        task_ids.append(task_id)
+    return task_ids, changed
 
 
 def _rebuild_commit_hashes(
@@ -121,16 +145,14 @@ def _setup_scenario(
 
     # Use file lock to coordinate seeding across parallel processes
     with scenario_file_lock(lock_name):
-        if is_task_scenario_seeded(ts, _TASKS_DATA):
-            # Scenario exists - just rebuild local state
-            print(f"Scenario already seeded ({ctx}), rebuilding local state...")
-            task_ids = rebuild_task_id_mapping(ts, _TASKS_DATA)
-            _rebuild_commit_hashes(ctx, commit_hashes)
-        else:
-            # Scenario not seeded - seed it
-            print(f"Seeding task scheduler scenario ({ctx})...")
-            task_ids = _seed_tasks(ts)
+        task_ids, changed = _seed_tasks(ts)
+        if changed:
+            # The rollback baseline has to contain the reconciled data.
+            print(f"Seeded task scheduler scenario ({ctx})...")
             _commit_contexts_for_rollback(ctx, commit_hashes)
+        else:
+            print(f"Scenario already seeded ({ctx}), rebuilding local state...")
+            _rebuild_commit_hashes(ctx, commit_hashes)
 
     unisdk.unset_context()
     return ts, task_ids

--- a/tests/task_scheduler/test_ask.py
+++ b/tests/task_scheduler/test_ask.py
@@ -29,18 +29,18 @@ def _answer_semantic(ts: TaskScheduler, question: str) -> str:
     q = question.lower()
     tasks = ts._filter_tasks()
 
-    if "how many scheduled" in q:
+    if "how many enabled" in q:
         return str(sum(1 for t in tasks if t.enabled is True))
 
-    if "cancelled" in q and "how many" in q:
+    if "how many disabled" in q:
         return str(sum(1 for t in tasks if t.enabled is False))
 
     return "N/A"
 
 
 QUESTIONS = [
-    "How many scheduled tasks are there?",
-    "How many cancelled tasks are there?",
+    "How many enabled tasks are there?",
+    "How many disabled tasks are there?",
 ]
 
 
@@ -115,32 +115,32 @@ async def test_ask_with_interjection(
     """Ask a question, interject with a follow-up, and ensure the final answer covers both."""
     ts, _ = task_scheduler_read_scenario
     try:
-        # 1) Initial question ⇢ scheduled task count
+        # 1) Initial question ⇢ enabled task count
         handle = await ts.ask(
-            text="How many scheduled tasks are there?",
+            text=QUESTIONS[0],
             _return_reasoning_steps=True,
         )
 
-        # 2) Mid-conversation interjection ⇢ cancelled task count
-        await handle.interject("Also, how many cancelled tasks are there?")
+        # 2) Mid-conversation interjection ⇢ disabled task count
+        await handle.interject("Also, how many disabled tasks are there?")
 
         # 3) Await combined answer
         answer, steps = await handle.result()
-        scheduled_cnt = _answer_semantic(ts, QUESTIONS[0])
-        cancelled_cnt = _answer_semantic(ts, QUESTIONS[1])
+        enabled_cnt = _answer_semantic(ts, QUESTIONS[0])
+        disabled_cnt = _answer_semantic(ts, QUESTIONS[1])
 
         # 4) Assert presence of both pieces of information
-        assert scheduled_cnt in answer, assertion_failed(
-            f"Answer containing scheduled count '{scheduled_cnt}'",
+        assert enabled_cnt in answer, assertion_failed(
+            f"Answer containing enabled count '{enabled_cnt}'",
             answer,
             steps,
-            "Scheduled count not mentioned in combined answer",
+            "Enabled count not mentioned in combined answer",
         )
-        assert cancelled_cnt in answer, assertion_failed(
-            f"Answer containing cancelled count '{cancelled_cnt}'",
+        assert disabled_cnt in answer, assertion_failed(
+            f"Answer containing disabled count '{disabled_cnt}'",
             answer,
             steps,
-            "Cancelled count not mentioned in combined answer",
+            "Disabled count not mentioned in combined answer",
         )
     except Exception as exc:
         raise exc

--- a/tests/task_scheduler/test_creation_deletion.py
+++ b/tests/task_scheduler/test_creation_deletion.py
@@ -40,7 +40,6 @@ def test_create_task():
     assert row.repeat is None
     assert row.priority == Priority.normal
     assert row.task_id == 0
-    assert row.instance_id == 0
     assert row.response_policy is None
     assert row.entrypoint == 101
     assert row.enabled is True
@@ -314,7 +313,6 @@ def test_sanitize_activation_drops_orchestra_nulls_for_bool_defaults():
     ts = TaskScheduler.__new__(TaskScheduler)
     row = {
         "task_id": 1,
-        "instance_id": 0,
         "name": "Integration scheduled task",
         "description": "Quietly start this work when it becomes due.",
         "status": "scheduled",

--- a/tests/task_scheduler/test_project_task_occurrence.py
+++ b/tests/task_scheduler/test_project_task_occurrence.py
@@ -1,0 +1,70 @@
+"""A projected occurrence is pending; only a starting run is running.
+
+Both paths share one create-or-adopt POST, and reusing the starting-run helper
+for projection created every successor already ``running`` with a fresh
+``started_at`` — ten minutes before it was due. Overlap guards then saw a live
+concurrent run the moment the predecessor started, and the two skipped each
+other forever.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from unify.task_scheduler import machine_state
+from unify.task_scheduler.machine_state import (
+    TaskRunProvenance,
+    create_or_adopt_live_task_run,
+    project_task_occurrence,
+)
+
+
+def _provenance(**overrides) -> TaskRunProvenance:
+    base = dict(
+        assistant_id="1406",
+        task_id=12,
+        wake="scheduled",
+        delivery="offline",
+        destination="team:11",
+        revision=None,
+        scheduled_for="2026-07-30T10:10:00+00:00",
+        dispatch_offset_seconds=72.99,
+    )
+    base.update(overrides)
+    return TaskRunProvenance(**base)
+
+
+def _posted_body(call) -> dict:
+    return call.args[1]
+
+
+def test_projection_posts_a_pending_row() -> None:
+    with patch.object(machine_state, "_orchestra_admin_post") as post:
+        post.return_value = {"run": {"run_key": "k"}}
+        project_task_occurrence(_provenance())
+
+    body = _posted_body(post.call_args)
+    assert body["state"] == "scheduled"
+    assert "started_at" not in body
+    assert body["dispatch_offset_seconds"] == 72.99
+
+
+def test_projection_stores_the_revision_the_key_digested() -> None:
+    """run_key hashed str(revision or ""); the row must carry that same value
+    or the dispatcher rebuilds a different key at fire time and mints a twin."""
+
+    with patch.object(machine_state, "_orchestra_admin_post") as post:
+        post.return_value = {"run": {"run_key": "k"}}
+        project_task_occurrence(_provenance(revision=None))
+
+    assert _posted_body(post.call_args)["revision"] == ""
+
+
+def test_a_starting_run_is_still_marked_running() -> None:
+    with patch.object(machine_state, "_orchestra_admin_post") as post:
+        post.return_value = {"run": {"run_key": "k"}}
+        create_or_adopt_live_task_run(_provenance())
+
+    body = _posted_body(post.call_args)
+    assert body["state"] == "running"
+    assert body["started_at"]

--- a/tests/task_scheduler/test_prompt_builders.py
+++ b/tests/task_scheduler/test_prompt_builders.py
@@ -17,7 +17,6 @@ from unify.task_scheduler.types.task import DeliveryMode, ExecutionStyle, Task
 def test_task_derives_delivery_mode_and_execution_style_independently():
     agentic_offline = Task(
         task_id=9,
-        instance_id=0,
         name="Offline agentic task",
         description="Interpret this description in the headless lane.",
         priority=Priority.normal,
@@ -28,7 +27,6 @@ def test_task_derives_delivery_mode_and_execution_style_independently():
     )
     symbolic_live = Task(
         task_id=10,
-        instance_id=0,
         name="Live symbolic task",
         description="Run the durable executor in the live lane.",
         priority=Priority.normal,
@@ -51,7 +49,6 @@ def test_task_derives_delivery_mode_and_execution_style_independently():
 def test_build_task_execution_request_includes_run_metadata():
     task = Task(
         task_id=7,
-        instance_id=2,
         name="Weekly AI report",
         description="Summarize the previous week's AI research.",
         priority=Priority.normal,
@@ -75,7 +72,6 @@ def test_build_task_execution_request_includes_run_metadata():
 def test_build_task_execution_request_omits_history_and_info():
     task = Task(
         task_id=7,
-        instance_id=3,
         name="Daily briefing",
         description="Prepare the briefing from current sources.",
         priority=Priority.normal,
@@ -93,7 +89,6 @@ def test_build_task_execution_request_omits_history_and_info():
 def test_build_task_run_guidelines_keep_child_actor_focused_on_one_task():
     task = Task(
         task_id=3,
-        instance_id=1,
         name="Invoice follow-up",
         description="Draft an invoice reply.",
         priority=Priority.normal,

--- a/tests/task_scheduler/test_provider_event_captured_instance.py
+++ b/tests/task_scheduler/test_provider_event_captured_instance.py
@@ -40,7 +40,6 @@ def _seed_provider_event_definition(
     next_task_id = int(scheduler._store.get_metric_max(key="task_id") or 0) + 1
     payload = {
         "task_id": next_task_id,
-        "instance_id": 0,
         "name": "GitHub issue triage",
         "description": "Triage new GitHub issues.",
         "trigger": _provider_event_trigger(),
@@ -78,7 +77,6 @@ async def test_provider_event_start_leaves_definition_unarmed():
     scheduler = TaskScheduler(actor=SimulatedActor(steps=None, duration=None))
     task_id = _seed_provider_event_definition(scheduler, task_revision=5)
     definition_before = scheduler._get_task_or_raise(task_id)
-    assert definition_before.instance_id == 0
     assert definition_before.trigger is not None
 
     untrusted = {"kind": "provider_event_context", "trust": "untrusted_data"}
@@ -102,7 +100,6 @@ async def test_provider_event_start_leaves_definition_unarmed():
     rows = scheduler._filter_tasks(filter=f"task_id == {task_id}")
     assert len(rows) == 1
     definition_after = rows[0]
-    assert definition_after.instance_id == 0
     assert definition_after.trigger is not None
 
 

--- a/tests/task_scheduler/test_provider_event_live_completion.py
+++ b/tests/task_scheduler/test_provider_event_live_completion.py
@@ -53,7 +53,6 @@ async def test_registered_provider_event_handle_preserves_definition_status():
 
     rows = scheduler._filter_tasks(filter=f"task_id == {task_id}")
     definition_row = rows[0]
-    assert definition_row.instance_id == 0
     assert definition_row.trigger is not None
 
 

--- a/tests/task_scheduler/test_provider_event_live_dispatch_flow.py
+++ b/tests/task_scheduler/test_provider_event_live_dispatch_flow.py
@@ -90,7 +90,6 @@ def test_provider_event_context_is_marked_untrusted_data() -> None:
 
     task = Task(
         task_id=1,
-        instance_id=0,
         name="Triage",
         description="Triage issues",
         priority=Priority.normal,

--- a/tests/task_scheduler/test_provider_event_prompt_injection_eval.py
+++ b/tests/task_scheduler/test_provider_event_prompt_injection_eval.py
@@ -17,7 +17,6 @@ from unify.task_scheduler.types.trigger import parse_task_trigger
 def _provider_task(*, destination: str | None = None) -> Task:
     return Task(
         task_id=42,
-        instance_id=1,
         name="Summarize issue",
         description="Summarize the GitHub issue for the boss.",
         priority="normal",

--- a/tests/task_scheduler/test_provider_event_run_key_contract.py
+++ b/tests/task_scheduler/test_provider_event_run_key_contract.py
@@ -1,0 +1,57 @@
+"""Two provider events sharing an identity-hmac prefix must not share a run key.
+
+The run key is the create-or-adopt idempotency token. Collapse two distinct
+events onto one key and the second adopts the first's execution instead of
+minting its own — the event is accepted, acknowledged, and silently never run.
+Truncating the identity digest the way the revision digest is truncated is
+exactly what would collapse them, so the digest is embedded in full.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from unify.task_scheduler.offline_runner_contract import build_provider_event_run_key
+
+_FIXTURE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "fixtures"
+    / "task_trigger_contract"
+    / "provider_event_run_key_collision.json"
+)
+
+
+def _fixture() -> dict:
+    return json.loads(_FIXTURE_PATH.read_text(encoding="utf-8"))
+
+
+def test_shared_prefix_identities_produce_distinct_run_keys() -> None:
+    fixture = _fixture()
+    first_hmac, second_hmac = fixture["shared_prefix_hmacs"]
+    shared = {
+        "assistant_id": fixture["assistant_id"],
+        "task_id": fixture["task_id"],
+        "binding_id": fixture["binding_id"],
+        "revision": fixture["revision"],
+    }
+
+    first = build_provider_event_run_key(event_identity_hmac=first_hmac, **shared)
+    second = build_provider_event_run_key(event_identity_hmac=second_hmac, **shared)
+
+    assert first != second
+    assert first.endswith(f":{first_hmac}")
+    assert second.endswith(f":{second_hmac}")
+
+
+def test_fixture_identities_overlap_past_the_truncation_widths() -> None:
+    """The case only bites while the two identities share a leading run of hex.
+
+    Both digests in this builder are cut to 12 hex, so an overlap shorter than
+    that would let the assertion above pass against a truncating implementation.
+    """
+
+    first_hmac, second_hmac = _fixture()["shared_prefix_hmacs"]
+
+    assert first_hmac != second_hmac
+    assert first_hmac[:16] == second_hmac[:16]

--- a/tests/task_scheduler/test_task_revision_cas.py
+++ b/tests/task_scheduler/test_task_revision_cas.py
@@ -49,7 +49,6 @@ def _provider_event_task(*, task_revision: int | None = 1) -> Task:
     assert isinstance(trigger, ProviderEventTrigger)
     return Task(
         task_id=42,
-        instance_id=0,
         name="GitHub issue triage",
         description="Triage new GitHub issues.",
         trigger=trigger,

--- a/tests/task_scheduler/test_task_run_key_contract.py
+++ b/tests/task_scheduler/test_task_run_key_contract.py
@@ -1,0 +1,69 @@
+"""The run key built here must match the one Orchestra projects for the occurrence.
+
+Create-or-adopt converges only when both sides produce the same key. When they
+drift, the dispatcher cannot adopt the execution Orchestra projected and mints a
+second one for the same slot; two rows read as concurrency, and an overlap guard
+then skips every tick — a silent halt, not an error.
+
+Orchestra pins the same fixture against ``_build_open_execution_run_key``, so a
+change on either side that the other does not follow fails in that side's own
+suite rather than only downstream.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from unify.task_scheduler.machine_state import TaskRunProvenance, build_task_run_key
+from unify.task_scheduler.types.execution import Delivery, Wake
+
+_FIXTURE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "fixtures"
+    / "task_trigger_contract"
+    / "task_run_key_contract.v1.json"
+)
+
+
+def _cases() -> list[dict]:
+    return json.loads(_FIXTURE_PATH.read_text(encoding="utf-8"))["cases"]
+
+
+def _provenance(inputs: dict) -> TaskRunProvenance:
+    """Map one contract case onto the provenance record that carries those facts."""
+
+    return TaskRunProvenance(
+        assistant_id=inputs["assistant_id"],
+        task_id=inputs["task_id"],
+        wake=Wake.normalize(inputs["wake"]),
+        delivery=Delivery.normalize(inputs["delivery"]),
+        revision=inputs["revision"],
+        destination=inputs["destination"],
+        scheduled_for=inputs["due_at"],
+    )
+
+
+@pytest.mark.parametrize("case", _cases(), ids=lambda case: case["name"])
+def test_run_key_matches_shared_contract(case: dict) -> None:
+    assert build_task_run_key(_provenance(case["inputs"])) == case["run_key"]
+
+
+def test_free_form_components_are_normalized() -> None:
+    """Anything that reaches the key is lowercased and hyphen-separated."""
+
+    key = build_task_run_key(
+        TaskRunProvenance(
+            assistant_id="1406",
+            task_id=12,
+            wake=Wake.scheduled,
+            delivery=Delivery.offline,
+            revision="r1",
+            destination="Team:11",
+            scheduled_for="2026-07-29T16:50:00+00:00",
+        ),
+    )
+
+    assert ":team-11:" in key

--- a/unify/actor/prompt_examples.py
+++ b/unify/actor/prompt_examples.py
@@ -161,7 +161,7 @@ async def classify_with_small_model(email_text: str):
     return await query_llm(
         email_text,
         system="Return a compact category and confidence for email triage.",
-        model="gpt-4.1-nano@openai",
+        model="openai/gpt-4.1-nano@openrouter",
         temperature=0.0,
     )
 
@@ -195,7 +195,7 @@ async def draft_replies_for_messages(messages: list[dict]) -> list[dict]:
             f"From: {message.get('from')}\n\n"
             f"{message.get('body')}",
             response_format=DraftDecision,
-            model="gpt-4.1-nano@openai",
+            model="openai/gpt-4.1-nano@openrouter",
             temperature=0.0,
         )
         drafts.append({

--- a/unify/common/reasoning.py
+++ b/unify/common/reasoning.py
@@ -63,7 +63,7 @@ def list_llms(provider: str | None = None) -> list[str]:
     """Return supported UniLLM endpoint strings available in this runtime.
 
     Endpoint strings use ``model@provider`` form, such as
-    ``"gpt-4.1-nano@openai"``. Pass ``provider`` to filter to one provider,
+    ``"openai/gpt-4.1-nano@openrouter"``. Pass ``provider`` to filter to one provider,
     e.g. ``list_llms("openai")``.
 
     Use this helper when choosing a concrete ``model=`` value for
@@ -98,7 +98,7 @@ def get_llm_model_selection_context() -> str:
         ### Choosing A Model For `query_llm(...)`
 
         Pass model overrides as UniLLM endpoint strings, e.g.
-        `model="gpt-4.1-nano@openai"`.
+        `model="openai/gpt-4.1-nano@openrouter"`.
 
         For durable or recurring stored functions, choose `model=` deliberately.
         Do not silently inherit the default high-reasoning model for bounded,
@@ -245,7 +245,7 @@ async def query_llm(
             "in the user's voice. Return null for draft_reply when no reply is needed.\\n"
             f"Subject: {subject}\\nFrom: {sender}\\nBody: {body}",
             response_format=EmailDraftDecision,
-            model="gpt-4.1-nano@openai",
+            model="openai/gpt-4.1-nano@openrouter",
         )
 
     Custom rubric with ``system`` for consistent bulk classification::

--- a/unify/common/task_execution_context.py
+++ b/unify/common/task_execution_context.py
@@ -129,6 +129,31 @@ current_task_execution_delegate: ContextVar[TaskExecutionDelegate | None] = Cont
 )
 
 
+# Tracks the chain of task_ids currently active in this async execution's own
+# ancestry (the task_id passed to each still-running `TaskScheduler.execute`
+# call in this async task tree, from the outermost run down to the current
+# one).
+#
+# This exists to catch *reentrancy*: a task invoking its own task_id again
+# (directly, or transitively via a nested `primitives.tasks.execute` call)
+# while it is still active. It is intentionally narrower than "is any
+# instance of this task_id active anywhere" -- unrelated concurrent
+# instances of the same task_id (e.g. two separate scheduled wakes) are
+# allowed and must not trip this check.
+#
+# - Set at the top of `TaskScheduler.execute`, extended with the current
+#   task_id, and reset in a `finally` block once the child run has been
+#   started (the spawned run keeps its own copied context, so resetting the
+#   caller's context afterward does not affect it).
+# - Checked at the top of `TaskScheduler.execute`: if the requested task_id
+#   is already in this set, the call is self-invocation and must be
+#   rejected rather than silently starting a duplicate nested run.
+current_task_execution_ancestors: ContextVar[frozenset[int]] = ContextVar(
+    "current_task_execution_ancestors",
+    default=frozenset(),
+)
+
+
 @dataclass(frozen=True)
 class PostRunReviewContext:
     """Run-scoped metadata for an optional post-completion storage review."""

--- a/unify/task_scheduler/base.py
+++ b/unify/task_scheduler/base.py
@@ -301,9 +301,9 @@ class BaseTaskScheduler(BaseStateManager, metaclass=SingletonABCMeta):
         execution requires an explicitly configured actor; otherwise execution
         fails loudly instead of silently using a simulated fallback.
 
-        Symbolic entrypoints receive opt-in kwargs such as ``task_id``,
-        ``instance_id``, and ``task_execution_context`` so they can apply their
-        own concurrency or skip logic when desired.
+        Symbolic entrypoints receive opt-in kwargs such as ``task_id`` and
+        ``task_execution_context`` so they can apply their own concurrency or
+        skip logic when desired.
 
         Returns
         -------

--- a/unify/task_scheduler/base.py
+++ b/unify/task_scheduler/base.py
@@ -74,7 +74,7 @@ class BaseTaskScheduler(BaseStateManager, metaclass=SingletonABCMeta):
     Scope and positioning (LLM‑facing)
     ----------------------------------
     Use this interface for activities that should be represented as durable
-    Tasks with names, descriptions, scheduling fields and completion status.
+    Tasks with names, descriptions, scheduling fields and an arming flag.
     It returns a steerable execution handle when starting such tasks.
     """
 
@@ -104,9 +104,9 @@ class BaseTaskScheduler(BaseStateManager, metaclass=SingletonABCMeta):
         Purpose
         -------
         Use this method to locate and inspect tasks that already exist in the
-        table: find task ids, check statuses, schedules, deadlines, triggers,
-        or summarise/compare existing entries. This call must never create,
-        modify, or delete tasks.
+        table: find task ids, check whether a task is armed, inspect schedules,
+        deadlines and triggers, or summarise/compare existing entries. This
+        call must never create, modify, or delete tasks.
 
         Clarifications
         --------------

--- a/unify/task_scheduler/machine_state.py
+++ b/unify/task_scheduler/machine_state.py
@@ -315,8 +315,17 @@ def consume_live_task_run_provenance(
     source_task_log_id: int | None = None,
     destination: str | None = None,
     trigger_attempt_token: str | None = None,
+    offline: bool | None = None,
 ) -> TaskRunProvenance | None:
-    """Claim the pending live-run provenance for one task, or build a fallback."""
+    """Claim the pending live-run provenance for one task, or build a fallback.
+
+    ``offline`` should be the target task definition's own ``offline`` field,
+    when known to the caller. It is used only for the fallback provenance
+    built below (no pending provenance was registered for this task/wake/
+    destination) -- a pending provenance already carries its own correct
+    ``delivery`` from whoever registered it. Without ``offline``, the
+    fallback defaults to live delivery, matching prior behavior.
+    """
 
     wake = _normalize_wake(wake)
     normalized_assistant_id = _coerce_str(assistant_id)
@@ -343,7 +352,7 @@ def consume_live_task_run_provenance(
         assistant_id=normalized_assistant_id,
         task_id=task_id,
         wake=wake,
-        delivery=Delivery.live,
+        delivery=Delivery.offline if offline else Delivery.live,
         source_task_log_id=source_task_log_id
         or (execution.source_task_log_id if execution is not None else None),
         revision=(execution.revision if execution is not None else None),

--- a/unify/task_scheduler/machine_state.py
+++ b/unify/task_scheduler/machine_state.py
@@ -446,6 +446,32 @@ def create_or_adopt_live_task_run(
 ) -> TaskRunReference | None:
     """Create or adopt one live execution row at the moment execution begins."""
 
+    return _create_or_adopt_task_run(
+        provenance,
+        state=ExecutionState.running,
+        started_at=started_at or _now_iso(),
+    )
+
+
+def project_task_occurrence(provenance: TaskRunProvenance) -> TaskRunReference | None:
+    """Create or adopt the pending execution row for one future occurrence.
+
+    A projected occurrence has not started: it is ``scheduled`` with no
+    ``started_at``, so overlap guards ignore it and dispatch owns the moment it
+    actually begins. Projecting it as a running row made every successor look
+    like a live concurrent run the instant its predecessor started, and the
+    predecessor and successor then overlap-skipped each other forever.
+    """
+
+    return _create_or_adopt_task_run(provenance, state=ExecutionState.scheduled)
+
+
+def _create_or_adopt_task_run(
+    provenance: TaskRunProvenance,
+    *,
+    state: ExecutionState,
+    started_at: str | None = None,
+) -> TaskRunReference | None:
     run_key = build_task_run_key(provenance)
     response_body = _orchestra_admin_post(
         _TASK_EXECUTION_CREATE_OR_ADOPT_PATH,
@@ -458,7 +484,11 @@ def create_or_adopt_live_task_run(
                 "source_task_log_id": provenance.source_task_log_id,
                 "wake": provenance.wake.value,
                 "delivery": provenance.delivery.value,
-                "revision": provenance.revision,
+                # The digest inside run_key hashed str(revision or ""), so the
+                # row must carry the same value the dispatcher will rebuild the
+                # key from at fire time. Dropping a None here would leave the
+                # dispatcher hashing a value the row never stored.
+                "revision": str(provenance.revision or ""),
                 "destination": provenance.destination,
                 "scheduled_for": provenance.scheduled_for,
                 "dispatch_offset_seconds": provenance.dispatch_offset_seconds,
@@ -468,8 +498,8 @@ def create_or_adopt_live_task_run(
                 "source_contact_display_name": provenance.source_contact_display_name,
                 "task_name": provenance.task_name,
                 "task_description": provenance.task_description,
-                "started_at": started_at or _now_iso(),
-                "state": ExecutionState.running.value,
+                "started_at": started_at,
+                "state": state.value,
             },
         ),
     )

--- a/unify/task_scheduler/offline_runner_contract.py
+++ b/unify/task_scheduler/offline_runner_contract.py
@@ -184,7 +184,12 @@ def build_provider_event_run_key(
     event_identity_hmac: str,
     delivery: Literal["live", "offline"] = "offline",
 ) -> str:
-    """Build the deterministic provider-event run key."""
+    """Build the deterministic provider-event run key.
+
+    Unlike communication-trigger keys, the provider event identity digest is
+    included in full so two identities that share a 12-hex prefix cannot
+    collide through truncation.
+    """
 
     revision_digest = hashlib.sha256(
         str(revision or "").encode("utf-8"),

--- a/unify/task_scheduler/prompt_builders.py
+++ b/unify/task_scheduler/prompt_builders.py
@@ -169,9 +169,9 @@ def build_ask_prompt(
         "--------",
         "",
         "- Tool selection (read carefully) -",
-        f"When the user quotes an **exact task name** (or asks for status/description/fields of a named task), use `{filter_tasks_fname}` with `name == '…'` — do **not** open `{search_tasks_fname}` or `{contact_ask_fname}`. A person's name inside that exact title is part of the task name, not a contact lookup.",
+        f"When the user quotes an **exact task name** (or asks for the description/fields of a named task), use `{filter_tasks_fname}` with `name == '…'` — do **not** open `{search_tasks_fname}` or `{contact_ask_fname}`. A person's name inside that exact title is part of the task name, not a contact lookup.",
         f"For ANY other semantic question over free-form text (e.g., fuzzy name/description meaning), ALWAYS use `{search_tasks_fname}`. Never try to approximate meaning with brittle substring filters.",
-        f"Use `{filter_tasks_fname}` for exact/boolean logic over structured fields (ids, status, priority, timestamps, exact name) or for narrow, constrained text checks.",
+        f"Use `{filter_tasks_fname}` for exact/boolean logic over structured fields (ids, arming flag, priority, timestamps, exact name) or for narrow, constrained text checks.",
         f"For questions about how to communicate with a specific person/role (tone, formality, how to address them, what wording to use), ALWAYS call `{contact_ask_fname}` to retrieve that contact's communication preferences/response policy. Do not guess.",
         "",
         "- Semantic search across tasks (ranked by cosine distance) -",
@@ -180,12 +180,13 @@ def build_ask_prompt(
         "",
         "- Filtering (exact/boolean; not semantic) -",
         f"Exact named task: `{filter_tasks_fname}(filter=\"name == 'Prepare notes for Alice (single msg 123)'\")`",
-        f"All scheduled high-priority tasks: `{filter_tasks_fname}(filter=\"status == 'scheduled' and priority == 'high'\")`",
+        f"All armed high-priority tasks: `{filter_tasks_fname}(filter=\"enabled == True and priority == 'high'\")`",
+        f'All paused tasks: `{filter_tasks_fname}(filter="enabled == False")`. Boolean literals are capitalized; `true`/`false` silently match nothing.',
         f"Tasks due this month: `{filter_tasks_fname}(filter=\"deadline >= '2024-08-01T00:00:00' and deadline < '2024-09-01T00:00:00'\")`",
         "",
         "- Numeric aggregations -",
         f"For numeric reduction metrics (count, sum, mean, min, max, median, mode, var, std) over numeric columns, use `{reduce_fname}` instead of filtering and computing in-memory.",
-        f"  `{reduce_fname}(metric='sum', keys='task_id', group_by='status')`",
+        f"  `{reduce_fname}(metric='count', keys='task_id', group_by='enabled')`",
         "",
         "Anti-patterns to avoid",
         "---------------------",
@@ -261,7 +262,7 @@ def build_ask_prompt(
             f"Call `{contact_ask_fname}` only for communication-style / preference questions "
             f"about a person, or when a task trigger/assignee explicitly references a "
             f"contact_id. Do **not** call it first when the user already gave an exact "
-            f"task name and only wants that task's fields (status, description, etc.)."
+            f"task name and only wants that task's fields (description, schedule, etc.)."
             if contact_ask_fname
             else ""
         ),
@@ -364,7 +365,7 @@ def build_update_prompt(
         f"(e.g. `filter=\"name == 'Close loop with Bob (integration)'\"`) — do **not** call "
         f"`{ask_fname}` or `{contact_ask_fname}` first.",
         f"When the user describes EXISTING tasks semantically (by meaning over name/description), first call `{search_tasks_fname}` to identify candidate `task_id` values, then apply the mutation(s).",
-        f"Use `{filter_tasks_fname}` for exact constraints over structured fields (ids, status, name, priority, timestamps) to narrow/validate the target set before mutating.",
+        f"Use `{filter_tasks_fname}` for exact constraints over structured fields (ids, name, priority, timestamps, `enabled == True`/`False`) to narrow/validate the target set before mutating.",
         (
             f"If you still cannot uniquely identify the intended task(s), call `{request_clar_fname}` "
             f"or `{ask_fname}` for a focused disambiguation before changing data."
@@ -397,7 +398,7 @@ def build_update_prompt(
             f"(e.g. 'every Monday', 'weekly', 'tomorrow at 9', 'first run Monday 12:00 UTC, repeat weekly'), include "
             f"`schedule={{'start_at': <iso8601>}}` and (for recurrence) `repeat=[...]` in the create call.",
             "For requests like 'do this every Monday' or 'send this report daily', create a live scheduled task with `schedule.start_at` for the first run and `repeat` for the cadence.",
-            "For requests like 'whenever Alice emails about invoices', create a live triggerable task with `trigger` and status 'triggerable'. Use contact lookup first when the trigger references a person.",
+            "For requests like 'whenever Alice emails about invoices', create a live task with a `trigger`. Use contact lookup first when the trigger references a person.",
             "A scheduled/triggered live task may have `entrypoint=None`. This is the normal default for newly described natural-language workflows.",
             "Do not create an entrypoint function merely because a recurring task is being created. Entrypoint creation should follow an explicit user request or a successful run that has been reviewed as stable enough to store.",
             "Offline is a delivery lane, not an execution style. An offline task may be agentic (`entrypoint=None`) or symbolic (`entrypoint=<function_id>`).",
@@ -414,12 +415,6 @@ def build_update_prompt(
             "Daily at a fixed time: set `schedule.start_at` to the first due datetime and `repeat=[{'frequency':'daily','interval':1}]`.",
             "Weekly on Monday at 12:00 UTC: set first `schedule.start_at` to the next Monday 12:00 UTC and `repeat=[{'frequency':'weekly','interval':1,'weekdays':['MO'],'time_of_day':'12:00'}]`.",
             "End after N runs: include `count`. End after a date: include `until`.",
-            "",
-            "Status invariants (must-follow)",
-            "-------------------------------",
-            "A task with `schedule.start_at` must have status 'scheduled'.",
-            "A task with a `trigger` must have status 'triggerable'.",
-            "Status is updated implicitly based on operations (activation, scheduling, completion). Do not set status explicitly.",
             "",
             "Enabled flag",
             "------------",
@@ -438,7 +433,7 @@ def build_update_prompt(
             "",
             "Triggers vs Schedules",
             "----------------------",
-            f"A task with a `trigger` must be in state 'triggerable'. Use `{update_task_fname}(task_id=<id>, trigger=...)` to add/remove triggers. Do not set `start_at` on trigger-based tasks.",
+            f"A task with a `trigger` is armed by that trigger, not by a start time. Use `{update_task_fname}(task_id=<id>, trigger=...)` to add/remove triggers. Do not set `start_at` on trigger-based tasks.",
             "`schedule` and `trigger` are mutually exclusive. Use `repeat` with `schedule` for cadence-based tasks; use `trigger` for inbound-event tasks.",
             "",
             "Provider-event triggers",
@@ -481,7 +476,7 @@ def build_update_prompt(
             ),
             "Meet user-level triggers and other empty config_schema rows leave trigger_config {}.",
             (
-                f"Create with `{create_task_fname}(..., status='triggerable', trigger={{"
+                f"Create with `{create_task_fname}(..., trigger={{"
                 "'kind': 'provider_event', 'state': 'enabled', 'connection_id': <exact id>, "
                 "'backend_id': <catalog backend>, 'canonical_app_slug': <catalog app>, "
                 "'provider_trigger_slug': <catalog slug>, "

--- a/unify/task_scheduler/task_scheduler.py
+++ b/unify/task_scheduler/task_scheduler.py
@@ -1163,6 +1163,7 @@ class TaskScheduler(BaseTaskScheduler):
             wake=task_run_wake,
             destination=task.destination,
             trigger_attempt_token=trigger_attempt_token,
+            offline=task.offline,
         )
         explicit_assistant_id = str(
             SESSION_DETAILS.assistant.agent_id

--- a/unify/task_scheduler/task_scheduler.py
+++ b/unify/task_scheduler/task_scheduler.py
@@ -2835,7 +2835,6 @@ class TaskScheduler(BaseTaskScheduler):
             "provider_event_binding_id",
             "name",
             "description",
-            "status",
             "trigger",
             "schedule",
             "enabled",
@@ -2915,7 +2914,6 @@ class TaskScheduler(BaseTaskScheduler):
             "task_id",
             "name",
             "description",
-            "status",
             "priority",
             "schedule",
             "deadline",
@@ -2940,9 +2938,12 @@ class TaskScheduler(BaseTaskScheduler):
         """Filter tasks using a boolean expression over task fields.
 
         Returns all task rows that match the given filter expression.
-        The expression uses field names from the task schema (e.g.
-        ``status == 'scheduled'``, ``task_id == 42``).  Returns an empty
-        list when no rows match.
+        The expression uses field names from the task schema and Python
+        literals (e.g. ``task_id == 42``, ``priority == 'high'``).  Boolean
+        fields such as ``enabled`` compare against ``True``/``False``
+        capitalized — ``enabled == true`` is not a boolean literal here and
+        matches no rows rather than raising.  Returns an empty list when no
+        rows match.
         """
 
         normalized_filter = normalize_filter_expr(filter)
@@ -3053,7 +3054,9 @@ class TaskScheduler(BaseTaskScheduler):
         """Compute aggregate metrics over the current task list.
 
         Supports count, sum, mean, min, max, and other standard reductions
-        grouped by one or more task fields (e.g. ``status``, ``priority``).
+        grouped by one or more task fields (e.g. ``priority``, ``enabled``).
+        Any ``filter`` follows the same expression rules as the task filter
+        tool, including capitalized ``True``/``False`` for boolean fields.
         Returns a dictionary of group keys to metric values.
         """
 

--- a/unify/task_scheduler/task_scheduler.py
+++ b/unify/task_scheduler/task_scheduler.py
@@ -70,12 +70,12 @@ from .machine_state import (
     TaskRunReference,
     build_task_run_key,
     consume_live_task_run_provenance,
-    create_or_adopt_live_task_run,
     find_running_execution_for_task,
     find_terminal_execution_for_task,
     latest_scheduled_occurrence_for_task,
     latest_task_run_reference_for_source,
     peek_live_task_run_provenance,
+    project_task_occurrence,
     remember_live_task_run_provenance,
     update_task_run_record,
 )
@@ -1524,7 +1524,7 @@ class TaskScheduler(BaseTaskScheduler):
             # project the next occurrence into.
             return False
         try:
-            create_or_adopt_live_task_run(
+            project_task_occurrence(
                 TaskRunProvenance(
                     assistant_id=assistant_id,
                     task_id=int(task.task_id),

--- a/unify/task_scheduler/task_scheduler.py
+++ b/unify/task_scheduler/task_scheduler.py
@@ -50,7 +50,10 @@ from ..common.model_to_fields import model_to_fields
 from ..common.read_only_ask_guard import ReadOnlyAskGuardHandle
 from ..common.search_utils import table_search_top_k
 from ..common.sentinels import _UnsetSentinel
-from ..common.task_execution_context import current_task_execution_delegate
+from ..common.task_execution_context import (
+    current_task_execution_ancestors,
+    current_task_execution_delegate,
+)
 from ..common.tool_outcome import ToolOutcome, ToolErrorException
 from ..common.tool_spec import ToolSpec, read_only
 from ..events.manager_event_logging import log_manager_call
@@ -180,6 +183,18 @@ class StaleActivationSuperseded(Exception):
 # Columns definitions carried before run state moved to Tasks/Executions.
 # Dropped on read so rows written before the migration still load.
 _LEGACY_DEFINITION_FIELDS = frozenset({"status", "activated_by", "instance_id"})
+
+
+class TaskSelfInvocationError(RuntimeError):
+    """A task attempted to execute itself while already active in its own run.
+
+    Raised when ``TaskScheduler.execute(task_id=N)`` is called (directly, or
+    via the ``primitives.tasks.execute`` tool) while ``N`` is already an
+    ancestor of the current execution -- i.e. the same task invoking itself,
+    rather than a genuinely separate concurrent instance or a distinct child
+    task. Do the work directly instead of re-invoking this task, or target a
+    different ``task_id`` if a distinct child task is intended.
+    """
 
 
 class TaskScheduler(BaseTaskScheduler):
@@ -1081,6 +1096,19 @@ class TaskScheduler(BaseTaskScheduler):
                 f"(run_key={finished.run_key}).",
             )
 
+        # Reject reentrancy: a task invoking its own task_id again (directly,
+        # or transitively via a nested primitives.tasks.execute call) while it
+        # is already active in this same execution chain. This is narrower
+        # than "any instance of task_id is active anywhere" -- see the
+        # concurrent-instance note below, which remains intentionally allowed.
+        if task_id in current_task_execution_ancestors.get():
+            raise TaskSelfInvocationError(
+                f"Task {task_id} cannot invoke itself via primitives.tasks.execute "
+                f"while it is already active in its own execution chain. Perform "
+                f"the work directly instead of re-invoking this task, or target a "
+                f"different task_id if a distinct child task is intended.",
+            )
+
         # Concurrent instances of the same task_id are allowed. Only block when
         # execution provenance targets a row that is already active.
         task_run_wake = (
@@ -1210,37 +1238,49 @@ class TaskScheduler(BaseTaskScheduler):
 
         self._project_next_occurrence(task)
 
-        handle = await ActiveTask.create(
-            fallback_actor,
-            task_description=build_task_execution_request(task),
-            _parent_chat_context=_parent_chat_context,
-            _clarification_up_q=_clarification_up_q,
-            _clarification_down_q=_clarification_down_q,
-            task_id=task_id,
-            instance_id=task.instance_id,
-            scheduler=self,
-            entrypoint=task.entrypoint,
-            entrypoint_kwargs=entrypoint_kwargs,
-            entrypoint_repair_attempts=1 if task.entrypoint is not None else 0,
-            entrypoint_repair_context=(
-                {
-                    "task_run_context": entrypoint_kwargs.get(
-                        "task_execution_context",
-                        {},
-                    ),
-                    "task_request": build_task_execution_request(task),
-                }
-                if entrypoint_kwargs is not None
-                else None
-            ),
-            destination=task.destination,
-            task_run_provenance=task_run_provenance,
-            task_entrypoint_review=self._build_task_entrypoint_review(
-                task=task,
-                reason=reason,
-            ),
-            task_guidelines=build_task_run_guidelines(task, reason),
+        # Extend the ancestor chain for the duration of starting the child run,
+        # so a spawned run that calls back into TaskScheduler.execute with this
+        # same task_id (directly or via nested primitives.tasks.execute) is
+        # caught by the reentrancy check above. The spawned run's own asyncio
+        # task captures a copy of this context at creation time, so resetting
+        # it here afterward does not affect the already-running child.
+        ancestor_token = current_task_execution_ancestors.set(
+            current_task_execution_ancestors.get() | {task_id},
         )
+        try:
+            handle = await ActiveTask.create(
+                fallback_actor,
+                task_description=build_task_execution_request(task),
+                _parent_chat_context=_parent_chat_context,
+                _clarification_up_q=_clarification_up_q,
+                _clarification_down_q=_clarification_down_q,
+                task_id=task_id,
+                instance_id=task.instance_id,
+                scheduler=self,
+                entrypoint=task.entrypoint,
+                entrypoint_kwargs=entrypoint_kwargs,
+                entrypoint_repair_attempts=1 if task.entrypoint is not None else 0,
+                entrypoint_repair_context=(
+                    {
+                        "task_run_context": entrypoint_kwargs.get(
+                            "task_execution_context",
+                            {},
+                        ),
+                        "task_request": build_task_execution_request(task),
+                    }
+                    if entrypoint_kwargs is not None
+                    else None
+                ),
+                destination=task.destination,
+                task_run_provenance=task_run_provenance,
+                task_entrypoint_review=self._build_task_entrypoint_review(
+                    task=task,
+                    reason=reason,
+                ),
+                task_guidelines=build_task_run_guidelines(task, reason),
+            )
+        finally:
+            current_task_execution_ancestors.reset(ancestor_token)
 
         return handle
 

--- a/unify/task_scheduler/task_scheduler.py
+++ b/unify/task_scheduler/task_scheduler.py
@@ -841,10 +841,6 @@ class TaskScheduler(BaseTaskScheduler):
                     "Activation source task log does not match requested task: "
                     f"expected task_id={expected_task_id}, got task_id={row_task_id}.",
                 )
-            instance_id = entries.get("instance_id")
-            if instance_id is None:
-                instance_id = 0
-            entries["instance_id"] = instance_id
             entries.setdefault(
                 "destination",
                 self._destination_from_task_context(context_name),
@@ -890,8 +886,7 @@ class TaskScheduler(BaseTaskScheduler):
         if task_scheduled_for != provenance_scheduled_for:
             raise StaleActivationSuperseded(
                 "Scheduled activation superseded by re-armed task definition: "
-                f"task_id={task.task_id}, instance_id={task.instance_id}, "
-                f"task_start_at={task_scheduled_for}, "
+                f"task_id={task.task_id}, task_start_at={task_scheduled_for}, "
                 f"activation_scheduled_for={provenance_scheduled_for}.",
             )
 
@@ -1256,7 +1251,7 @@ class TaskScheduler(BaseTaskScheduler):
                 _clarification_up_q=_clarification_up_q,
                 _clarification_down_q=_clarification_down_q,
                 task_id=task_id,
-                instance_id=task.instance_id,
+                instance_id=0,
                 scheduler=self,
                 entrypoint=task.entrypoint,
                 entrypoint_kwargs=entrypoint_kwargs,
@@ -1321,7 +1316,7 @@ class TaskScheduler(BaseTaskScheduler):
 
         source_task_log_id = self._get_log_by_task_instance(
             task_id=definition.task_id,
-            instance_id=definition.instance_id,
+            instance_id=0,
         ).id
 
         provenance = TaskRunProvenance(
@@ -1396,7 +1391,7 @@ class TaskScheduler(BaseTaskScheduler):
             fallback_actor,
             task_description=task_request,
             task_id=definition.task_id,
-            instance_id=definition.instance_id,
+            instance_id=0,
             scheduler=self,
             entrypoint=definition.entrypoint,
             entrypoint_kwargs=entrypoint_kwargs,
@@ -1436,7 +1431,7 @@ class TaskScheduler(BaseTaskScheduler):
             row for row in rows if self._task_has_provider_event_trigger(row)
         ]
         if definitions:
-            return sorted(definitions, key=lambda row: row.instance_id)[0]
+            return definitions[0]
         try:
             return self._get_provider_event_task_or_raise(task_id)
         except ValueError as exc:
@@ -2348,50 +2343,6 @@ class TaskScheduler(BaseTaskScheduler):
             )
         return {"detail": "No-op provider-event task update."}
 
-    def _update_task_instance(
-        self,
-        *,
-        task_id: int,
-        instance_id: int,
-        **kwargs: Any,
-    ) -> Dict[str, str]:
-        """Update supported fields on one concrete task instance."""
-
-        task = self._get_task_or_raise(task_id)
-        with self._use_task_destination(task.destination):
-            log_objs = self._store.get_rows(
-                filter=f"task_id == {task_id} and instance_id == {instance_id}",
-                limit=1,
-                return_ids_only=False,
-            )
-            if not log_objs:
-                raise ValueError(
-                    f"No task instance found for task_id={task_id}, instance_id={instance_id}",
-                )
-
-            log_to_update = log_objs[0]
-            if self._running_execution(task_id) is not None:
-                return {
-                    "outcome": "skipped",
-                    "reason": "Cannot update a task while a run is in flight",
-                }
-
-            entries_to_write: Dict[str, Any] = {}
-
-            if "info" in kwargs:
-                entries_to_write["info"] = kwargs["info"]
-
-            if not entries_to_write:
-                return {
-                    "outcome": "no changes",
-                    "details": {"task_id": task_id, "instance_id": instance_id},
-                }
-
-            return self._write_log_entries(
-                logs=log_to_update.id,
-                entries=entries_to_write,
-            )
-
     @staticmethod
     def _default_ask_tool_policy(
         step_index: int,
@@ -2878,10 +2829,7 @@ class TaskScheduler(BaseTaskScheduler):
     def _task_from_typed_response(self, typed_response: dict[str, Any]) -> Task:
         """Build one Task from a typed Tasks API row."""
 
-        entries = {
-            "task_id": int(typed_response["task_id"]),
-            "instance_id": 0,
-        }
+        entries = {"task_id": int(typed_response["task_id"])}
         for key in (
             "task_revision",
             "provider_event_binding_id",
@@ -2965,7 +2913,6 @@ class TaskScheduler(BaseTaskScheduler):
 
         allowed_fields: List[str] = [
             "task_id",
-            "instance_id",
             "name",
             "description",
             "status",
@@ -3012,7 +2959,9 @@ class TaskScheduler(BaseTaskScheduler):
                 return_ids_only=False,
                 include_fields=include_fields,
             )
-            for log in root_logs:
+            # Order by log id so callers that disambiguate duplicate rows for one
+            # task_id (a pre-migration shape) always resolve the oldest row.
+            for log in sorted(root_logs, key=lambda obj: int(obj.id)):
                 row = dict(log.entries or {})
                 row.setdefault("assistant_id", SESSION_DETAILS.assistant_context)
                 row["destination"] = destination

--- a/unify/task_scheduler/types/task.py
+++ b/unify/task_scheduler/types/task.py
@@ -198,11 +198,3 @@ class TaskBase(AuthoredRow):
 
 class Task(TaskBase):
     task_id: int = Field(description="Unique identifier for the task")
-    instance_id: int = Field(
-        default=0,
-        description=(
-            "Legacy occurrence counter retained for migration reads. "
-            "Task identity is ``task_id`` only; executions live in "
-            "``Tasks/Executions``."
-        ),
-    )


### PR DESCRIPTION
Projection reused the helper that materializes a run at the moment execution
begins, so every successor was born state=running with a fresh started_at.
A projected occurrence is now scheduled with no started_at, and stores the
revision its run_key digested so the dispatcher adopts it at fire time.

Paired with the orchestra release PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)