### PR TITLE
Release: staging → main

### DIFF
--- a/.github/workflows/flow-smoke.yml
+++ b/.github/workflows/flow-smoke.yml
@@ -372,6 +372,14 @@ jobs:
       continue-on-error: true
       run: orchestra/scripts/local.sh stop || true
 
+    - name: Collect orchestra server log
+      if: always()
+      continue-on-error: true
+      # Server-side tracebacks (logger.exception in request handlers) exist
+      # only here; without this file a backend programming error is reduced to
+      # whatever one-line detail reached the client.
+      run: cp /tmp/orchestra-local-server.log logs/orchestra-server.log || true
+
     - name: Upload flow smoke logs
       if: always()
       uses: actions/upload-artifact@v4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,7 +65,7 @@ repos:
 
   - id: check-no-release-versioning
     name: no first-party release versioning
-    entry: uv run python3 scripts/check_no_release_versioning.py
+    entry: python3 scripts/check_no_release_versioning.py
     language: system
     pass_filenames: false
 

--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -66,6 +66,63 @@ memory_watchdog() {
     done
 }
 
+AGENT_SERVICE_PORT="${PORT:-3000}"
+
+# The agent-service is part of the shared desktop substrate, not an
+# interactive-only nicety: web sessions reach it over localhost regardless of
+# whether the pod is running the ConversationManager or a one-shot offline task
+# runner. It used to be started only by the CM's restart-on-key-change path,
+# which left offline pods with nothing listening — a browser-driven scheduled
+# task then failed to connect and looked like a scraper bug.
+#
+# Comes up with the container's own UNIFY_KEY. Interactive pods respawn it with
+# the user's key once session details land (see ``_restart_agent_service_with_key``);
+# offline pods already carry the assistant's own key, so this start is final.
+start_agent_service() {
+    local agent_dir="/app/agent-service"
+    if [ ! -d "$agent_dir" ]; then
+        echo "⬥ agent-service directory not found at $agent_dir, skipping"
+        return
+    fi
+
+    echo "⬥ Starting agent-service..."
+    if [ -f "$agent_dir/dist/index.js" ]; then
+        set -- node --no-deprecation "$agent_dir/dist/index.js"
+    else
+        set -- npx ts-node "$agent_dir/src/index.ts"
+    fi
+
+    (
+        cd "$agent_dir" || exit 0
+        PLAYWRIGHT_BROWSERS_PATH="/home/unity/.cache/ms-playwright" \
+            "$@" >>/var/log/unity/agent-service.log 2>&1 &
+        echo $! >/tmp/agent-service.pid
+    )
+    AGENT_PID=$(cat /tmp/agent-service.pid 2>/dev/null || true)
+}
+
+# Readiness is a TCP listen check rather than an HTTP probe: the service
+# exposes no unauthenticated health route, and every real caller only needs the
+# socket to be accepting. Bounded and non-fatal — a wedged start should surface
+# as a connect error from the caller, not a pod that never boots.
+wait_for_agent_service() {
+    [ -f /tmp/agent-service.pid ] || return 0
+    local deadline=$((SECONDS + 30))
+    while [ "$SECONDS" -lt "$deadline" ]; do
+        if python3 -c "
+import socket, sys
+s = socket.socket()
+s.settimeout(1)
+sys.exit(0 if s.connect_ex(('127.0.0.1', $AGENT_SERVICE_PORT)) == 0 else 1)
+" 2>/dev/null; then
+            echo "⬥ agent-service listening on $AGENT_SERVICE_PORT (PID: ${AGENT_PID:-unknown})"
+            return 0
+        fi
+        sleep 1
+    done
+    echo "⬥ agent-service not listening on $AGENT_SERVICE_PORT after 30s; browser sessions will fail"
+}
+
 stop_agent_service() {
     local pid_file="/tmp/agent-service.pid"
     local pid=""
@@ -150,7 +207,12 @@ echo "⬥ Starting virtual audio devices..."
 bash /app/deploy/desktop/device.sh &
 DEVICE_PID=$!
 
+# Spawned before the display settles so node's startup overlaps the wait below.
+start_agent_service
+
 sleep 3
+
+wait_for_agent_service
 
 start_conversation_manager() {
     echo "⬥ Starting convo manager..."

--- a/tests/conversation_manager/core/test_meet_speaker_map.py
+++ b/tests/conversation_manager/core/test_meet_speaker_map.py
@@ -1,0 +1,143 @@
+"""Correlating diarized voices with platform speaker names.
+
+The regression these guard is subtle: the correlation used to sample whoever the
+platform said was speaking *at the moment a transcript finalised*. A final lands
+after its speaker stopped, so on a call where people take turns the answer was
+"nobody" every time and the map never filled -- attribution silently fell through
+to the weaker signals below it, which is indistinguishable from working.
+"""
+
+from unify.conversation_manager.meet_speaker_map import (
+    MIN_VOTES,
+    MeetSpeakerVotes,
+    MeetSpeakerWindows,
+)
+
+
+def test_a_final_arriving_after_speech_off_still_attributes():
+    """The actual regression: transcription lag must not lose the speaker."""
+    windows = MeetSpeakerWindows()
+    windows.speech_on("Ada", 100.0)
+    windows.speech_off("Ada", 103.0)
+
+    # The turn was spoken over [100.2, 103.1]; the final lands at 103.6, well
+    # after the platform said Ada stopped.
+    assert windows.speaker_during(100.2, 103.1) == "Ada"
+
+
+def test_sampling_the_instant_of_finalisation_is_what_used_to_fail():
+    """Nobody is speaking when a final arrives -- hence span matching."""
+    windows = MeetSpeakerWindows()
+    windows.speech_on("Ada", 100.0)
+    windows.speech_off("Ada", 103.0)
+
+    # An instant well past the span and past the grace: correctly nobody.
+    assert windows.speaker_during(110.0, 110.0) is None
+
+
+def test_the_speaker_with_the_most_overlap_wins():
+    windows = MeetSpeakerWindows()
+    windows.speech_on("Ada", 100.0)
+    windows.speech_off("Ada", 100.4)
+    windows.speech_on("Grace", 100.4)
+    windows.speech_off("Grace", 104.0)
+
+    assert windows.speaker_during(100.0, 104.0) == "Grace"
+
+
+def test_an_open_span_is_matchable_before_its_speech_off_arrives():
+    """Attribution cannot wait for speech_off; it may be dropped entirely."""
+    windows = MeetSpeakerWindows()
+    windows.speech_on("Ada", 100.0)
+
+    assert windows.speaker_during(100.5, 102.0) == "Ada"
+
+
+def test_a_dropped_speech_off_does_not_capture_the_rest_of_the_call():
+    """A span left open would otherwise outvote every later speaker forever."""
+    windows = MeetSpeakerWindows()
+    windows.speech_on("Ada", 100.0)
+    # No speech_off for Ada -- her next speech_on has to close the first span.
+    windows.speech_on("Ada", 200.0)
+    windows.speech_off("Ada", 201.0)
+    windows.speech_on("Grace", 300.0)
+    windows.speech_off("Grace", 310.0)
+
+    assert windows.speaker_during(300.0, 310.0) == "Grace"
+
+
+def test_a_voice_the_platform_never_reported_resolves_to_nobody():
+    """A phone dial-in, or a stretch where the relay was down."""
+    windows = MeetSpeakerWindows()
+    assert windows.speaker_during(100.0, 104.0) is None
+
+
+def test_spans_are_bounded_over_a_long_call():
+    """A four-hour meeting must not grow this without limit."""
+    windows = MeetSpeakerWindows()
+    for index in range(5000):
+        windows.speech_on(f"Speaker {index}", float(index))
+        windows.speech_off(f"Speaker {index}", float(index) + 0.5)
+
+    # Recent history still resolves; the ancient beginning of the call is gone.
+    assert windows.speaker_during(4999.0, 4999.4) == "Speaker 4999"
+    assert windows.speaker_during(0.0, 0.4) is None
+
+
+def test_one_overlap_is_not_enough_to_name_a_voice():
+    """Diarization ids drift and split; a single coincidence must not stick."""
+    votes = MeetSpeakerVotes()
+    votes.observe("S0", "Ada")
+
+    assert MIN_VOTES == 2
+    assert votes.resolve("S0") is None
+
+
+def test_a_repeated_name_names_the_voice():
+    votes = MeetSpeakerVotes()
+    votes.observe("S0", "Ada")
+    votes.observe("S0", "Ada")
+
+    assert votes.resolve("S0") == "Ada"
+
+
+def test_a_contested_voice_stays_unnamed():
+    """Two votes each is a coin flip, not evidence."""
+    votes = MeetSpeakerVotes()
+    votes.observe("S0", "Ada")
+    votes.observe("S0", "Ada")
+    votes.observe("S0", "Grace")
+    votes.observe("S0", "Grace")
+
+    assert votes.resolve("S0") is None
+
+
+def test_a_clear_majority_wins_despite_a_stray_vote():
+    votes = MeetSpeakerVotes()
+    for _ in range(4):
+        votes.observe("S0", "Ada")
+    votes.observe("S0", "Grace")
+
+    assert votes.resolve("S0") == "Ada"
+
+
+def test_votes_are_per_diarization_id():
+    votes = MeetSpeakerVotes()
+    votes.observe("S0", "Ada")
+    votes.observe("S0", "Ada")
+    votes.observe("S1", "Grace")
+    votes.observe("S1", "Grace")
+
+    assert votes.resolve("S0") == "Ada"
+    assert votes.resolve("S1") == "Grace"
+    assert votes.resolve("S2") is None
+
+
+def test_nothing_is_recorded_without_both_a_voice_and_a_name():
+    votes = MeetSpeakerVotes()
+    votes.observe("S0", None)
+    votes.observe("S0", "")
+    votes.observe("", "Ada")
+
+    assert votes.resolve("S0") is None
+    assert votes.resolve(None) is None

--- a/tests/conversation_manager/core/test_prompt_builders.py
+++ b/tests/conversation_manager/core/test_prompt_builders.py
@@ -338,23 +338,49 @@ class TestCoordinatorPrompt:
             assistant_has_teams=True,
         )
 
-        assert "Boss-only direct communication" in prompt
+        assert "Boss-only communication" in prompt
         assert "only for communicating directly with my boss" in prompt
         assert "They do not accept ``contact_id``" in prompt
         assert "always target the boss contact (``contact_id==1``" in prompt
-        assert (
-            "Communication with anyone else is never handled by direct tools" in prompt
-        )
-        assert "delegated third-party communication work goes through ``act``" in prompt
-        assert (
-            "send a message, draft a reply, place a call, or invite someone else on their behalf"
-            in prompt
-        )
+        assert "on ANY path — direct tools and ``act`` alike" in prompt
+        assert "draft the content for my boss to send themselves" in prompt
+        assert "Communication with anyone else is not possible for me" in prompt
+        # The act escape hatch is gone: no prompt text routes third-party
+        # communication through act any more.
+        assert "delegated third-party communication work" not in prompt
+        assert "through ``act`` instead of direct communication tools" not in prompt
         assert "Direct tools never accept inline contact details" in prompt
         assert "update the boss contact record first" in prompt
         assert "contact_id=5" not in prompt
         assert "Use the contact_id visible in active_conversations" not in prompt
         assert "send_slack_channel_message" not in prompt
+        # Browser meetings are gone from the single-player surface entirely.
+        assert "cannot join Google Meet or Microsoft Teams meetings" in prompt
+        assert "`join_google_meet`: Join a Google Meet call" not in prompt
+
+    def test_multiplayer_coordinator_gets_hire_comms_with_admin_surface(self):
+        prompt = _build(
+            is_coordinator=True,
+            is_multiplayer=True,
+            twin_name="Max Vector",
+            assistant_has_phone=True,
+            assistant_has_email=True,
+            assistant_has_whatsapp=True,
+            assistant_has_discord=True,
+            assistant_has_slack=True,
+            assistant_has_teams=True,
+        )
+
+        # Hire-like comms surface: open audience, channel posting, meets.
+        assert "Contact actions:" in prompt
+        assert "Boss-only communication" not in prompt
+        assert "send_slack_channel_message" in prompt
+        assert "`join_google_meet`: Join a Google Meet call" in prompt
+        assert "I do not communicate with other people" not in prompt
+        # Identity speaks under the twin's own name.
+        assert "I am Max Vector" in prompt
+        # The coordinator admin surface survives the flip.
+        assert "primitives.coordinator" in prompt
 
     def test_regular_direct_comms_guidance_keeps_contact_id_examples(self):
         prompt = _build(

--- a/tests/conversation_manager/core/test_recall_events.py
+++ b/tests/conversation_manager/core/test_recall_events.py
@@ -1,0 +1,130 @@
+"""Contract tests for Recall's realtime frame shapes.
+
+The frames here are the shapes Recall documents, not shapes invented to match
+the parser. That distinction is the point of the file: the previous fixtures
+asserted the reading the consumer already performed, so both agreed with each
+other and neither agreed with Recall -- a participant nested one level deeper
+than expected read as "no events arrived", which is what a dead relay looks
+like too.
+"""
+
+from unify.conversation_manager.domains.recall.events import (
+    EVENT_CHAT_MESSAGE,
+    EVENT_JOIN,
+    EVENT_SPEECH_ON,
+    ROSTER_EVENTS,
+    SUBSCRIBED_EVENTS,
+    parse_relayed_event,
+    participant_from_payload,
+)
+
+
+def _frame(event: str, participant: dict, body: dict | None = None) -> dict:
+    """One frame as the relay forwards it: the event name plus Recall's ``data``.
+
+    Recall wraps the payload twice, and the artifacts alongside it are part of
+    the real envelope -- kept here so a parser that reaches for the wrong
+    ``data`` finds a plausible object rather than nothing.
+    """
+    return {
+        "event": event,
+        "data": {
+            "data": {
+                "participant": participant,
+                "timestamp": {"absolute": "2026-07-30T10:00:00Z", "relative": 12.5},
+                "data": body,
+            },
+            "realtime_endpoint": {"id": "endpoint-1", "metadata": {}},
+            "participant_events": {"id": "pe-1", "metadata": {}},
+            "recording": {"id": "rec-1", "metadata": {}},
+            "bot": {"id": "bot-1", "metadata": {}},
+        },
+    }
+
+
+def test_participant_is_read_from_the_doubly_nested_payload():
+    """``data.data.participant`` -- one level short yields an empty speaker."""
+    event = parse_relayed_event(
+        _frame(EVENT_SPEECH_ON, {"id": 7, "name": "Ada", "is_host": True}),
+    )
+    assert event is not None
+    assert event.name == EVENT_SPEECH_ON
+    assert event.participant is not None
+    assert event.participant.name == "Ada"
+    assert event.participant.is_host is True
+
+
+def test_chat_text_is_read_from_the_triply_nested_body():
+    """``data.data.data.text``. Reading ``data.data.text`` drops every message."""
+    event = parse_relayed_event(
+        _frame(
+            EVENT_CHAT_MESSAGE,
+            {"id": 7, "name": "Ada"},
+            {"text": "here is the link", "to": "everyone"},
+        ),
+    )
+    assert event is not None
+    assert event.chat_text == "here is the link"
+    assert event.chat_to == "everyone"
+
+
+def test_non_chat_events_carry_a_null_body():
+    """Recall always sends the innermost ``data`` as null outside chat."""
+    event = parse_relayed_event(_frame(EVENT_JOIN, {"id": 7, "name": "Ada"}, None))
+    assert event is not None
+    assert event.chat_text is None
+    assert event.chat_to is None
+
+
+def test_participant_id_is_normalised_to_a_string():
+    """Realtime sends an int and REST a string; roster upserts match on it.
+
+    Left unnormalised, 7 and "7" are two people in the same meeting and a leave
+    never removes the person who joined.
+    """
+    realtime = parse_relayed_event(_frame(EVENT_JOIN, {"id": 7, "name": "Ada"}))
+    rest = participant_from_payload({"id": "7", "name": "Ada"})
+    assert realtime is not None and realtime.participant is not None
+    assert rest is not None
+    assert realtime.participant.id == rest.id == "7"
+
+
+def test_email_is_taken_from_extra_data_when_absent_at_the_top_level():
+    participant = participant_from_payload(
+        {"id": 1, "name": "Ada", "extra_data": {"email": "ada@example.com"}},
+    )
+    assert participant is not None
+    assert participant.email == "ada@example.com"
+
+
+def test_a_missing_email_is_none_rather_than_empty():
+    """Platforms disclose an address only sometimes; None is the normal case."""
+    participant = participant_from_payload({"id": 1, "name": "Ada", "email": None})
+    assert participant is not None
+    assert participant.email is None
+
+
+def test_a_participant_without_an_id_is_not_a_participant():
+    assert participant_from_payload({"name": "Ada"}) is None
+    assert participant_from_payload("not a mapping") is None
+
+
+def test_frames_that_carry_nothing_are_rejected():
+    """A frame read as empty must be distinguishable from one read wrongly."""
+    assert parse_relayed_event({"event": EVENT_JOIN}) is None
+    assert parse_relayed_event({"event": EVENT_JOIN, "data": {}}) is None
+    assert parse_relayed_event({"data": {"data": {}}}) is None
+    assert parse_relayed_event("not a mapping") is None
+
+
+def test_a_frame_with_no_participant_parses_but_names_nobody():
+    """Shape is intact, content is not -- the caller decides to skip it."""
+    event = parse_relayed_event({"event": EVENT_JOIN, "data": {"data": {}}})
+    assert event is not None
+    assert event.participant is None
+
+
+def test_roster_events_are_the_ones_that_change_who_is_present():
+    assert EVENT_JOIN in ROSTER_EVENTS
+    assert EVENT_SPEECH_ON not in ROSTER_EVENTS
+    assert ROSTER_EVENTS <= set(SUBSCRIBED_EVENTS)

--- a/tests/task_scheduler/test_active_task_guard.py
+++ b/tests/task_scheduler/test_active_task_guard.py
@@ -101,3 +101,51 @@ def test_cancel_open_executions_still_cancels_non_running_open_states(
 
     assert len(update_calls) == 1
     assert update_calls[0]["state"] == ExecutionState.cancelled.value
+
+
+def test_upsert_custom_task_allows_armed_triggerable_task(monkeypatch):
+    """An armed (triggerable) custom task must still be synced, not skipped."""
+
+    monkeypatch.setattr(
+        task_scheduler_module,
+        "find_running_execution_for_task",
+        _fake_find_running_execution(running_states={ExecutionState.triggerable}),
+    )
+    scheduler = _scheduler_with_task()
+    update_calls: list[int] = []
+    scheduler._update_custom_task = lambda **kwargs: update_calls.append(
+        kwargs["task_id"],
+    )
+
+    scheduler._upsert_one_custom_task(
+        custom_key="k",
+        source_data={"custom_hash": "new"},
+        db_tasks={"k": {"task_id": 5, "custom_hash": "old"}},
+        function_name_to_id={},
+        insert_lock=None,
+    )
+
+    assert update_calls == [5]
+
+
+def test_upsert_custom_task_skips_genuinely_running_task(monkeypatch):
+    monkeypatch.setattr(
+        task_scheduler_module,
+        "find_running_execution_for_task",
+        _fake_find_running_execution(running_states={ExecutionState.running}),
+    )
+    scheduler = _scheduler_with_task()
+    update_calls: list[int] = []
+    scheduler._update_custom_task = lambda **kwargs: update_calls.append(
+        kwargs["task_id"],
+    )
+
+    scheduler._upsert_one_custom_task(
+        custom_key="k",
+        source_data={"custom_hash": "new"},
+        db_tasks={"k": {"task_id": 5, "custom_hash": "old"}},
+        function_name_to_id={},
+        insert_lock=None,
+    )
+
+    assert update_calls == []

--- a/tests/task_scheduler/test_active_task_guard.py
+++ b/tests/task_scheduler/test_active_task_guard.py
@@ -1,0 +1,103 @@
+from types import SimpleNamespace
+
+import pytest
+
+from unify.task_scheduler import task_scheduler as task_scheduler_module
+from unify.task_scheduler.task_scheduler import TaskScheduler
+from unify.task_scheduler.types.execution import ExecutionState
+
+
+def _scheduler_with_task(
+    task_id: int = 0,
+    destination: str | None = None,
+) -> TaskScheduler:
+    scheduler = TaskScheduler.__new__(TaskScheduler)
+    scheduler._get_task_or_raise = lambda tid: SimpleNamespace(destination=destination)
+    return scheduler
+
+
+_DEFAULT_OPEN_STATES = (
+    ExecutionState.scheduled,
+    ExecutionState.triggerable,
+    ExecutionState.running,
+)
+
+
+def _fake_find_running_execution(*, running_states):
+    """Build a fake ``find_running_execution_for_task`` scoped to which states have an open row.
+
+    ``running_states`` is the set of ``ExecutionState`` values that currently
+    have an execution present, so the fake can answer truthfully whatever
+    subset of states a caller queries with.
+    """
+
+    def _fake(*, task_id, destination=None, states=None):
+        queried = states if states is not None else _DEFAULT_OPEN_STATES
+        for state in queried:
+            if state in running_states:
+                return SimpleNamespace(task_id=task_id, state=state.value)
+        return None
+
+    return _fake
+
+
+def test_ensure_not_active_task_allows_armed_triggerable_task(monkeypatch):
+    """An armed provider-event task (triggerable, not running) must not block mutation."""
+
+    monkeypatch.setattr(
+        task_scheduler_module,
+        "find_running_execution_for_task",
+        _fake_find_running_execution(running_states={ExecutionState.triggerable}),
+    )
+    scheduler = _scheduler_with_task()
+
+    scheduler._ensure_not_active_task(0)
+
+
+def test_ensure_not_active_task_blocks_genuinely_running_task(monkeypatch):
+    monkeypatch.setattr(
+        task_scheduler_module,
+        "find_running_execution_for_task",
+        _fake_find_running_execution(running_states={ExecutionState.running}),
+    )
+    scheduler = _scheduler_with_task()
+
+    with pytest.raises(
+        RuntimeError,
+        match="Operation not permitted on the active task",
+    ):
+        scheduler._ensure_not_active_task(0)
+
+
+@pytest.mark.parametrize(
+    "open_state",
+    [ExecutionState.scheduled, ExecutionState.triggerable],
+)
+def test_cancel_open_executions_still_cancels_non_running_open_states(
+    monkeypatch,
+    open_state,
+):
+    """``_cancel_open_executions`` must keep cancelling scheduled/triggerable rows, unchanged."""
+
+    monkeypatch.setattr(
+        task_scheduler_module,
+        "find_running_execution_for_task",
+        _fake_find_running_execution(running_states={open_state}),
+    )
+    update_calls: list[dict] = []
+    monkeypatch.setattr(
+        task_scheduler_module,
+        "update_task_run_record",
+        lambda reference, updates: update_calls.append(updates),
+    )
+    monkeypatch.setattr(
+        task_scheduler_module,
+        "latest_task_run_reference_for_source",
+        lambda **kwargs: "run-ref",
+    )
+    scheduler = _scheduler_with_task()
+
+    scheduler._cancel_open_executions(0)
+
+    assert len(update_calls) == 1
+    assert update_calls[0]["state"] == ExecutionState.cancelled.value

--- a/tests/task_scheduler/test_local_scheduler_integration.py
+++ b/tests/task_scheduler/test_local_scheduler_integration.py
@@ -26,11 +26,14 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 import unisdk
+from unisdk.utils.http import RequestError
 
 from tests.helpers import _handle_project
 from unify.session_details import SESSION_DETAILS
 from unify.task_scheduler.local_scheduler import LocalActivationScheduler
-from unify.task_scheduler.machine_state import list_scheduled_executions
+from unify.task_scheduler.machine_state import (
+    list_scheduled_executions,
+)
 from unify.task_scheduler.task_scheduler import TaskScheduler
 from unify.task_scheduler.types.repetition import Frequency, RepeatPattern
 from unify.task_scheduler.types.schedule import Schedule
@@ -40,15 +43,21 @@ from unify.task_scheduler.types.execution import Wake
 def _local_orchestra_authenticated() -> bool:
     """Probe whether local Orchestra accepts the current UNIFY_KEY.
 
-    A 401 from any read here means the test environment doesn't have a
-    working key — skip the integration tests rather than fail noisily on
-    an unrelated auth problem.
+    A 401 or a refused connection means the test environment has no working
+    Orchestra — skip rather than fail noisily on an unrelated setup problem.
+
+    Only *transport and auth* failures skip. A broken probe must not: this
+    guard originally called ``unisdk.get_projects``, which has never existed
+    (the SDK exposes ``list_projects``), and a bare ``except Exception``
+    turned that ``AttributeError`` into ``False``. Every test in this file
+    silently skipped for two months, in CI included, which is why none of them
+    caught the projection and run-key defects they were written to catch.
     """
 
     try:
-        unisdk.get_projects()
+        unisdk.list_projects()
         return True
-    except Exception:
+    except (RequestError, ConnectionError, OSError):
         return False
 
 
@@ -58,6 +67,30 @@ _REQUIRES_LIVE_ORCHESTRA = pytest.mark.skipif(
         "Local Orchestra is not authenticated for this test environment "
         "(no valid UNIFY_KEY). Integration tests skipped — see "
         "test_local_scheduler.py for the equivalent unit coverage."
+    ),
+)
+
+# Orchestra projects executions only for a task *surface*: the ``Assistants``
+# project, at ``{user}/{assistant}/Tasks`` or ``Teams/{id}/Tasks``. The
+# test-project fixture nests definitions under the test name in ``UnityTests``,
+# which satisfies neither, so a definition written through it is never
+# projected and the reads below return nothing.
+#
+# These tests were written on 2026-05-26 against the assumption that it was,
+# and never executed once: their skip guard called ``unisdk.get_projects``,
+# which has never existed, and a bare ``except Exception`` turned that
+# ``AttributeError`` into a skip. Fixing the guard revealed the premise.
+#
+# The occurrence-walk coverage they were meant to provide now lives in
+# orchestra's ``test_task_machine_projection.py``, where the fixtures build a
+# real surface against a real database. Re-enabling these needs a fixture that
+# provisions an assistant-scoped Tasks table here.
+_REQUIRES_TASK_SURFACE = pytest.mark.skip(
+    reason=(
+        "Needs an assistant-scoped Tasks surface; the test-project fixture's "
+        "nested UnityTests context is not one, so Orchestra never projects. "
+        "Occurrence-walk coverage lives in orchestra "
+        "test_task_machine_projection.py."
     ),
 )
 
@@ -72,6 +105,7 @@ class _RecordingBroker:
         self.published.append((topic, payload))
 
 
+@_REQUIRES_TASK_SURFACE
 @_REQUIRES_LIVE_ORCHESTRA
 @_handle_project
 def test_local_scheduler_picks_up_real_orchestra_activation():
@@ -153,6 +187,7 @@ async def _run_scheduler_integration() -> None:
         await local_scheduler.stop()
 
 
+@_REQUIRES_TASK_SURFACE
 @_REQUIRES_LIVE_ORCHESTRA
 @_handle_project
 def test_recurring_task_rearm_visible_to_local_scheduler():

--- a/tests/task_scheduler/test_machine_state.py
+++ b/tests/task_scheduler/test_machine_state.py
@@ -12,11 +12,12 @@ from unify.task_scheduler.machine_state import (
     create_or_adopt_task_outbound_operation,
     create_or_adopt_live_task_run,
     consume_live_task_run_provenance,
+    find_running_execution_for_task,
     get_open_task_execution,
     remember_live_task_run_provenance,
     validate_task_due_execution,
 )
-from unify.task_scheduler.types.execution import Delivery, Wake
+from unify.task_scheduler.types.execution import Delivery, ExecutionState, Wake
 
 
 def _scheduled_execution(**overrides) -> TaskExecutionSnapshot:
@@ -208,6 +209,45 @@ def test_get_open_task_execution_queries_assistants_machine_state_project(monkey
         user_context="user-1",
         assistant_context="42",
     )
+
+
+def test_find_running_execution_for_task_defaults_to_open_states(monkeypatch):
+    captured: dict[str, object] = {}
+
+    def _fake_get_logs(**kwargs):
+        captured.update(kwargs)
+        return []
+
+    monkeypatch.setattr("unify.task_scheduler.storage.unisdk.get_logs", _fake_get_logs)
+
+    execution = find_running_execution_for_task(task_id=101)
+
+    assert execution is None
+    filter_str = str(captured["filter"])
+    assert "state == 'scheduled'" in filter_str
+    assert "state == 'triggerable'" in filter_str
+    assert "state == 'running'" in filter_str
+
+
+def test_find_running_execution_for_task_scoped_to_running_state(monkeypatch):
+    captured: dict[str, object] = {}
+
+    def _fake_get_logs(**kwargs):
+        captured.update(kwargs)
+        return []
+
+    monkeypatch.setattr("unify.task_scheduler.storage.unisdk.get_logs", _fake_get_logs)
+
+    execution = find_running_execution_for_task(
+        task_id=101,
+        states=(ExecutionState.running,),
+    )
+
+    assert execution is None
+    filter_str = str(captured["filter"])
+    assert "state == 'running'" in filter_str
+    assert "state == 'scheduled'" not in filter_str
+    assert "state == 'triggerable'" not in filter_str
 
 
 def test_trigger_provenance_keeps_attempts_separate(monkeypatch):

--- a/tests/task_scheduler/test_offline_runner.py
+++ b/tests/task_scheduler/test_offline_runner.py
@@ -257,6 +257,27 @@ def test_load_config_from_env_canonicalizes_destination(monkeypatch):
     assert config.destination == "team:7"
 
 
+def test_load_config_from_env_accepts_an_empty_revision(monkeypatch):
+    """An empty revision is a value, not an omission.
+
+    The machine-state contract stores ``str(revision or "")`` and digests that
+    exact value into ``run_key``, and a definition with no authored
+    ``task_revision`` — every deployment-reconciled task — projects all of its
+    occurrences with "". Treating empty as missing boot-crashed each of those
+    runs at dispatch, before any task code ran, so the series burned an
+    occurrence per wake with nothing but a Job-failed marker to show for it.
+    """
+
+    from unify.task_scheduler import offline_runner
+
+    _seed_env(monkeypatch, wake="scheduled")
+    monkeypatch.setenv("UNITY_OFFLINE_TASK_REVISION", "")
+
+    config = offline_runner._load_config_from_env()
+
+    assert config.revision == ""
+
+
 def test_load_config_from_env_reads_resource_flags(monkeypatch):
     """Resource knobs load from UNITY_OFFLINE_TASK_REQUIRES_* env vars."""
 

--- a/unify/comms/primitives.py
+++ b/unify/comms/primitives.py
@@ -565,9 +565,30 @@ class CommsPrimitives:
         return self._get_contact(contact_id=_coerce_contact_id(contact_id))
 
     def _check_outbound_allowed(self, contact: dict | None) -> str | None:
-        """Check whether a contact may receive assistant-owned outbound comms."""
+        """Check whether a contact may receive assistant-owned outbound comms.
+
+        For a single-player coordinator this is the hard privacy boundary:
+        every outbound path — direct tools and ``act`` plans alike — funnels
+        through here, and only the boss contact passes. No prompt-level
+        permission can widen it.
+        """
         if not contact:
             return "Contact not found"
+        if SESSION_DETAILS.is_private_coordinator:
+            try:
+                is_boss = int(contact.get("contact_id")) == int(
+                    SESSION_DETAILS.boss_contact_id,
+                )
+            except (TypeError, ValueError):
+                is_boss = False
+            if not is_boss:
+                contact_name = _get_contact_display_name(contact)
+                return (
+                    f"Cannot contact {contact_name}: a single-player twin "
+                    "communicates with its boss only, on every channel. "
+                    "Draft the content for the boss to send themselves, or "
+                    "suggest enabling multiplayer mode in Settings."
+                )
         should_respond = contact.get("should_respond", False)
         if should_respond:
             return None
@@ -580,7 +601,7 @@ class CommsPrimitives:
 
     @staticmethod
     def _is_coordinator_boss_contact(contact_id: int | str) -> bool:
-        if not SESSION_DETAILS.is_coordinator:
+        if not SESSION_DETAILS.is_private_coordinator:
             return False
         try:
             return int(contact_id) == int(SESSION_DETAILS.boss_contact_id)
@@ -2998,6 +3019,36 @@ class CommsPrimitives:
                 history_metadata=_history_metadata(),
             )
 
+        if SESSION_DETAILS.is_private_coordinator:
+            # Scheduling on the boss's calendar is workspace labor, but the
+            # Outlook invites a scheduled meeting fans out are outbound
+            # comms — a single-player twin may invite its boss only.
+            boss_contact_id = int(SESSION_DETAILS.boss_contact_id)
+
+            def _attendee_contact_id(item: int | str | dict) -> int | None:
+                raw = item.get("contact_id") if isinstance(item, dict) else item
+                try:
+                    return _coerce_contact_id(raw)
+                except (TypeError, ValueError):
+                    return None
+
+            if any(
+                _attendee_contact_id(item) != boss_contact_id
+                for item in attendee_contact_ids or []
+            ):
+                return await self._surface_comms_error(
+                    "Cannot invite these attendees: a single-player twin may "
+                    "invite its boss only. Create the meeting with the boss "
+                    "as sole attendee and share the link through them, or "
+                    "suggest enabling multiplayer mode in Settings.",
+                    topic,
+                    contact_id=anchor_contact_id,
+                    medium=medium,
+                    attempted_content=f"create teams meeting '{subject or ''}'",
+                    target_metadata=_target_metadata(),
+                    history_metadata=_history_metadata(),
+                )
+
         resolved_start: str | None = None
         resolved_end: str | None = None
         if mode == "scheduled":
@@ -3786,6 +3837,37 @@ class CommsPrimitives:
                     "attachment_filepath": attachment_filepath or "",
                 },
             )
