### PR TITLE
Release: staging → main

### DIFF
--- a/tests/task_scheduler/test_recurring_template_resilience.py
+++ b/tests/task_scheduler/test_recurring_template_resilience.py
@@ -68,6 +68,23 @@ def test_matching_scheduled_activation_passes():
     )
 
 
+def test_projected_successor_after_the_anchor_passes():
+    """Every occurrence after the first is later than the anchor by design.
+
+    `schedule.start_at` is authored intent and is never rewritten, so a
+    recurring series only matches it on its first occurrence. Treating any
+    mismatch as stale skipped every projected successor — the skip finalized
+    the run as a benign "completed" and projected nothing, so a healthy
+    ten-minute series silently ended one occurrence after every re-arm.
+    """
+
+    scheduler = object.__new__(TaskScheduler)
+    scheduler._validate_task_matches_provenance(
+        task=_task("2026-07-14T15:10:00+00:00"),
+        provenance=_provenance("2026-07-14T15:20:00+00:00"),
+    )
+
+
 def test_equivalent_offset_scheduled_activation_passes():
     scheduler = object.__new__(TaskScheduler)
     scheduler._validate_task_matches_provenance(

--- a/unify/task_scheduler/task_scheduler.py
+++ b/unify/task_scheduler/task_scheduler.py
@@ -883,7 +883,25 @@ class TaskScheduler(BaseTaskScheduler):
         provenance_scheduled_for = self._normalize_activation_datetime(
             provenance.scheduled_for,
         )
-        if task_scheduled_for != provenance_scheduled_for:
+        if task_scheduled_for is None or provenance_scheduled_for is None:
+            return
+        # `schedule.start_at` is the series anchor and is never rewritten, so
+        # only the first occurrence can equal it — every projected successor is
+        # later. An occurrence is superseded exactly when it falls *behind* the
+        # anchor: the author re-armed the series past it (the same `not_before`
+        # rule the backend projection applies). Requiring equality here skipped
+        # every successor as "stale", each skip projected no successor of its
+        # own, and a healthy ten-minute series silently ended one occurrence
+        # after each re-arm.
+        try:
+            is_stale = datetime.fromisoformat(
+                provenance_scheduled_for,
+            ) < datetime.fromisoformat(task_scheduled_for)
+        except ValueError:
+            # An unparseable timestamp survives normalization verbatim; the
+            # only safe comparison left is identity.
+            is_stale = provenance_scheduled_for != task_scheduled_for
+        if is_stale:
             raise StaleActivationSuperseded(
                 "Scheduled activation superseded by re-armed task definition: "
                 f"task_id={task.task_id}, task_start_at={task_scheduled_for}, "


### PR DESCRIPTION
Carries the last series-halting scheduler defect: the stale-activation guard
required an occurrence to equal `schedule.start_at` exactly. Correct when the
definition's start_at advanced per occurrence; wrong ever since the anchor
became authored intent that is never rewritten — only a series' first occurrence
can match it, so every projected successor was skipped as "stale". The skip
finalizes as a benign "completed" and projects nothing, so a healthy recurring
series silently ends one occurrence after every re-arm.

Superseded now means what the backend projection means by it: the occurrence
falls behind the anchor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)