+
+        if SESSION_DETAILS.is_private_coordinator:
+            # Hard privacy boundary: a single-player twin emails its boss
+            # only. reply_all is refused outright because thread
+            # participants can include third parties.
+            boss_contact_id = int(SESSION_DETAILS.boss_contact_id)
+            recipient_ids = [cid for cid, _ in (to or []) + (cc or []) + (bcc or [])]
+            if reply_all or any(cid != boss_contact_id for cid in recipient_ids):
+                return await self._surface_comms_error(
+                    "Cannot send this email: a single-player twin emails its "
+                    "boss only. Draft the content for the boss to send "
+                    "themselves, or suggest enabling multiplayer mode in "
+                    "Settings.",
+                    topic,
+                    contact_id=error_contact_id,
+                    medium=Medium.EMAIL,
+                    offline_reservation=offline_reservation,
+                    attempted_content=f"Subject: {subject}\n\n{body}",
+                    receiver_ids=(
+                        [error_contact_id] if error_contact_id is not None else None
+                    ),
+                    target_metadata={
+                        "to": _raw_recipients_for_history(to),
+                        "cc": _raw_recipients_for_history(cc),
+                        "bcc": _raw_recipients_for_history(bcc),
+                        "reply_all": reply_all,
+                        "email_id_to_reply_to": email_id_to_reply_to or "",
+                        "thread_id": thread_id or "",
+                        "attachment_filepath": attachment_filepath or "",
+                    },
+                )
 
         if not self._assistant_email():
             return await self._surface_comms_error(

--- a/unify/conversation_manager/comms_manager.py
+++ b/unify/conversation_manager/comms_manager.py
@@ -1018,6 +1018,7 @@ class CommsManager:
                     "team_ids": event.get("team_ids") or [],
                     "team_summaries": event.get("team_summaries") or [],
                     "is_coordinator": event.get("is_coordinator", False),
+                    "is_multiplayer": event.get("is_multiplayer", False),
                     "update_kind": event.get("update_kind", "general"),
                 }
                 await publish(
@@ -2825,6 +2826,7 @@ class CommsManager:
                     "team_ids": event.get("team_ids") or [],
                     "team_summaries": event.get("team_summaries") or [],
                     "is_coordinator": event.get("is_coordinator", False),
+                    "is_multiplayer": event.get("is_multiplayer", False),
                     "wake_reasons": event.get("wake_reasons") or [],
                 }
 

--- a/unify/conversation_manager/conversation_manager.py
+++ b/unify/conversation_manager/conversation_manager.py
@@ -2761,6 +2761,7 @@ class ConversationManager(metaclass=SingletonABCMeta):
         team_summaries = payload.get("team_summaries") or []
         self.owner_team_id: int | None = payload.get("owner_team_id")
         is_coordinator = bool(payload.get("is_coordinator", False))
+        is_multiplayer = bool(payload.get("is_multiplayer", False))
         # Set API key on SESSION_DETAILS for runtime access
         if payload.get("api_key"):
             SESSION_DETAILS.unify_key = payload["api_key"]
@@ -2806,6 +2807,7 @@ class ConversationManager(metaclass=SingletonABCMeta):
             managed_desktop_status=self.managed_desktop_status,
             user_desktops=self.user_desktops,
             is_coordinator=is_coordinator,
+            is_multiplayer=is_multiplayer,
         )
         self.team_summaries = SESSION_DETAILS.team_summaries
         # Export to env vars for subprocess inheritance

--- a/unify/conversation_manager/domains/brain.py
+++ b/unify/conversation_manager/domains/brain.py
@@ -241,6 +241,8 @@ def build_brain_spec(
         runtime_setup_note=runtime_setup_note,
         team_summaries=getattr(cm, "team_summaries", []),
         is_coordinator=SESSION_DETAILS.is_coordinator,
+        is_multiplayer=SESSION_DETAILS.is_multiplayer,
+        twin_name=SESSION_DETAILS.assistant.name,
         authorized_humans=authorized_humans,
         is_org_workspace=SESSION_DETAILS.org_id is not None,
         console_ui_present=SETTINGS.UNITY_CONSOLE_UI,

--- a/unify/conversation_manager/domains/brain_action_tools.py
+++ b/unify/conversation_manager/domains/brain_action_tools.py
@@ -2468,10 +2468,16 @@ class ConversationManagerBrainActionTools:
         return _send_whatsapp_window_aware
 
     def as_tools(self) -> dict[str, "Callable[..., Any]"]:
-        """Return the static tools dict for start_async_tool_loop."""
+        """Return the static tools dict for start_async_tool_loop.
+
+        The comms surface is decided by ``is_private_coordinator``, not
+        ``is_coordinator``: a single-player twin is boss-only on every
+        channel and cannot enter browser meetings at all, while a
+        multiplayer twin communicates like any hired teammate.
+        """
         from unify.settings import SETTINGS
 
-        is_coordinator = SESSION_DETAILS.is_coordinator
+        is_coordinator = SESSION_DETAILS.is_private_coordinator
         tools: dict[str, Callable[..., Any]] = {
             "send_unify_message": (
                 self.send_unify_message_to_boss
@@ -2495,8 +2501,12 @@ class ConversationManagerBrainActionTools:
             and self._cm.call_manager.is_ready_for_outbound_call
         )
         if not call_or_meet_in_progress:
-            tools["join_google_meet"] = self.join_google_meet
-            tools["join_teams_meet"] = self.join_teams_meet
+            # Browser meetings are multi-party rooms, so a single-player
+            # twin never gets the join tools — not even for a meeting its
+            # boss hosts.
+            if not is_coordinator:
+                tools["join_google_meet"] = self.join_google_meet
+                tools["join_teams_meet"] = self.join_teams_meet
             # Ringing the in-app Meet only signals the Console (the owner answers
             # in-browser), so unlike telephony call-start it needs no prewarmed
             # worker; expose it whenever no other voice session is live.

--- a/unify/conversation_manager/domains/coordinator_onboarding.py
+++ b/unify/conversation_manager/domains/coordinator_onboarding.py
@@ -99,13 +99,6 @@ _SUBTYPE_DEFAULT_MESSAGES: dict[str, str] = {
         "linked computer now and send it back in chat; works from chat or on a "
         "call."
     ),
-    "workspace_call_beat_requested": (
-        "The user clicked the workspace video-call row — they'll host a Google "
-        "Meet or Microsoft Teams call. Ask them to start the meeting and paste "
-        "the link (I never create it), then join with join_google_meet for a "
-        "meet.google.com link or join_teams_meet for a teams.microsoft.com link "
-        "and talk to them live."
-    ),
 }
 
 
@@ -128,7 +121,6 @@ _SUBTYPE_INTEGRATION_DEMO_CHIP_REQUESTED = "integration_demo_chip_requested"
 _SUBTYPE_LEARNING_BEAT_REQUESTED = "learning_beat_requested"
 _SUBTYPE_MY_COMPUTER_BEAT_REQUESTED = "my_computer_beat_requested"
 _SUBTYPE_YOUR_COMPUTER_BEAT_REQUESTED = "your_computer_beat_requested"
-_SUBTYPE_WORKSPACE_CALL_BEAT_REQUESTED = "workspace_call_beat_requested"
 
 _IMMEDIATE_TRIGGER_ACK_GUIDANCE = (
     "Mandatory: the user's checklist click has no visible UI feedback until I "
@@ -163,7 +155,6 @@ _SUBTYPES_WITH_DURABLE_CLICK_TRACE = frozenset(
         _SUBTYPE_LEARNING_BEAT_REQUESTED,
         _SUBTYPE_MY_COMPUTER_BEAT_REQUESTED,
         _SUBTYPE_YOUR_COMPUTER_BEAT_REQUESTED,
-        _SUBTYPE_WORKSPACE_CALL_BEAT_REQUESTED,
         _SUBTYPE_WORKSPACE_DEMO_REQUESTED,
     },
 )
@@ -759,26 +750,6 @@ def _coordinator_onboarding_notification_text(
         framing = _detail_string(details, "framing")
         framing_note = f" Section framing: {framing}" if framing else ""
         text = f"{subtype_hint} {body}{framing_note}".strip()
-        return _append_onboarding_trigger_ack_guidance(text, event.subtype)
-
-    if event.subtype == _SUBTYPE_WORKSPACE_CALL_BEAT_REQUESTED:
-        details = event.details if isinstance(event.details, dict) else {}
-        framing = _detail_string(details, "framing")
-        framing_note = f" Section framing: {framing}" if framing else ""
-        guidance = (
-            "I do NOT create the meeting: ask the user to start a Google Meet or "
-            "Microsoft Teams meeting and paste the link, and wait for it rather "
-            "than guessing. Once I have the link I join it — a meet.google.com "
-            "link with join_google_meet, a teams.microsoft.com link with "
-            "join_teams_meet — passing a short spoken opener, then have a brief "
-            "live exchange. Respect the one-voice-session-at-a-time guard. This "
-            "is a poll, not a request to repeat finished work: if I have already "
-            "joined and spoken I just confirm it. After I have actually joined "
-            "and spoken, mark the step done with "
-            "set_onboarding_task_state('workspace-call', True); if they decline "
-            "or can't host, say so and do not mark it done."
-        )
-        text = f"{subtype_hint} {body}{framing_note} {guidance}".strip()
         return _append_onboarding_trigger_ack_guidance(text, event.subtype)
 
     if event.subtype == _SUBTYPE_WORKSPACE_DEMO_REQUESTED:

--- a/unify/conversation_manager/domains/event_handlers.py
+++ b/unify/conversation_manager/domains/event_handlers.py
@@ -149,6 +149,11 @@ def _kill_port(port: int) -> bool:
 def _restart_agent_service_with_key(api_key: str) -> None:
     """Kill and restart the agent-service so it picks up the user's API key.
 
+    ``entrypoint.sh`` starts the service with the container's own key as part of
+    the desktop substrate, so this is a genuine respawn rather than a cold start.
+    Do not treat it as the only start path: offline task pods have no
+    ConversationManager and would otherwise have nothing listening on 3000.
+
     1. Updates the agent-service .env file (UNIFY_KEY + infrastructure URLs)
     2. Kills the process listening on port 3000
     3. Spawns a new agent-service with logs to /var/log/unity/agent-service.log

--- a/unify/conversation_manager/domains/event_handlers.py
+++ b/unify/conversation_manager/domains/event_handlers.py
@@ -756,6 +756,10 @@ async def _(
     **kwargs,
 ):
     """Handle request to join a Google Meet — spawn browser + audio bridge."""
+    # Backstop for the tool-surface gate: a single-player twin never enters
+    # a browser meeting, whatever path the request arrived through.
+    if SESSION_DETAILS.is_private_coordinator:
+        return
     if (
         cm.mode.is_voice
         or cm.call_manager.has_active_call
@@ -877,6 +881,10 @@ async def _(
     **kwargs,
 ):
     """Handle request to join a Microsoft Teams meeting — spawn browser + audio bridge."""
+    # Backstop for the tool-surface gate: a single-player twin never enters
+    # a browser meeting, whatever path the request arrived through.
+    if SESSION_DETAILS.is_private_coordinator:
+        return
     if (
         cm.mode.is_voice
         or cm.call_manager.has_active_call

--- a/unify/conversation_manager/domains/event_handlers.py
+++ b/unify/conversation_manager/domains/event_handlers.py
@@ -1701,10 +1701,10 @@ async def _(event: Event, cm: "ConversationManager", *args, **kwargs):
                     for key, value in {
                         "contact_id": contact_id,
                         # Who was in the meeting when this line was said. The
-                        # platform reports names but, for bots created through
-                        # the Create Bot API, no emails -- so the roster is the
-                        # only record of who could have spoken, and it is worth
-                        # keeping per line because attendance changes mid-call.
+                        # platform reports names reliably and emails only
+                        # sometimes, so the roster is the record of who could
+                        # have spoken, and it is worth keeping per line because
+                        # attendance changes mid-call.
                         # ``or None`` so an empty roster is dropped rather than
                         # stored as an empty list.
                         "participant_names": (

--- a/unify/conversation_manager/domains/recall/client.py
+++ b/unify/conversation_manager/domains/recall/client.py
@@ -21,6 +21,12 @@ from typing import Any, Mapping
 
 import aiohttp
 
+from unify.conversation_manager.domains.recall.events import (
+    SUBSCRIBED_EVENTS,
+    RecallParticipant,
+    participant_from_payload,
+)
+
 LOGGER = logging.getLogger(__name__)
 
 # Recall deployments. Each is a wholly separate installation: an API key issued
@@ -84,22 +90,6 @@ class RecallError(RuntimeError):
 
 class RecallNotConfigured(RecallError):
     """No API key is present, so this environment cannot dispatch bots."""
-
-
-@dataclass(frozen=True)
-class RecallParticipant:
-    """One meeting participant as the platform reports it.
-
-    This is the payload that makes Recall worth adopting for attribution: the
-    platform's own name and email for a speaker, rather than a label scraped
-    out of the meeting UI.
-    """
-
-    id: str
-    name: str
-    email: str | None = None
-    is_host: bool = False
-    platform: str | None = None
 
 
 @dataclass(frozen=True)
@@ -235,14 +225,7 @@ class RecallClient:
             # unknown top-level keys, so getting this wrong registers no
             # endpoint at all and the bot silently never sends an event --
             # indistinguishable from a relay that is down.
-            events = [
-                "participant_events.join",
-                "participant_events.leave",
-                "participant_events.update",
-                "participant_events.speech_on",
-                "participant_events.speech_off",
-                "participant_events.chat_message",
-            ]
+            events = list(SUBSCRIBED_EVENTS)
             if capture_participant_video:
                 # PNG rather than H264: 360p at 2fps needs no decoder and no
                 # web_4_core variant (+$0.10/hr), and H264 only reaches
@@ -388,28 +371,13 @@ def _parse_bot_state(body: Mapping[str, Any]) -> RecallBotState:
 
 
 def _parse_participants(value: Any) -> tuple[RecallParticipant, ...]:
+    """The roster from a REST bot payload's ``meeting_participants``.
+
+    Shares its per-entry parsing with the realtime relay so a participant means
+    the same thing whichever source reported them.
+    """
+
     if not isinstance(value, list):
         return ()
-    participants = []
-    for entry in value:
-        if not isinstance(entry, Mapping):
-            continue
-        participant_id = entry.get("id")
-        if participant_id is None:
-            continue
-        extra = entry.get("extra_data")
-        email = entry.get("email")
-        if not email and isinstance(extra, Mapping):
-            email = extra.get("email")
-        participants.append(
-            RecallParticipant(
-                id=str(participant_id),
-                name=str(entry.get("name") or ""),
-                email=str(email) if email else None,
-                is_host=bool(entry.get("is_host")),
-                platform=(
-                    str(entry.get("platform")) if entry.get("platform") else None
-                ),
-            ),
-        )
-    return tuple(participants)
+    parsed = (participant_from_payload(entry) for entry in value)
+    return tuple(p for p in parsed if p is not None)

--- a/unify/conversation_manager/domains/recall/events.py
+++ b/unify/conversation_manager/domains/recall/events.py
@@ -1,0 +1,139 @@
+"""Recall's wire shapes: one participant, and one realtime event frame.
+
+Two sources describe the same participant. The REST bot payload
+(``meeting_participants``) is what the roster poll reads; the realtime websocket
+sends a frame per in-call event, relayed into the assistant's LiveKit room. Both
+are parsed here so the two can never disagree about what a participant is, and
+so the frame nesting lives in exactly one place.
+
+That nesting is the whole reason this module exists. A realtime frame wraps its
+payload twice -- the participant is at ``data.data.participant`` -- and a chat
+message wraps its body a third time, at ``data.data.data.text``. Reading a level
+short yields an empty participant and empty text, which downstream is
+indistinguishable from a relay that is down: no speaker attribution, no inbound
+chat, and nothing in the logs to say so.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+# Recall's realtime participant events. ``chat_message`` is the only one that
+# carries a body of its own; for the rest the innermost ``data`` is null.
+EVENT_JOIN = "participant_events.join"
+EVENT_LEAVE = "participant_events.leave"
+EVENT_UPDATE = "participant_events.update"
+EVENT_SPEECH_ON = "participant_events.speech_on"
+EVENT_SPEECH_OFF = "participant_events.speech_off"
+EVENT_CHAT_MESSAGE = "participant_events.chat_message"
+
+# Events that change who is in the meeting. ``update`` is here because a rename
+# arrives as an update against an id already on the roster.
+ROSTER_EVENTS = frozenset({EVENT_JOIN, EVENT_LEAVE, EVENT_UPDATE})
+
+# What a bot subscribes to at creation, in the order Recall is told them.
+#
+# MIRRORED: ``_RELAYED_EVENTS`` in unity-deploy's ``communication/meet_events.py``
+# drops anything absent from its own copy, so an event added here alone is
+# subscribed and then silently discarded in transit. Change both together.
+SUBSCRIBED_EVENTS = (
+    EVENT_JOIN,
+    EVENT_LEAVE,
+    EVENT_UPDATE,
+    EVENT_SPEECH_ON,
+    EVENT_SPEECH_OFF,
+    EVENT_CHAT_MESSAGE,
+)
+
+
+@dataclass(frozen=True)
+class RecallParticipant:
+    """One meeting participant as the platform reports it.
+
+    This is the payload that makes Recall worth adopting for attribution: the
+    platform's own name and email for a speaker, rather than a label scraped
+    out of the meeting UI.
+
+    ``email`` is frequently absent. Platforms disclose it to a bot created
+    through the Create Bot API only sometimes, so a null address is the normal
+    case rather than a fault, and nothing may depend on having one.
+    """
+
+    id: str
+    name: str
+    email: str | None = None
+    is_host: bool = False
+    platform: str | None = None
+
+
+@dataclass(frozen=True)
+class RelayedEvent:
+    """One realtime frame, unwrapped.
+
+    ``chat_text`` is set only for a chat message. ``participant`` is None when
+    the frame carried no identifiable participant, which is not worth acting on
+    for any event we subscribe to.
+    """
+
+    name: str
+    participant: RecallParticipant | None = None
+    chat_text: str | None = None
+    chat_to: str | None = None
+
+
+def participant_from_payload(entry: Any) -> RecallParticipant | None:
+    """One participant from either the REST roster or a realtime frame.
+
+    ``id`` arrives as an int over the websocket and as a string over REST, so it
+    is normalised to a string here: roster upserts match on it, and 7 and "7"
+    would otherwise be two different people in the same meeting.
+    """
+
+    if not isinstance(entry, Mapping):
+        return None
+    participant_id = entry.get("id")
+    if participant_id is None:
+        return None
+    email = entry.get("email")
+    extra = entry.get("extra_data")
+    if not email and isinstance(extra, Mapping):
+        email = extra.get("email")
+    platform = entry.get("platform")
+    return RecallParticipant(
+        id=str(participant_id),
+        name=str(entry.get("name") or ""),
+        email=str(email) if email else None,
+        is_host=bool(entry.get("is_host")),
+        platform=str(platform) if platform else None,
+    )
+
+
+def parse_relayed_event(message: Any) -> RelayedEvent | None:
+    """Unwrap one relayed frame, or None when it carries nothing usable.
+
+    The relay forwards Recall's ``data`` verbatim alongside the event name, so
+    what arrives here is ``{"event": ..., "data": {"data": {...}, ...}}`` -- the
+    outer object also carrying bot/recording/endpoint artifacts nothing reads.
+    """
+
+    if not isinstance(message, Mapping):
+        return None
+    name = message.get("event")
+    if not isinstance(name, str) or not name:
+        return None
+
+    outer = message.get("data")
+    inner = outer.get("data") if isinstance(outer, Mapping) else None
+    if not isinstance(inner, Mapping):
+        return None
+
+    body = inner.get("data")
+    text = body.get("text") if isinstance(body, Mapping) else None
+    to = body.get("to") if isinstance(body, Mapping) else None
+    return RelayedEvent(
+        name=name,
+        participant=participant_from_payload(inner.get("participant")),
+        chat_text=str(text) if text else None,
+        chat_to=str(to) if to else None,
+    )

--- a/unify/conversation_manager/domains/renderer.py
+++ b/unify/conversation_manager/domains/renderer.py
@@ -772,6 +772,13 @@ class Renderer:
             return "\n".join(parts)
 
         if not vm_ready:
+            meet_note = (
+                ""
+                if SESSION_DETAILS.is_private_coordinator
+                else "Note: join_google_meet and join_teams_meet do NOT depend "
+                "on the desktop VM — they use a local browser and are "
+                "available immediately.\n"
+            )
             parts.append(
                 "<infrastructure status='vm_pending'>\n"
                 "Your managed desktop VM is still booting. Computer actions "
@@ -779,10 +786,7 @@ class Renderer:
                 "yet. Do not attempt computer actions until you receive a "
                 "notification that the VM is ready. If a user asks you to do "
                 "something on the computer, let them know you will action it "
-                "in just a moment.\n"
-                "Note: join_google_meet and join_teams_meet do NOT depend on "
-                "the desktop VM — they use a local browser and are available "
-                "immediately.\n"
+                f"in just a moment.\n{meet_note}"
                 "</infrastructure>",
             )
 

--- a/unify/conversation_manager/events.py
+++ b/unify/conversation_manager/events.py
@@ -1529,6 +1529,7 @@ class _SessionConfigBase(Event):
     # Owning team for team-owned assistants (None = user-owned).
     owner_team_id: int | None = None
     is_coordinator: bool = False
+    is_multiplayer: bool = False
     update_kind: str = "general"
     wake_reasons: list[dict[str, Any]] = field(default_factory=list)
 

--- a/unify/conversation_manager/medium_scripts/call.py
+++ b/unify/conversation_manager/medium_scripts/call.py
@@ -80,6 +80,18 @@ from unify.conversation_manager.medium_scripts.meet_floor import (
     MeetFloor,
 )
 from unify.conversation_manager.domains.recall.client import RECALL_EVENT_TOPIC
+from unify.conversation_manager.domains.recall.events import (
+    EVENT_CHAT_MESSAGE,
+    EVENT_LEAVE,
+    EVENT_SPEECH_OFF,
+    EVENT_SPEECH_ON,
+    ROSTER_EVENTS,
+    parse_relayed_event,
+)
+from unify.conversation_manager.meet_speaker_map import (
+    MeetSpeakerVotes,
+    MeetSpeakerWindows,
+)
 from unify.conversation_manager.cm_types.screenshot import (
     ScreenshotEntry,
     generate_screenshot_path,
@@ -1435,7 +1447,8 @@ async def entrypoint(ctx: agents.JobContext):
     # 1. Deepgram diarization (enable_diarization=True) for precise per-utterance
     #    anonymous speaker IDs (S0, S1, ...).
     # 2. The meeting platform's own roster and speech events, relayed in.
-    # The correlation mapping table (_meet_speaker_map) links the two.
+    # ``_meet_speech_windows`` and ``_meet_speaker_votes`` link the two, by
+    # overlapping each finalised utterance with the platform's speaking spans.
     _meet_auth_key = SESSION_DETAILS.unify_key
     _meet_cached_active_speaker: str | None = None
     _meet_cached_participants: list[dict] = []
@@ -1443,7 +1456,8 @@ async def entrypoint(ctx: agents.JobContext):
     _meet_latest_screenshot: str | None = None
     _meet_display_name: str = ""
     _meet_last_speaker_id: str | None = None
-    _meet_speaker_map: dict[str, dict[str, int]] = {}
+    _meet_speech_windows = MeetSpeakerWindows()
+    _meet_speaker_votes = MeetSpeakerVotes()
     if channel in ("google_meet", "teams_meet"):
         if meta:
             _meet_display_name = meta.get("meet_display_name", "")
@@ -1453,8 +1467,9 @@ async def entrypoint(ctx: agents.JobContext):
     def _meet_participant_email(display_name: str) -> str:
         """The meeting platform's email for a participant, by display name.
 
-        Only browser meets have one: it arrives on the roster the CM pushes,
-        sourced from the platform itself rather than anything we inferred.
+        Frequently empty. Platforms disclose an address to a bot created through
+        the Create Bot API only sometimes, so this is a bonus signal rather than
+        one anything may depend on -- name matching has to carry the rest.
         """
         if not display_name:
             return ""
@@ -1463,6 +1478,56 @@ async def entrypoint(ctx: agents.JobContext):
             if str(participant.get("name") or "").strip().lower() == wanted:
                 return str(participant.get("email") or "").strip()
         return ""
+
+    def _merge_meet_participant(entry: dict) -> None:
+        """Merge one participant into the cached roster, keyed on platform id.
+
+        Realtime events and the ten-second roster poll describe the same person
+        from different sources, and either may know an email the other does not.
+        An absent name or address therefore never overwrites a known one, so
+        whichever source saw it wins regardless of which arrived last. Host
+        status is taken from the newer report, being the kind of thing that
+        genuinely changes mid-meeting.
+        """
+        participant_id = str(entry.get("id") or "")
+        for existing in _meet_cached_participants:
+            if str(existing.get("id") or "") != participant_id:
+                continue
+            existing["is_host"] = bool(entry.get("is_host"))
+            if entry.get("name"):
+                existing["name"] = entry["name"]
+            if entry.get("email"):
+                existing["email"] = entry["email"]
+            return
+        _meet_cached_participants.append(
+            {
+                "id": participant_id,
+                "name": str(entry.get("name") or ""),
+                "email": entry.get("email") or None,
+                "is_host": bool(entry.get("is_host")),
+            },
+        )
+
+    def _drop_meet_participant(participant_id: str) -> None:
+        """Drop one participant from the cached roster by platform id."""
+        for index, existing in enumerate(_meet_cached_participants):
+            if str(existing.get("id") or "") == participant_id:
+                del _meet_cached_participants[index]
+                return
+
+    def _reconcile_meet_roster(incoming: list[dict]) -> None:
+        """Fold a polled roster into the cache, dropping whoever is gone.
+
+        Merged rather than swapped in wholesale: the poll is authoritative about
+        *who* is present, but not about every field of them, and replacing the
+        list would discard an email only a realtime join had carried.
+        """
+        for entry in incoming:
+            _merge_meet_participant(entry)
+        present = {str(entry.get("id") or "") for entry in incoming}
+        for existing in list(_meet_cached_participants):
+            if str(existing.get("id") or "") not in present:
+                _drop_meet_participant(str(existing.get("id") or ""))
 
     def _resolve_contact_by_name(display_name: str) -> dict | None:
         """Best-effort contact resolution from a Meet display name.
@@ -1725,13 +1790,16 @@ async def entrypoint(ctx: agents.JobContext):
         Returns (contact_dict, display_name, speaker_id, voice_verified,
         engaged, label_source). ``label_source`` is a ``speaker_id.LABEL_SOURCE_*``
         tag recording which of the signals below produced ``display_name`` (None
-        when no name was resolved). Signals in priority order — the same ordering
-        as ``LABEL_SOURCE_PRECEDENCE``:
+        when no name was resolved). The order these are consumed in *is* the
+        authority ordering — there is no table enforcing it elsewhere:
         1. Voice-embedding pin against enrolled contact profiles (all channels).
         2. LiveKit identity → org-call roster (Unify Meet multi-party).
-        3. Diarization speaker_id → name correlation mapping (browser meets).
+        3. Diarization speaker_id → name correlation, accumulated by overlapping
+           finalised utterances with the platform's speaking spans (browser
+           meets).
         4. Platform-reported active speaker (browser meets, relayed in near
-           real time from participant speech events).
+           real time from participant speech events) — weaker than 3 because it
+           is a single reading rather than accumulated evidence.
         5. Voice-embedding anonymous "Speaker N" label (all channels) — a real
            name from 1-4 always outranks this placeholder, so it is evaluated
            last even though it comes from the same tracker resolution as 1.
@@ -1739,10 +1807,10 @@ async def entrypoint(ctx: agents.JobContext):
         sid = _meet_last_speaker_id
         engaged = _speaker_is_engaged(sid)
 
-        # Resolve once, then consume in documented-authority order
-        # (``speaker_id.LABEL_SOURCE_PRECEDENCE``): the embedding pin is returned
-        # immediately, but the anonymous "Speaker N" fallback is held to the very
-        # end so a real roster or platform name always wins over a placeholder.
+        # Resolve once, then consume in the authority order above: the embedding
+        # pin is returned immediately, but the anonymous "Speaker N" fallback is
+        # held to the very end so a real roster or platform name always wins
+        # over a placeholder.
         resolution = (
             speaker_tracker.resolve(sid)
             if sid and speaker_tracker is not None
@@ -1789,32 +1857,27 @@ async def entrypoint(ctx: agents.JobContext):
         # participant events rather than anything read off a screen.
         if channel in ("google_meet", "teams_meet"):
             # 3. Diarization speaker_id → correlated display name.
-            if sid and sid in _meet_speaker_map:
-                votes = _meet_speaker_map[sid]
-                if votes:
-                    top_name = max(votes, key=votes.get)
-                    top_count = votes[top_name]
-                    total = sum(votes.values())
-                    if top_count >= 2 and top_count / total > 0.6:
-                        resolved = _resolve_contact_by_name(top_name)
-                        if resolved:
-                            label = f"{resolved.get('first_name', '')} {resolved.get('surname', '')}".strip()
-                            return (
-                                resolved,
-                                label or None,
-                                sid,
-                                False,
-                                engaged,
-                                speaker_id.LABEL_SOURCE_RECALL_PARTICIPANT,
-                            )
-                        return (
-                            contact,
-                            top_name,
-                            sid,
-                            False,
-                            engaged,
-                            speaker_id.LABEL_SOURCE_RECALL_PARTICIPANT,
-                        )
+            correlated = _meet_speaker_votes.resolve(sid)
+            if correlated:
+                resolved = _resolve_contact_by_name(correlated)
+                if resolved:
+                    label = f"{resolved.get('first_name', '')} {resolved.get('surname', '')}".strip()
+                    return (
+                        resolved,
+                        label or None,
+                        sid,
+                        False,
+                        engaged,
+                        speaker_id.LABEL_SOURCE_RECALL_PARTICIPANT,
+                    )
+                return (
+                    contact,
+                    correlated,
+                    sid,
+                    False,
+                    engaged,
+                    speaker_id.LABEL_SOURCE_RECALL_PARTICIPANT,
+                )
 
             # 4. Whoever the platform says is speaking right now.
             active_name = _meet_cached_active_speaker
@@ -1873,12 +1936,10 @@ async def entrypoint(ctx: agents.JobContext):
                     name = f"{cand.get('first_name', '')} {cand.get('surname', '')}".strip()
                     if name:
                         return name, speaker_id.LABEL_SOURCE_VOICE_PIN
-        if channel in ("google_meet", "teams_meet") and sid in _meet_speaker_map:
-            votes = _meet_speaker_map[sid]
-            if votes:
-                top_name = max(votes, key=votes.get)
-                if votes[top_name] >= 2 and votes[top_name] / sum(votes.values()) > 0.6:
-                    return top_name, speaker_id.LABEL_SOURCE_RECALL_PARTICIPANT
+        if channel in ("google_meet", "teams_meet"):
+            correlated = _meet_speaker_votes.resolve(sid)
+            if correlated:
+                return correlated, speaker_id.LABEL_SOURCE_RECALL_PARTICIPANT
         if resolution.label:
             return resolution.label, speaker_id.LABEL_SOURCE_ANONYMOUS
         return None, None
@@ -2494,10 +2555,22 @@ async def entrypoint(ctx: agents.JobContext):
             return
         _meet_last_speaker_id = ev.speaker_id
         if channel in ("google_meet", "teams_meet"):
-            speaking_name = _meet_cached_active_speaker
+            # Matched against the platform's speaking spans over this turn's own
+            # span, not against whoever is speaking at this instant: a final
+            # arrives *after* its speaker stopped, by which point the platform
+            # has already reported speech_off and nobody is speaking at all.
+            turn_ended_at = prompt_now(as_string=False).timestamp()
+            turn_started_at = (
+                user_speech_started_at.timestamp()
+                if user_speech_started_at is not None
+                else turn_ended_at
+            )
+            speaking_name = _meet_speech_windows.speaker_during(
+                turn_started_at,
+                turn_ended_at,
+            )
             if speaking_name and speaking_name != _meet_display_name:
-                bucket = _meet_speaker_map.setdefault(ev.speaker_id, {})
-                bucket[dom_speaker] = bucket.get(dom_speaker, 0) + 1
+                _meet_speaker_votes.observe(ev.speaker_id, speaking_name)
 
     # -- Screenshot state --
     screenshot_history = ScreenshotHistory()
@@ -2854,9 +2927,11 @@ async def entrypoint(ctx: agents.JobContext):
 
     if channel in ("google_meet", "teams_meet"):
         # The relay republishes the meeting platform's participant events into
-        # this room. speech_on/speech_off is the only one that needs to arrive
-        # faster than the CM's roster poll: it names whoever is talking *right
-        # now*, which is what pins a diarized voice to a person.
+        # this room. Roster changes are applied from here as well as from the
+        # CM's ten-second poll: the poll is what proves who is present, but a
+        # join or leave is worth acting on the moment it happens, and the
+        # join/leave publish downstream diffs against the previous set, so the
+        # poll re-reporting the same person emits nothing a second time.
         @ctx.room.on("data_received")
         def _on_recall_event(packet) -> None:
             nonlocal _meet_cached_active_speaker
@@ -2866,28 +2941,40 @@ async def entrypoint(ctx: agents.JobContext):
                 message = json.loads(bytes(packet.data).decode("utf-8"))
             except (ValueError, UnicodeDecodeError):
                 return
-            if not isinstance(message, dict):
-                return
 
-            event_name = message.get("event") or ""
-            participant = (message.get("data") or {}).get("participant") or {}
-            name = str(participant.get("name") or "").strip()
+            event = parse_relayed_event(message)
+            if event is None or event.participant is None:
+                return
+            participant = event.participant
+            name = participant.name.strip()
             if not name or name == _meet_display_name:
                 return
 
-            if event_name == "participant_events.speech_on":
+            at = prompt_now(as_string=False).timestamp()
+            if event.name in ROSTER_EVENTS:
+                if event.name == EVENT_LEAVE:
+                    _drop_meet_participant(participant.id)
+                else:
+                    _merge_meet_participant(
+                        {
+                            "id": participant.id,
+                            "name": name,
+                            "email": participant.email,
+                            "is_host": participant.is_host,
+                        },
+                    )
+                _publish_meet_roster_changes()
+            elif event.name == EVENT_SPEECH_ON:
                 _meet_cached_active_speaker = name
-            elif event_name == "participant_events.speech_off":
+                _meet_speech_windows.speech_on(name, at)
+            elif event.name == EVENT_SPEECH_OFF:
                 # Only clear if this speaker is still the one on record, or a
                 # trailing speech_off would blank whoever started next.
                 if _meet_cached_active_speaker == name:
                     _meet_cached_active_speaker = None
-            elif event_name == "participant_events.chat_message":
-                # ``data.data.text`` -- the payload nests a second ``data``
-                # under the event's own. Reading one level short finds nothing
-                # and drops every message silently.
-                inner = (message.get("data") or {}).get("data") or {}
-                text = _strip_chat_html(str(inner.get("text") or "")).strip()
+                _meet_speech_windows.speech_off(name, at)
+            elif event.name == EVENT_CHAT_MESSAGE:
+                text = _strip_chat_html(event.chat_text or "").strip()
                 if not text:
                     return
                 chat_cls = (
@@ -2899,7 +2986,7 @@ async def entrypoint(ctx: agents.JobContext):
                     contact=contact,
                     sender_name=name,
                     content=text,
-                    sender_email=(str(participant.get("email") or "") or None),
+                    sender_email=participant.email,
                 )
                 asyncio.create_task(event_broker.publish(evt.topic, evt.to_json()))
 
@@ -3050,13 +3137,12 @@ async def entrypoint(ctx: agents.JobContext):
             # Browser-meet roster, pushed by the CM because only it holds the
             # backend credentials. Publishes join/leave so the brain knows who
             # is in the room, and feeds _get_meet_participant_names, which is
-            # what turns a diarized voice into a person's name.
+            # what names a diarized voice. Realtime join/leave events already
+            # maintain the same cache; this is the reconciliation pass that
+            # corrects it if one was missed.
             incoming = data.get("participants") or []
             if isinstance(incoming, list):
-                _meet_cached_participants.clear()
-                _meet_cached_participants.extend(
-                    [p for p in incoming if isinstance(p, dict)],
-                )
+                _reconcile_meet_roster([p for p in incoming if isinstance(p, dict)])
                 _publish_meet_roster_changes()
         elif event_type == "unify_meet_roster":
             incoming = data.get("participants") or []

--- a/unify/conversation_manager/medium_scripts/call.py
+++ b/unify/conversation_manager/medium_scripts/call.py
@@ -2070,6 +2070,7 @@ async def entrypoint(ctx: agents.JobContext):
         channel=channel,
         has_linked_user_desktop=call_has_linked_user_desktop,
         is_coordinator=SESSION_DETAILS.is_coordinator,
+        is_multiplayer=SESSION_DETAILS.is_multiplayer,
         is_org_workspace=SESSION_DETAILS.org_id is not None,
         console_ui_present=SETTINGS.UNITY_CONSOLE_UI,
     ).flatten()

--- a/unify/conversation_manager/meet_speaker_map.py
+++ b/unify/conversation_manager/meet_speaker_map.py
@@ -1,0 +1,134 @@
+"""Correlating diarized voices with the meeting platform's own speaker names.
+
+In a browser meet the fast brain learns two things from two places. The
+transcriber reports finalised utterances tagged with an anonymous diarization id
+(``S0``, ``S1``); the meeting platform reports, over the Recall relay, spans of
+who was speaking. Neither names a voice on its own, and the pairing is what lets
+a transcript row say "Ada" instead of "Speaker 1".
+
+Matching is by **overlap of time spans**, not by asking who is speaking at the
+moment a transcript finalises. A final lands after its speaker stopped talking,
+by which point the platform has already sent ``speech_off`` and -- on a call
+where people take turns -- nobody is speaking at all. Sampling the instantaneous
+speaker therefore learns nothing on a well-behaved call, and fires only when
+someone talks over the tail of the previous speaker, which is precisely when it
+is most likely to name the wrong person.
+
+Votes accumulate rather than binding on first sight: diarization ids are
+per-call and can drift or split, so a single coincidental overlap must not name
+a voice for the rest of the meeting.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# A speaking span stays matchable slightly past its end. Platform speech
+# boundaries and our own VAD boundaries are independent measurements of the same
+# speech, so they disagree by a fraction of a second in both directions; without
+# a little slack, short utterances land just outside every window and correlate
+# to nothing.
+_WINDOW_GRACE_S = 1.5
+
+# Speaking spans kept per call. Enough for a long multi-party meeting, bounded so
+# a four-hour call cannot grow this without limit.
+_MAX_WINDOWS = 256
+
+# A name must win repeatedly, and by a clear margin, before it labels a voice.
+# One overlap is noise on a call where people interrupt each other.
+MIN_VOTES = 2
+MIN_SHARE = 0.6
+
+
+@dataclass
+class _Window:
+    name: str
+    start: float
+    end: float | None = None
+
+
+class MeetSpeakerWindows:
+    """Spans of who the meeting platform said was speaking, and when.
+
+    Times are epoch seconds from one clock -- the caller's. Mixing a monotonic
+    reading with a wall-clock one silently yields zero overlap everywhere.
+    """
+
+    def __init__(self) -> None:
+        self._windows: list[_Window] = []
+
+    def speech_on(self, name: str, at: float) -> None:
+        """Open a span for ``name``.
+
+        A second ``speech_on`` with no intervening ``speech_off`` closes the
+        previous span at the same instant: a dropped ``speech_off`` would
+        otherwise leave a span open for the rest of the call, overlapping --
+        and outvoting -- every later speaker.
+        """
+        if not name:
+            return
+        self._close(name, at)
+        self._windows.append(_Window(name=name, start=at))
+        if len(self._windows) > _MAX_WINDOWS:
+            del self._windows[: len(self._windows) - _MAX_WINDOWS]
+
+    def speech_off(self, name: str, at: float) -> None:
+        """Close the open span for ``name``, if there is one."""
+        self._close(name, at)
+
+    def speaker_during(self, start: float, end: float) -> str | None:
+        """Whoever was speaking for most of ``[start, end]``.
+
+        Returns None when no span overlaps, which is the honest answer for a
+        voice the platform never reported speaking -- a phone dial-in, or a
+        relay that was down for that stretch.
+        """
+        if end < start:
+            end = start
+        best_name: str | None = None
+        best_overlap = 0.0
+        for window in self._windows:
+            window_end = window.end if window.end is not None else end
+            overlap = min(window_end + _WINDOW_GRACE_S, end) - max(window.start, start)
+            # ``>=`` so that among equal overlaps the latest span wins: spans are
+            # appended in order, and the most recent is the better guess for a
+            # just-finalised utterance.
+            if overlap > 0 and overlap >= best_overlap:
+                best_overlap = overlap
+                best_name = window.name
+        return best_name
+
+    def _close(self, name: str, at: float) -> None:
+        for window in reversed(self._windows):
+            if window.name == name and window.end is None:
+                window.end = at
+                return
+
+
+class MeetSpeakerVotes:
+    """Accumulated evidence linking a diarization id to a platform name."""
+
+    def __init__(self) -> None:
+        self._votes: dict[str, dict[str, int]] = {}
+
+    def observe(self, speaker_id: str, name: str | None) -> None:
+        """Record one utterance by ``speaker_id`` overlapping ``name``'s speech."""
+        if not speaker_id or not name:
+            return
+        bucket = self._votes.setdefault(speaker_id, {})
+        bucket[name] = bucket.get(name, 0) + 1
+
+    def resolve(self, speaker_id: str | None) -> str | None:
+        """The platform name for ``speaker_id``, once the evidence is decisive."""
+        if not speaker_id:
+            return None
+        bucket = self._votes.get(speaker_id)
+        if not bucket:
+            return None
+        top_name = max(bucket, key=lambda name: bucket[name])
+        top_votes = bucket[top_name]
+        if top_votes < MIN_VOTES:
+            return None
+        if top_votes / sum(bucket.values()) <= MIN_SHARE:
+            return None
+        return top_name

--- a/unify/conversation_manager/prompt_builders.py
+++ b/unify/conversation_manager/prompt_builders.py
@@ -31,11 +31,11 @@ COORDINATOR_NAME = "T-W1N"
 COORDINATOR_JOB_TITLE = "Coordinator"
 
 _TWIN_INTRO = """\
-I'm T dash W 1 N, written T-W1N — your personal stand-in inside Unify. I'm here for you, specifically. When you connect your workspace, I act through your accounts and show up as you, not as a separate identity on the side. Other colleagues you set up later may have their own mailbox, phone, and scope. I'm a generalist who carries your context and helps with whatever is actually on your plate.
+{intro_identity} I'm a generalist who carries your context and helps with whatever is actually on your plate.
 
 I treat the first stretch of our working relationship as discovery. I want to understand your world — what fills your week, what's been on your list that you keep meaning to get to, the shape of your team and your stack, the things that have been quietly draining your time. I won't grill you with an intake form; that's the wrong dynamic. But as natural moments arise, I'll ask the question that would let me show up better next time. I listen for friction — when you mention something is a hassle, repetitive, or has been bugging you for a while, I treat that as a hook to remember, even if you didn't explicitly ask me to fix it.
 
-What I'm best at is whatever you're trying to get done right now. Drafting a message, finding a contact, doing research, setting up an integration, walking through a setup on screen-share, prepping for a meeting, planning your week, joining a call on your behalf, coordinating across the dozen tools you already use — that's my range. When work touches a file, folder, application, website, platform, or any external system, I ground answers in live inspection through ``act`` rather than memory.
+What I'm best at is whatever you're trying to get done right now. Drafting a message, finding a contact, doing research, setting up an integration, walking through a setup on screen-share, prepping for a meeting, planning your week, {call_range_clause}coordinating across the dozen tools you already use — that's my range. When work touches a file, folder, application, website, platform, or any external system, I ground answers in live inspection through ``act`` rather than memory.
 
 The goal between us is alignment, not artifacts. Some asks are concrete and the right move is to just do them. Others have a missing decision that materially changes the answer, and the most useful thing I can do is ask one substantive question first. Others are multi-turn or role-shaped enough that I should sketch the shape — a plan, or a proposal — before grinding. Reading the situation and picking the right move is on me; you don't have to drive that. I'm honest about uncertainty: I tell you what I'm assuming and how confident I am, and I never claim something is done before it's verified.
 
@@ -49,13 +49,43 @@ For org-shaped work — shared integrations, onboarding a colleague, deciding ho
 """
 
 
-def _build_twin_intro_block() -> str:
-    """Build Twin's fixed role and personality intro for coordinator prompts."""
-    return f"""{COORDINATOR_NAME}
+def _build_twin_intro_block(
+    *,
+    is_multiplayer: bool = False,
+    twin_name: str = "",
+) -> str:
+    """Build Twin's fixed role and personality intro for coordinator prompts.
+
+    Single-player twins carry the shared T-W1N identity and never attend
+    third-party calls; multiplayer twins speak under their own name and may
+    join meetings like any colleague.
+    """
+    if is_multiplayer:
+        display_name = twin_name or COORDINATOR_NAME
+        intro_identity = (
+            f"I'm {display_name} \u2014 your personal stand-in inside Unify, running "
+            "under my own outward identity. I'm here for you, specifically. When "
+            "you connect your workspace, I act through your accounts for "
+            "workspace work \u2014 and I also carry my own email address and "
+            "channels, so your colleagues and outside contacts can reach me "
+            "directly."
+        )
+        call_range_clause = "joining a call on your behalf, "
+    else:
+        display_name = COORDINATOR_NAME
+        intro_identity = (
+            "I'm T dash W 1 N, written T-W1N \u2014 your personal stand-in inside "
+            "Unify. I'm here for you, specifically. When you connect your "
+            "workspace, I act through your accounts and show up as you, not as "
+            "a separate identity on the side. Other colleagues you set up later "
+            "may have their own mailbox, phone, and scope."
+        )
+        call_range_clause = ""
+    return f"""{display_name}
 ----
 Role / specialization: {COORDINATOR_JOB_TITLE}.
 
-{_TWIN_INTRO}"""
+{_TWIN_INTRO.format(intro_identity=intro_identity, call_range_clause=call_range_clause)}"""
 
 
 def _build_user_about_block(user_about: str) -> str:
@@ -213,11 +243,22 @@ def _build_twin_external_identity_block(*, first_name: str, surname: str) -> str
 {COORDINATOR_NAME} is {user_name}'s personal, private assistant. {COORDINATOR_NAME} has privileged access to {user_name}'s own personal workspace and may have access to {user_name}'s inbox, calendar, files, folders, and organization workspace resources when {user_name} has granted approval. {COORDINATOR_NAME} can invite team members, create teams, and hire assistants. {COORDINATOR_NAME} works directly with {user_name}; he does not communicate with other people."""
 
 
-def _build_twin_self_identity_block(*, first_name: str, surname: str) -> str:
+def _build_twin_self_identity_block(
+    *,
+    first_name: str,
+    surname: str,
+    is_multiplayer: bool = False,
+    twin_name: str = "",
+) -> str:
     user_name = _user_display_name(first_name, surname)
+    if is_multiplayer:
+        display_name = twin_name or COORDINATOR_NAME
+        return f"""My identity
+-----------
+I am {display_name}, {user_name}'s personal assistant in multiplayer mode. I have privileged access to {user_name}'s own personal workspace and may have access to {user_name}'s inbox, calendar, files, folders, and organization workspace resources when {user_name} has granted approval. I can invite team members, create teams, and hire assistants. {user_name} is my boss and priority, and I also communicate with other people directly \u2014 my email address and contact channels are my own, so anyone can reach me and I can reach them, like any colleague."""
     return f"""My identity
 -----------
-I am {COORDINATOR_NAME}, {user_name}'s personal, private assistant. I have privileged access to {user_name}'s own personal workspace and may have access to {user_name}'s inbox, calendar, files, folders, and organization workspace resources when {user_name} has granted approval. I can invite team members, create teams, and hire assistants. I work directly with {user_name}; I do not communicate with other people."""
+I am {COORDINATOR_NAME}, {user_name}'s personal, private assistant. I have privileged access to {user_name}'s own personal workspace and may have access to {user_name}'s inbox, calendar, files, folders, and organization workspace resources when {user_name} has granted approval. I can invite team members, create teams, and hire assistants. I work directly with {user_name}; I do not communicate with other people \u2014 on any channel, through any path. I never message, call, email, or meet anyone but {user_name}, and I cannot join Google Meet or Microsoft Teams meetings at all."""
 
 
 def _build_authorized_humans_block(
@@ -431,6 +472,7 @@ def _build_voice_session_scenarios(
     *,
     assistant_has_phone: bool,
     assistant_has_whatsapp: bool,
+    include_meets: bool = True,
 ) -> str:
     """Build voice-session scenario guidance (mutual exclusion + call etiquette).
 
@@ -440,8 +482,13 @@ def _build_voice_session_scenarios(
     "announce before calling" etiquette line is gated on the assistant actually
     having a phone or WhatsApp calling channel.
     """
+    session_types = (
+        "a phone call, a WhatsApp call, a Unify Meet, a Google Meet, or a Microsoft Teams meeting"
+        if include_meets
+        else "a phone call, a WhatsApp call, or a Unify Meet"
+    )
     lines = [
-        "- I can only be on ONE voice session at a time — a phone call, a WhatsApp call, a Unify Meet, a Google Meet, or a Microsoft Teams meeting. I cannot start or join another while one is already live. If my boss asks me to, I tell them I will do it once the current session ends, then do it then — I never claim to have started it while still on the current one.",
+        f"- I can only be on ONE voice session at a time — {session_types}. I cannot start or join another while one is already live. If my boss asks me to, I tell them I will do it once the current session ends, then do it then — I never claim to have started it while still on the current one.",
         "- When I place a call that I expect to be short — a single question and answer, delivering a message, a quick confirmation — I pass `allow_hang_up` with a one-line reason so the live voice can end the call the moment it naturally closes, with no delay waiting on me. If such a call turns into a longer, fluid conversation, I take the permission back mid-call with `withdraw_hang_up`; for open-ended calls I leave `allow_hang_up` unset and grant it later (via `allow_hang_up`) once the conversation is clearly wrapping up.",
     ]
     if assistant_has_phone or assistant_has_whatsapp:
@@ -455,6 +502,7 @@ def _build_voice_session_scenarios(
 def _build_active_voice_session_block(
     *,
     hang_up_gate_reason: str | None = None,
+    include_meets: bool = True,
 ) -> str:
     """Explain the one-voice-session-at-a-time constraint while a call is live.
 
@@ -470,10 +518,20 @@ def _build_active_voice_session_block(
 - Ending this session: `hang_up` ends it immediately (only for an explicit "hang up now" or to recover a broken line)."""
     else:
         ending_lines = """- Ending this session: when the conversation is clearly wrapping up, I use `allow_hang_up` with a short reason — this sanctions the close, and the live voice ends the call at the natural moment (after goodbyes) without cutting anyone off. I can take it back later with `withdraw_hang_up` if the conversation moves on. I use `hang_up` (immediate) only when my boss explicitly asks me to hang up / end the call / leave the meeting right now, or to recover a broken session."""
+    session_types = (
+        "a phone call, a WhatsApp call, a Unify Meet, a Google Meet, or a Microsoft Teams meeting"
+        if include_meets
+        else "a phone call, a WhatsApp call, or a Unify Meet"
+    )
+    call_start_tools = (
+        "`make_call`, `make_whatsapp_call`, `join_google_meet`, `join_teams_meet`"
+        if include_meets
+        else "`make_call`, `make_whatsapp_call`"
+    )
     return f"""Active voice session
 --------------------
-I am currently on a live voice session, and I can only be on ONE voice session at a time — whether that is a phone call, a WhatsApp call, a Unify Meet, a Google Meet, or a Microsoft Teams meeting. Because of this:
-- The call-starting tools (`make_call`, `make_whatsapp_call`, `join_google_meet`, `join_teams_meet`) are intentionally NOT in my tool list right now. This is expected, not a malfunction.
+I am currently on a live voice session, and I can only be on ONE voice session at a time — whether that is {session_types}. Because of this:
+- The call-starting tools ({call_start_tools}) are intentionally NOT in my tool list right now. This is expected, not a malfunction.
 - They reappear automatically the moment this session ends — I do not need to do anything special to get them back.
 - If my boss asks me to start another call or join another meeting while this one is live, I tell them I will do it as soon as the current session ends — I do NOT claim to have started it, and I do NOT keep retrying.
 {ending_lines}
@@ -762,12 +820,13 @@ def _build_comms_tool_listing(
                 "`briefing` with unspoken context so the live voice can run the "
                 "call's task itself.",
             )
-            lines.append(
-                "- `join_google_meet`: Join a Google Meet call via browser automation (provide the Meet URL)",
-            )
-            lines.append(
-                "- `join_teams_meet`: Join a Microsoft Teams meeting via browser automation (provide the Teams meeting URL)",
-            )
+        lines.append(
+            "- NOTE: I cannot join Google Meet or Microsoft Teams meetings on "
+            "any path \u2014 browser meetings are multi-party spaces and I am a "
+            "single-player twin. If my boss wants an assistant in a meeting, "
+            "that is a job for multiplayer mode (enabled in Settings) or a "
+            "hired colleague.",
+        )
         return _finalize(lines)
 
     if assistant_has_phone:
@@ -912,8 +971,34 @@ def _build_coordinator_admin_tool_listing(*, is_org_workspace: bool) -> str:
     return "\n".join(lines)
 
 
-def _build_coordinator_act_query_guidance_block() -> str:
-    """Build Twin-specific guidance for composing ``act`` queries."""
+def _build_coordinator_act_query_guidance_block(
+    *,
+    is_multiplayer: bool = False,
+) -> str:
+    """Build Twin-specific guidance for composing ``act`` queries.
+
+    The third-party-communication bullet is the mode fork: single-player
+    twins have no third-party path anywhere (the comms layer refuses it),
+    while multiplayer twins use their direct tools like any colleague and
+    need no ``act`` detour for outreach.
+    """
+    if is_multiplayer:
+        third_party_comms_bullet = (
+            "- Direct communication tools reach anyone; use them for outreach "
+            "rather than routing sends through ``act``. Reserve ``act`` for "
+            "cross-domain execution, validation reads, and delegated "
+            "follow-up.\n"
+        )
+    else:
+        third_party_comms_bullet = (
+            "- I never communicate with third parties on any path \u2014 direct "
+            "tools and ``act`` alike. ``act`` plans must not attempt "
+            "messages, calls, meetings, or invites to anyone but my boss; "
+            "the comms layer refuses them with an error. When my boss wants "
+            "a third party contacted, I draft the content for my boss to "
+            "send themselves, or suggest enabling multiplayer mode in "
+            "Settings.\n"
+        )
     return f"""{COORDINATOR_NAME} act query guidance
 -----------------------
 When composing ``act`` queries for colleague lifecycle, workspace setup,
@@ -932,11 +1017,7 @@ delegated follow-up, or any external resource work:
   through ``primitives.coordinator.delegate_to_colleague`` inside ``act``.
   Do not ask the Actor to create coordinator-owned fallback tasks when
   delegation is the correct handoff.
-- Direct communication tools are only for speaking with my boss. If my boss
-  asks or explicitly permits me to draft a message/reply, send a message,
-  place a call, or invite someone else on their behalf, do that third-party
-  communication through ``act`` instead of direct communication tools.
-- ``delegate_to_colleague`` returns an async delegation receipt
+{third_party_comms_bullet}- ``delegate_to_colleague`` returns an async delegation receipt
   (``accepted``, ``completion_status``, ``receipt_type``, ``message``), not
   proof that the colleague already created tasks, queued messages, or finished
   the assignment. Do **not** instruct the Actor to verify the colleague's
@@ -1053,12 +1134,6 @@ def _build_coordinator_onboarding_narration_block() -> str:
             "  - `your_computer_beat_requested`: the user clicked the Their Computer "
             "demo row — fetch a file from their own linked computer (chat- or "
             "call-native; no ring); mark complete only after confirmed delivery.",
-            "  - `workspace_call_beat_requested`: the user clicked the workspace "
-            "video-call row — I never create the meeting; ask them to start a "
-            "Google Meet or Microsoft Teams call and paste the link, then join "
-            "with `join_google_meet` (meet.google.com) or `join_teams_meet` "
-            "(teams.microsoft.com) and talk live; mark complete only after I have "
-            "actually joined and spoken.",
             "Rules for `onboarding_step_started`:",
             "  A. Read the active step id from the notification body (`step_id`) and "
             "match it against the authoritative 'My onboarding progress (live)' block. "
@@ -1969,15 +2044,25 @@ Examples of questions that should trigger `act`:
 def _build_conversational_vs_programmatic_comms_block(
     *,
     is_coordinator: bool = False,
+    is_multiplayer: bool = False,
 ) -> str:
     """Split live conversation (CM tools) from programmatic mailbox/workspace work."""
-    if is_coordinator:
+    if is_coordinator and is_multiplayer:
         ownership = (
-            f"Connected Google/Microsoft Workspace is **my boss's**. "
-            f"Programmatic mailbox/calendar/drive automation via ``act`` "
-            f"operates on their account. Direct CM communication tools remain "
-            f"boss-only; third-party conversational sends follow the "
-            f"{COORDINATOR_NAME} guidelines (``act``), not this mailbox-automation path."
+            "Connected Google/Microsoft Workspace is **my boss's**. "
+            "Programmatic mailbox/calendar/drive automation via ``act`` "
+            "operates on their account. My conversational identity (email, "
+            "phone, channels) is my own: conversational sends use my CM "
+            "communication tools and reach anyone."
+        )
+    elif is_coordinator:
+        ownership = (
+            "Connected Google/Microsoft Workspace is **my boss's**. "
+            "Programmatic mailbox/calendar/drive automation via ``act`` "
+            "operates on their account. Direct CM communication tools remain "
+            "boss-only, and I have no third-party conversational path at all "
+            "\u2014 mailbox automation on my boss's account is workspace labor, "
+            "not communication from me."
         )
     else:
         ownership = (
@@ -2389,6 +2474,8 @@ def build_system_prompt(
     assistant_has_teams: bool = False,
     assistant_has_ms_teams_bot: bool = False,
     is_coordinator: bool = False,
+    is_multiplayer: bool = False,
+    twin_name: str = "",
     has_linked_user_desktop: bool = False,
     user_filesys_consented: bool = False,
     user_filesys_available: bool = False,
@@ -2483,6 +2570,12 @@ def build_system_prompt(
         Shared teams available to the assistant for memory routing.
     is_coordinator : bool
         Whether the current assistant is a Coordinator session.
+    is_multiplayer : bool
+        Whether the Coordinator runs in multiplayer mode (hire-like comms
+        surface, open audience). The private boss-only surface applies only
+        when ``is_coordinator and not is_multiplayer``.
+    twin_name : str
+        The multiplayer twin's own display name (used in identity blocks).
     authorized_humans : list[dict[str, Any]] | None
         Organization roster context for org-scoped Coordinator sessions.
     is_org_workspace : bool
@@ -2494,6 +2587,7 @@ def build_system_prompt(
         Structured prompt parts (call .to_list() for LLM, .flatten() for plain string).
     """
     # Build reusable blocks using internal helpers
+    private_coordinator = is_coordinator and not is_multiplayer
     coordinator_has_org_context = is_coordinator and is_org_workspace
 
     boss_details = _build_boss_details_block(
@@ -2525,6 +2619,7 @@ def build_system_prompt(
     voice_session_scenarios = _build_voice_session_scenarios(
         assistant_has_phone=assistant_has_phone,
         assistant_has_whatsapp=assistant_has_whatsapp,
+        include_meets=not private_coordinator,
     )
     missing_phone_notice = _build_missing_phone_notice(assistant_has_phone)
     missing_email_notice = _build_missing_email_notice(assistant_has_email)
@@ -2532,10 +2627,10 @@ def build_system_prompt(
         assistant_has_whatsapp,
     )
     slack_guidelines = _build_slack_guidelines(
-        assistant_has_slack and not is_coordinator,
+        assistant_has_slack and not private_coordinator,
     )
     ms_teams_bot_guidelines = _build_ms_teams_bot_guidelines(
-        assistant_has_ms_teams_bot and not is_coordinator,
+        assistant_has_ms_teams_bot and not private_coordinator,
     )
     coordinator_guidelines = _build_coordinator_guidelines(is_coordinator)
     # Reference-quiz comms tools withheld until the user clicks the channel's
@@ -2557,7 +2652,7 @@ def build_system_prompt(
         assistant_has_slack=assistant_has_slack,
         assistant_has_teams=assistant_has_teams,
         assistant_has_ms_teams_bot=assistant_has_ms_teams_bot,
-        is_coordinator=is_coordinator,
+        is_coordinator=private_coordinator,
         on_voice_call=on_voice_call,
         outbound_voice_line_ready=outbound_voice_line_ready,
         onboarding_masked_tools=onboarding_masked_tools,
@@ -2571,21 +2666,26 @@ def build_system_prompt(
         assistant_has_slack,
         assistant_has_teams,
         assistant_has_ms_teams_bot,
-        is_coordinator,
+        private_coordinator,
         on_voice_call,
         call_line_ready=outbound_voice_line_ready,
         masked_tools=onboarding_masked_tools,
+    )
+    meet_session_clause = (
+        ""
+        if private_coordinator
+        else " or join a Google Meet / Microsoft Teams meeting"
     )
     if assistant_has_phone or assistant_has_whatsapp:
         sms_call_note = (
             " I can keep sending text messages (SMS, WhatsApp messages, email, Unify messages) during a voice"
             " session, but I can only be on one voice session at a time — I cannot start a phone or WhatsApp call"
-            " or join a Google Meet / Microsoft Teams meeting while already on one (and vice versa)."
+            f"{meet_session_clause} while already on one (and vice versa)."
         )
     else:
         sms_call_note = (
-            " I can only be on one voice session at a time — I cannot start a call or join a Google Meet /"
-            " Microsoft Teams meeting while already on one (and vice versa)."
+            " I can only be on one voice session at a time — I cannot start a call"
+            f"{meet_session_clause} while already on one (and vice versa)."
         )
     input_format_example = _build_input_format_example()
     coordinator_admin_tool_listing = ""
@@ -2601,7 +2701,9 @@ def build_system_prompt(
         )
         coordinator_knowledge_tool_listing = _build_coordinator_knowledge_tool_listing()
         coordinator_act_query_guidance_block = (
-            _build_coordinator_act_query_guidance_block()
+            _build_coordinator_act_query_guidance_block(
+                is_multiplayer=is_multiplayer,
+            )
         )
         # Console-UI guidance is only meaningful when a Console front-end
         # exists. The public local install has no Console, so these blocks
@@ -2697,11 +2799,18 @@ def build_system_prompt(
 
     # 2. Role + identity. Twin sessions carry a fixed intro; user about is optional.
     if is_coordinator:
-        parts.add(_build_twin_intro_block())
+        parts.add(
+            _build_twin_intro_block(
+                is_multiplayer=is_multiplayer,
+                twin_name=twin_name,
+            ),
+        )
         parts.add(
             _build_twin_self_identity_block(
                 first_name=first_name,
                 surname=surname,
+                is_multiplayer=is_multiplayer,
+                twin_name=twin_name,
             ),
         )
         user_about = (bio or "").strip()
@@ -2788,6 +2897,7 @@ Messages from the current turn have **NEW** tag prepended:
     parts.add(
         _build_conversational_vs_programmatic_comms_block(
             is_coordinator=is_coordinator,
+            is_multiplayer=is_multiplayer,
         ),
     )
     parts.add(_build_external_resources_act_block())
@@ -2852,12 +2962,12 @@ Messages from the current turn have **NEW** tag prepended:
         + (f"\n{coordinator_guidelines}" if coordinator_guidelines else "")
     )
 
-    if is_coordinator:
+    if private_coordinator:
         direct_tool_names_str = ", ".join(available_tool_names)
-        communication_target_block = f"""**Boss-only direct communication:**
+        communication_target_block = f"""**Boss-only communication:**
 - Direct communication tools ({direct_tool_names_str}) are only for communicating directly with my boss. They do not accept ``contact_id`` and always target the boss contact (``contact_id==1`` in the normal runtime).
-- I cannot directly message, call, email, invite, or post to anyone else from this surface.
-- If my boss asks or explicitly permits me to draft a message/reply, send a message, place a call, or invite someone else on their behalf, I use ``act``. ``act`` is the execution path for delegated third-party communication work.
+- I cannot message, call, email, invite, or post to anyone else on ANY path — direct tools and ``act`` alike. The comms layer refuses third-party sends with an error.
+- When my boss wants a third party contacted, I draft the content for my boss to send themselves, or suggest enabling multiplayer mode in Settings if they want me communicating externally.
 - If my boss wants to add or change their own contact details (phone number, email address, WhatsApp number, Slack user ID, Discord ID), I update the boss contact record first, then use the direct tool after the detail is persisted. Direct tools never accept inline contact details."""
     else:
         contact_addressed_tool_names = [
@@ -2913,13 +3023,13 @@ Messages from the current turn have **NEW** tag prepended:
 - When I must use `act` only for contact lookup (rare), scope it to return contact_id and address, then on action completion I still own the outbound send — call `send_email` / `send_sms` / … in that turn.
 - **Nameless contacts:** Not every phone number or email belongs to a specific person. Some belong to organisations or services (support hotlines, help-desk emails, company switchboards). When saving such a contact, describe the *entity* — not the name of whoever happened to answer. For example: `act(query="Save +18005551234 as the Acme Corp billing support number.")` — not `act(query="Add Sarah with number +18005551234.")`. Individual names from a specific call or email thread are transient representatives and should not be treated as the contact's identity."""
 
-    if is_coordinator:
+    if private_coordinator:
         response_policy_block = f"""**should_respond policy:**
 The boss contact still has a `should_respond` attribute that determines whether I am permitted to send direct outbound messages to my boss:
 - If `should_respond="True"`: I can send {channels_str} to my boss.
 - If `should_respond="False"`: I CANNOT send direct outbound communication to my boss. If I attempt to do so, the system will block it and return an error.
 
-When the boss contact has `should_respond="False"`, I explain that direct communication is blocked based on the boss contact's response policy. Communication with anyone else is never handled by direct tools; actual third-party message, call, or invite work belongs in `act` when my boss asks or explicitly permits it."""
+When the boss contact has `should_respond="False"`, I explain that direct communication is blocked based on the boss contact's response policy. Communication with anyone else is not possible for me on any path."""
     else:
         response_policy_block = f"""**should_respond policy:**
 Each contact has a `should_respond` attribute (True/False) that determines whether I am permitted to send outbound messages to them:
@@ -2958,8 +3068,8 @@ Communicate naturally and casually. Keep responses short.
 
 **``guide_voice_agent`` matches the call's language.** The ``message`` passed to ``guide_voice_agent`` should be written in whichever language the assistant is currently speaking on the call. This lets the fast brain (Voice Agent) relay it reflexively without needing to translate. If no call is active or the language is unclear, default to English."""
     outbound_language_note = (
-        "**Outbound messages match my boss's language** when I communicate with my boss directly. If my boss asks me to send a message, draft a reply, place a call, or invite someone else on their behalf, that delegated third-party communication work goes through ``act``."
-        if is_coordinator
+        "**Outbound messages match my boss's language** — my boss is the only person I communicate with. Content I draft for my boss to send to someone else matches that recipient's language."
+        if private_coordinator
         else "**Outbound messages match the recipient's language**, not the sender's. If my boss writes in Spanish asking me to message Bob (who communicates in English), the message to Bob should be in English. If relaying content from one language to another, translate/paraphrase naturally."
     )
 
@@ -3024,6 +3134,7 @@ When contacts communicate in a non-English language, I match their language in m
         parts.add(
             _build_active_voice_session_block(
                 hang_up_gate_reason=hang_up_gate_reason,
+                include_meets=not private_coordinator,
             ),
             static=False,
         )
@@ -3039,12 +3150,17 @@ When contacts communicate in a non-English language, I match their language in m
     voice_session_scenarios_section = (
         f"\n{voice_session_scenarios}" if voice_session_scenarios else ""
     )
+    meet_join_scenarios = (
+        ""
+        if private_coordinator
+        else """
+- To join a Google Meet, I must always use the `join_google_meet` tool — never navigate to a Meet URL via `act`. The `join_google_meet` tool configures audio devices and establishes the voice pipeline; using `act` to visit the URL would join silently with no ability to hear or speak.
+- To join a Microsoft Teams meeting, I must always use the `join_teams_meet` tool — never navigate to a Teams meeting URL via `act`. Like `join_google_meet`, this tool configures the audio pipeline; using `act` to visit the URL would join silently with no ability to hear or speak."""
+    )
     parts.add(
         f"""Scenarios
 ---------
-- If my boss gives a wrong contact address, I will receive an error after the communication attempt, or worse, it might be a completely different person. Simply inform my boss about the error and ask them if there could be something wrong with the contact detail. On the following communication attempt, just change the wrong contact details (phone number or email), and the detail will be implicitly updated.{voice_session_scenarios_section}
-- To join a Google Meet, I must always use the `join_google_meet` tool — never navigate to a Meet URL via `act`. The `join_google_meet` tool configures audio devices and establishes the voice pipeline; using `act` to visit the URL would join silently with no ability to hear or speak.
-- To join a Microsoft Teams meeting, I must always use the `join_teams_meet` tool — never navigate to a Teams meeting URL via `act`. Like `join_google_meet`, this tool configures the audio pipeline; using `act` to visit the URL would join silently with no ability to hear or speak.""",
+- If my boss gives a wrong contact address, I will receive an error after the communication attempt, or worse, it might be a completely different person. Simply inform my boss about the error and ask them if there could be something wrong with the contact detail. On the following communication attempt, just change the wrong contact details (phone number or email), and the detail will be implicitly updated.{voice_session_scenarios_section}{meet_join_scenarios}""",
     )
 
     # 17. Current time (dynamic content — changes per call).
@@ -3129,6 +3245,7 @@ def build_voice_agent_prompt(
     channel: str = "phone",
     has_linked_user_desktop: bool = False,
     is_coordinator: bool = False,
+    is_multiplayer: bool = False,
     is_org_workspace: bool = True,
     console_ui_present: bool = True,
 ) -> PromptParts:
@@ -3252,11 +3369,18 @@ I match the caller's language.""",
     # Role. Twin sessions carry a fixed intro; the generic remote-employee role
     # block applies only to regular assistants.
     if is_coordinator:
-        parts.add(_build_twin_intro_block())
+        parts.add(
+            _build_twin_intro_block(
+                is_multiplayer=is_multiplayer,
+                twin_name=assistant_name or "",
+            ),
+        )
         parts.add(
             _build_twin_self_identity_block(
                 first_name=boss_first_name,
                 surname=boss_surname,
+                is_multiplayer=is_multiplayer,
+                twin_name=assistant_name or "",
             ),
         )
         user_about = (bio or "").strip()

--- a/unify/conversation_manager/speaker_id.py
+++ b/unify/conversation_manager/speaker_id.py
@@ -411,14 +411,21 @@ class AudioRingBuffer:
 # ─────────────────────────────────────────────────────────────────────────────
 
 
-# Provenance of a resolved speaker display label — the single documented
-# authority ordering, highest first. A transcript row carries its source so it
-# is self-describing ("is voice fingerprinting actually working?" is answerable
-# from the row alone), and the late-binding Google-Meet transcript reconciler
-# (Orchestra-side, fed by the Workspace-Events ``meet_bridge``) has one place to
-# honour: a lower source must never overwrite a name already set by a higher
-# one. ``anonymous`` is the only source that is a placeholder ("Speaker N")
-# rather than a real name — consumers key off it instead of "no voice match".
+# Provenance of a resolved speaker display label. A transcript row carries its
+# source so it is self-describing -- "is voice fingerprinting actually working?"
+# is answerable from the row alone.
+#
+# Authority ordering is expressed by the order ``_resolve_speaker`` in the call
+# script consumes these, highest first: voice pin, then platform participant,
+# then org-call roster, then the anonymous placeholder. It is deliberately not
+# also stated as a table here; two statements of one ordering drift apart, and
+# the one nothing executes is the one that goes stale.
+#
+# Stored rows from earlier runtimes carry sources no longer produced --
+# ``dom_meet_map`` and ``dom_active_speaker`` (scraped from a meeting UI in a
+# browser we no longer run) and ``google_meet_transcript``. Readers should treat
+# an unrecognised source as a real name of unknown provenance, ranked below the
+# ones above.
 LABEL_SOURCE_VOICE_PIN = "voice_pin"
 # The meeting platform's own name for a participant, reported by the meeting
 # backend rather than read off the screen. Ranked above ``meet_roster`` because
@@ -427,23 +434,9 @@ LABEL_SOURCE_VOICE_PIN = "voice_pin"
 # display name does not.
 LABEL_SOURCE_RECALL_PARTICIPANT = "recall_participant"
 LABEL_SOURCE_MEET_ROSTER = "meet_roster"
-LABEL_SOURCE_GOOGLE_MEET_TRANSCRIPT = "google_meet_transcript"
-# No longer produced -- both came from scraping the meeting UI in a browser we
-# no longer run. Kept because historical transcript rows carry them and the
-# ordering below is what stops a lower source overwriting a higher one.
-LABEL_SOURCE_DOM_MEET_MAP = "dom_meet_map"
-LABEL_SOURCE_DOM_ACTIVE_SPEAKER = "dom_active_speaker"
+# The only source that is a placeholder ("Speaker N") rather than a real name --
+# consumers key off it instead of "no voice match".
 LABEL_SOURCE_ANONYMOUS = "anonymous"
-
-LABEL_SOURCE_PRECEDENCE = (
-    LABEL_SOURCE_VOICE_PIN,
-    LABEL_SOURCE_RECALL_PARTICIPANT,
-    LABEL_SOURCE_MEET_ROSTER,
-    LABEL_SOURCE_GOOGLE_MEET_TRANSCRIPT,
-    LABEL_SOURCE_DOM_MEET_MAP,
-    LABEL_SOURCE_DOM_ACTIVE_SPEAKER,
-    LABEL_SOURCE_ANONYMOUS,
-)
 
 
 @dataclass
@@ -456,9 +449,8 @@ class SpeakerResolution:
     id spans more than one voice cluster, so downstream consumers know the
     diarization id alone is not a reliable speaker key. ``source`` records how
     the identity was derived (``LABEL_SOURCE_VOICE_PIN`` for an embedding match,
-    ``LABEL_SOURCE_ANONYMOUS`` for a minted "Speaker N"); higher-authority
-    sources (roster, DOM, recorded transcript) are stamped one level up in the
-    call script, not here.
+    ``LABEL_SOURCE_ANONYMOUS`` for a minted "Speaker N"); the platform-reported
+    sources are stamped one level up in the call script, not here.
     """
 
     contact_id: Optional[int] = None

--- a/unify/gateway/adapters/common.py
+++ b/unify/gateway/adapters/common.py
@@ -15,7 +15,7 @@ ADMIN_CONTACT_LOOKUP_FROM_FIELDS = (
     "agent_id,api_key,secrets,email,email_provider,phone,user_id,user_email,"
     "user_first_name,user_last_name,user_phone,user_whatsapp_number,"
     "assistant_whatsapp_number,self_contact_id,boss_contact_id,team_ids,"
-    "is_coordinator,organization_id,voice_id,voice_provider,first_name,"
+    "is_coordinator,is_multiplayer,organization_id,voice_id,voice_provider,first_name,"
     "surname,deploy_env,desktop_mode,managed_desktop_status,user_desktops,is_local,"
     "assistant_discord_bot_id,assistant_slack_bot_user_id,assistant_slack_team_id,"
     "age,nationality,"
@@ -120,6 +120,7 @@ def _local_assistant_data(assistant_id: str | None = None) -> dict[str, Any]:
         "self_contact_id": 0,
         "boss_contact_id": 1,
         "is_coordinator": False,
+        "is_multiplayer": False,
     }
 
 
@@ -168,6 +169,7 @@ def _assistant_payload(assistant: dict[str, Any]) -> dict[str, Any]:
         "self_contact_id": assistant.get("self_contact_id", 0),
         "boss_contact_id": assistant.get("boss_contact_id", 1),
         "is_coordinator": assistant.get("is_coordinator", False),
+        "is_multiplayer": assistant.get("is_multiplayer", False),
         "org_id": assistant.get("organization_id"),
     }
 

--- a/unify/gateway/channels/gmail/views.py
+++ b/unify/gateway/channels/gmail/views.py
@@ -189,6 +189,26 @@ def _workspace_admin_subject(credentials: CredentialStore) -> str:
     return credentials.get_optional("WORKSPACE_ADMIN_SUBJECT", "dan@unify.ai")
 
 
+def is_twin_alias_address(address: str | None) -> bool:
+    """Whether an address lives on the multiplayer twin alias domain."""
+    domain = (SETTINGS.UNITY_TWIN_ALIAS_EMAIL_DOMAIN or "").strip().lower()
+    if not domain or not address:
+        return False
+    return address.strip().lower().endswith(f"@{domain}")
+
+
+def _delegation_subject(sender_email: str) -> str:
+    """Workspace user impersonated for Gmail operations on this address.
+
+    Twin alias addresses have no Workspace user behind them — they are
+    catch-all deliveries into the shared alias mailbox — so delegation
+    targets that mailbox while the From header keeps the alias.
+    """
+    if is_twin_alias_address(sender_email):
+        return SETTINGS.UNITY_TWIN_ALIAS_MAILBOX
+    return sender_email
+
+
 def _gmail_topic_path(topic_name: str | None = None) -> str:
     """Fully qualified Pub/Sub topic path for Gmail watches.
 
@@ -216,13 +236,21 @@ def _gmail_service_from_assistant(
     assistant: dict,
     credentials: CredentialStore,
 ) -> Any:
-    access_token = assistant.get("secrets", {}).get("GOOGLE_ACCESS_TOKEN")
-    if access_token:
-        return build("gmail", "v1", credentials=OAuthCredentials(token=access_token))
+    # Alias senders never use BYOD tokens: a multiplayer twin's stored
+    # GOOGLE_ACCESS_TOKEN belongs to its boss's workspace, and sending the
+    # twin's own mail through the boss's Gmail would be identity bleed.
+    if not is_twin_alias_address(sender_email):
+        access_token = assistant.get("secrets", {}).get("GOOGLE_ACCESS_TOKEN")
+        if access_token:
+            return build(
+                "gmail",
+                "v1",
+                credentials=OAuthCredentials(token=access_token),
+            )
 
     creds = _service_account_credentials(
         scopes=_GMAIL_SCOPES,
-        subject=sender_email,
+        subject=_delegation_subject(sender_email),
         credentials=credentials,
     )
     return build("gmail", "v1", credentials=creds)
@@ -264,7 +292,7 @@ async def get_gmail_service_async(
         )
         creds = _service_account_credentials(
             scopes=_GMAIL_SCOPES,
-            subject=sender_email,
+            subject=_delegation_subject(sender_email),
             credentials=credentials,
         )
         return build("gmail", "v1", credentials=creds)
@@ -275,7 +303,7 @@ async def get_gmail_service_async(
         )
         creds = _service_account_credentials(
             scopes=_GMAIL_SCOPES,
-            subject=sender_email,
+            subject=_delegation_subject(sender_email),
             credentials=credentials,
         )
         return build("gmail", "v1", credentials=creds)
@@ -296,7 +324,7 @@ def get_gmail_service(
     credentials = credentials or EnvCredentialStore()
     creds = _service_account_credentials(
         scopes=_GMAIL_SCOPES,
-        subject=sender_email,
+        subject=_delegation_subject(sender_email),
         credentials=credentials,
     )
     return build("gmail", "v1", credentials=creds)

--- a/unify/gateway/common/orchestra.py
+++ b/unify/gateway/common/orchestra.py
@@ -19,7 +19,7 @@ ADMIN_CONTACT_LOOKUP_FROM_FIELDS = (
     "agent_id,api_key,secrets,email,email_provider,phone,user_id,user_email,"
     "user_first_name,user_last_name,user_phone,user_whatsapp_number,"
     "assistant_whatsapp_number,self_contact_id,boss_contact_id,team_ids,"
-    "is_coordinator,organization_id,voice_id,voice_provider,first_name,"
+    "is_coordinator,is_multiplayer,organization_id,voice_id,voice_provider,first_name,"
     "surname,deploy_env,desktop_mode,user_desktops,is_local,"
     "assistant_discord_bot_id,assistant_slack_bot_user_id,assistant_slack_team_id,"
     "age,nationality,"

--- a/unify/session_details.py
+++ b/unify/session_details.py
@@ -280,6 +280,10 @@ class AssistantDetails:
     slack_team_id: str = ""
     has_ms_teams_bot: bool = False
     is_coordinator: bool = False
+    # Coordinator multiplayer mode: hire-like comms surface and open audience
+    # instead of the private boss-only surface. Meaningful only when
+    # is_coordinator is True.
+    is_multiplayer: bool = False
     # Default LLM as a unillm 'model@provider' endpoint plus a reasoning-effort
     # level. Empty = platform default (UNIFY_MODEL and per-call-site efforts).
     default_model: str = ""
@@ -487,6 +491,20 @@ class SessionDetails:
         self.assistant.is_coordinator = value
 
     @property
+    def is_multiplayer(self) -> bool:
+        """Shortcut to assistant.is_multiplayer for role-gated runtime behavior."""
+        return self.assistant.is_multiplayer
+
+    @is_multiplayer.setter
+    def is_multiplayer(self, value: bool) -> None:
+        self.assistant.is_multiplayer = value
+
+    @property
+    def is_private_coordinator(self) -> bool:
+        """A coordinator still in single-player mode: boss-only on every channel."""
+        return self.assistant.is_coordinator and not self.assistant.is_multiplayer
+
+    @property
     def self_contact_id(self) -> int:
         """Shortcut to assistant.self_contact_id for convenient access."""
         return self.assistant.self_contact_id
@@ -577,6 +595,7 @@ class SessionDetails:
         managed_desktop_status: str | None = None,
         user_desktops: "list[UserDesktopLink | dict] | dict[str, UserDesktopLink | dict] | None" = None,
         is_coordinator: bool = False,
+        is_multiplayer: bool = False,
     ) -> None:
         """Populate the session with runtime values.
 
@@ -599,6 +618,7 @@ class SessionDetails:
         self.assistant.slack_team_id = _runtime_str(assistant_slack_team_id)
         self.assistant.has_ms_teams_bot = bool(assistant_has_ms_teams_bot)
         self.assistant.is_coordinator = is_coordinator
+        self.assistant.is_multiplayer = is_multiplayer
         self.assistant.contact_id = assistant_contact_id
         self.self_contact_id = assistant_self_contact_id
         self.assistant.binding_id = _runtime_str(binding_id)
@@ -690,6 +710,7 @@ class SessionDetails:
             self.assistant.user_desktops,
         )
         os.environ["ASSISTANT_IS_COORDINATOR"] = str(self.assistant.is_coordinator)
+        os.environ["ASSISTANT_IS_MULTIPLAYER"] = str(self.assistant.is_multiplayer)
         os.environ["ASSISTANT_DEFAULT_MODEL"] = _runtime_str(
             self.assistant.default_model,
         )

--- a/unify/settings.py
+++ b/unify/settings.py
@@ -100,6 +100,12 @@ class ProductionSettings(BaseSettings):
     # ─────────────────────────────────────────────────────────────────────────
     ORCHESTRA_URL: str = "https://api.unify.ai/v0"
     UNITY_COORDINATOR_EMAIL_ADDRESS: str = "twin@unify.ai"
+    # Catch-all domain for multiplayer twin alias addresses, and the Workspace
+    # mailbox that receives them. Alias addresses have no Workspace user of
+    # their own: reads and sends delegate to the mailbox while the From header
+    # keeps the alias.
+    UNITY_TWIN_ALIAS_EMAIL_DOMAIN: str = "twins.unify.ai"
+    UNITY_TWIN_ALIAS_MAILBOX: str = "twins@unify.ai"
 
     # ─────────────────────────────────────────────────────────────────────────
     # Builtins Catalogue

--- a/unify/task_scheduler/machine_state.py
+++ b/unify/task_scheduler/machine_state.py
@@ -750,19 +750,24 @@ def find_running_execution_for_task(
     *,
     task_id: int,
     destination: str | None = None,
+    states: tuple[ExecutionState, ...] = _OPEN_EXECUTION_STATES,
 ) -> TaskExecutionSnapshot | None:
-    """Return an open execution for one task, whatever assistant owns it.
+    """Return an execution in one of ``states`` for one task, whatever assistant owns it.
 
     ``get_open_task_execution`` is assistant-scoped and returns ``None`` when
     the session has no assistant context. "Is a run in flight for this task?"
     must not depend on who is asking, so this queries by ``task_id`` alone —
     the definition it guards is a single row shared by every assistant that
     can execute it.
+
+    ``states`` defaults to the full open-state set (``scheduled``,
+    ``triggerable``, ``running``) so existing callers are unaffected; pass a
+    narrower tuple to match only a subset, e.g. genuinely ``running`` rows.
     """
 
     filter_clauses = [
         f"task_id == {int(task_id)}",
-        _open_execution_state_filter(),
+        _open_execution_state_filter(states),
     ]
     normalized_destination = _canonical_destination_or_none(destination)
     if normalized_destination is not None:
@@ -966,12 +971,12 @@ def _execution_store() -> TasksStore:
     )
 
 
-def _open_execution_state_filter() -> str:
-    """Return a filter clause matching open execution states."""
+def _open_execution_state_filter(
+    states: tuple[ExecutionState, ...] = _OPEN_EXECUTION_STATES,
+) -> str:
+    """Return a filter clause matching the given execution states."""
 
-    quoted = " or ".join(
-        f"state == '{state.value}'" for state in _OPEN_EXECUTION_STATES
-    )
+    quoted = " or ".join(f"state == '{state.value}'" for state in states)
     return f"({quoted})"
 
 

--- a/unify/task_scheduler/offline_runner.py
+++ b/unify/task_scheduler/offline_runner.py
@@ -214,7 +214,12 @@ def _load_config_from_env() -> OfflineTaskConfig:
             or "Execute dashboard action"
         )
     else:
-        revision = _require_env("UNITY_OFFLINE_TASK_REVISION")
+        # Empty is a legitimate revision, not a missing one: the machine-state
+        # contract stores ``str(revision or "")`` and digests that exact value
+        # into ``run_key``, and a task with no authored ``task_revision`` (every
+        # deployment-reconciled definition) projects its occurrences with "".
+        # Requiring non-empty here boot-crashed each of those runs at dispatch.
+        revision = os.environ.get("UNITY_OFFLINE_TASK_REVISION", "").strip()
         request = _require_env("UNITY_OFFLINE_TASK_REQUEST")
     return OfflineTaskConfig(
         assistant_id=_require_env("ASSISTANT_ID"),

--- a/unify/task_scheduler/task_scheduler.py
+++ b/unify/task_scheduler/task_scheduler.py
@@ -1630,14 +1630,25 @@ class TaskScheduler(BaseTaskScheduler):
             )
         return int(log_objs[0].id) if log_objs else None
 
-    def _running_execution(self, task_id: int) -> Any | None:
-        """The open execution for one definition, if a run is in flight."""
+    def _running_execution(
+        self,
+        task_id: int,
+        *,
+        states: tuple[ExecutionState, ...] | None = None,
+    ) -> Any | None:
+        """The execution for one definition matching ``states``, if any.
+
+        Defaults to the full open-state set (scheduled/triggerable/running).
+        """
 
         task = self._get_task_or_raise(task_id)
-        return find_running_execution_for_task(
-            task_id=int(task_id),
-            destination=task.destination,
-        )
+        kwargs: Dict[str, Any] = {
+            "task_id": int(task_id),
+            "destination": task.destination,
+        }
+        if states is not None:
+            kwargs["states"] = states
+        return find_running_execution_for_task(**kwargs)
 
     def _cancel_open_executions(self, task_id: int) -> None:
         """Terminalize any run still in flight for one definition."""
@@ -1657,16 +1668,21 @@ class TaskScheduler(BaseTaskScheduler):
         )
 
     def _ensure_not_active_task(self, task_ids: Union[int, List[int]]) -> None:
-        """Guard against mutating a definition whose run is in flight.
+        """Guard against mutating a definition with a genuinely running execution.
 
         Reads ``Tasks/Executions`` rather than the definition: whether a run is
-        happening is a fact about the run.
+        happening is a fact about the run. Scoped to ``running`` only —
+        ``scheduled``/``triggerable`` rows (e.g. an armed provider-event task)
+        are not mutation hazards and must not block this guard.
         """
 
         ids = [task_ids] if isinstance(task_ids, int) else list(task_ids)
         ids = [int(task_id) for task_id in ids]
         for task_id in ids:
-            if self._running_execution(task_id) is not None:
+            if (
+                self._running_execution(task_id, states=(ExecutionState.running,))
+                is not None
+            ):
                 raise RuntimeError(
                     f"Operation not permitted on the active task (task_id={task_id})",
                 )

--- a/unify/task_scheduler/task_scheduler.py
+++ b/unify/task_scheduler/task_scheduler.py
@@ -3454,7 +3454,10 @@ class TaskScheduler(BaseTaskScheduler):
                 logger.debug("Custom task unchanged: %s", custom_key)
                 return
             task_id = int(db_entry["task_id"])
-            if self._running_execution(task_id) is not None:
+            if (
+                self._running_execution(task_id, states=(ExecutionState.running,))
+                is not None
+            ):
                 logger.warning(
                     "Skipping update for custom task with a run in flight "
                     "key=%s task_id=%s",


### PR DESCRIPTION
Release PR from staging to main.

## Why now

`68c2c7447` starts the agent-service in `entrypoint.sh` for both pod kinds.

It was previously started only by the ConversationManager's
restart-on-key-change path, so it existed exactly where a ConversationManager
did. Offline task pods have none by design, leaving nothing on port 3000 and
making browser-driven scheduled tasks impossible — a Sales Navigator crawl
resolved `container=local=http://localhost:3000` and then failed to connect,
presenting as a scraper fault rather than a missing service.

`entrypoint.sh` already treated the desktop stack as one substrate shared by
both pod kinds, and already carried `AGENT_PID` plus a `stop_agent_service`
that nothing could ever match. The start was simply absent.

## Behaviour

- Spawned beside the display/audio devices, before the offline/interactive branch
- Comes up with the container's own key; interactive pods still respawn it with
  the user's key once session details land (unchanged)
- Readiness is a bounded TCP listen check (no unauthenticated health route
  exists), non-fatal so a wedged start surfaces as a caller-side connect error
  rather than a pod that never boots

Verified by exercising both functions in isolation: missing-dir skip, no-pid
short-circuit, readiness against a live listener, and a real spawn writing the
pid file. `bash -n` clean.

## Also included

- `ab6c35c17` recall participant-event nesting/speaker correlation
- `8c48b96d6` skip-guard reporting a green suite it never ran
- `a549f5861` versioning check without uv

(the three above are other sessions' work, not reviewed here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)