### PR TITLE
Release: staging → main

### DIFF
--- a/tests/task_scheduler/repeat_projection_vectors.json
+++ b/tests/task_scheduler/repeat_projection_vectors.json
@@ -1,0 +1,356 @@
+{
+  "_contract": "Shared drift guard for the repeat-rule arithmetic mirrored between unify/task_scheduler/types/repetition.py and orchestra/services/task_repetition.py. This file is checked into both repos with byte-identical content; each repo runs its own implementation against every vector. Regenerate from unify and copy to both repos when the semantics deliberately change.",
+  "next_occurrence": [
+    {
+      "name": "minutely_10_advances_one_slot",
+      "previous_start": "2026-07-29T22:00:00+00:00",
+      "now": "2026-07-29T22:00:00+00:00",
+      "patterns": [
+        {
+          "frequency": "minutely",
+          "interval": 10
+        }
+      ],
+      "expected": "2026-07-29T22:10:00+00:00"
+    },
+    {
+      "name": "minutely_10_crash_catch_up_skips_to_first_future_slot",
+      "previous_start": "2026-07-29T22:10:00+00:00",
+      "now": "2026-07-30T09:47:23+00:00",
+      "patterns": [
+        {
+          "frequency": "minutely",
+          "interval": 10
+        }
+      ],
+      "expected": "2026-07-30T09:50:00+00:00"
+    },
+    {
+      "name": "hourly_6",
+      "previous_start": "2026-07-29T05:15:00+00:00",
+      "now": "2026-07-29T05:15:00+00:00",
+      "patterns": [
+        {
+          "frequency": "hourly",
+          "interval": 6
+        }
+      ],
+      "expected": "2026-07-29T11:15:00+00:00"
+    },
+    {
+      "name": "daily_preserves_clock_time",
+      "previous_start": "2026-07-29T08:30:00+00:00",
+      "now": "2026-07-29T08:30:00+00:00",
+      "patterns": [
+        {
+          "frequency": "daily"
+        }
+      ],
+      "expected": "2026-07-30T08:30:00+00:00"
+    },
+    {
+      "name": "daily_time_of_day_next_day_when_consumed",
+      "previous_start": "2026-07-29T09:00:00+00:00",
+      "now": "2026-07-29T09:00:00+00:00",
+      "patterns": [
+        {
+          "frequency": "daily",
+          "time_of_day": "09:00:00"
+        }
+      ],
+      "expected": "2026-07-30T09:00:00+00:00"
+    },
+    {
+      "name": "daily_time_of_day_same_day_when_still_ahead",
+      "previous_start": "2026-07-29T03:00:00+00:00",
+      "now": "2026-07-29T03:00:00+00:00",
+      "patterns": [
+        {
+          "frequency": "daily",
+          "time_of_day": "09:00:00"
+        }
+      ],
+      "expected": "2026-07-29T09:00:00+00:00"
+    },
+    {
+      "name": "weekly_interval_2_without_weekdays",
+      "previous_start": "2026-07-28T10:00:00+00:00",
+      "now": "2026-07-28T10:00:00+00:00",
+      "patterns": [
+        {
+          "frequency": "weekly",
+          "interval": 2
+        }
+      ],
+      "expected": "2026-08-11T10:00:00+00:00"
+    },
+    {
+      "name": "weekly_weekdays_picks_next_allowed_day",
+      "previous_start": "2026-07-29T10:00:00+00:00",
+      "now": "2026-07-29T10:00:00+00:00",
+      "patterns": [
+        {
+          "frequency": "weekly",
+          "weekdays": [
+            "MO",
+            "FR"
+          ]
+        }
+      ],
+      "expected": "2026-07-31T10:00:00+00:00"
+    },
+    {
+      "name": "weekly_weekdays_interval_2_respects_cadence",
+      "previous_start": "2026-07-31T10:00:00+00:00",
+      "now": "2026-07-31T10:00:00+00:00",
+      "patterns": [
+        {
+          "frequency": "weekly",
+          "interval": 2,
+          "weekdays": [
+            "MO",
+            "FR"
+          ]
+        }
+      ],
+      "expected": "2026-08-10T10:00:00+00:00"
+    },
+    {
+      "name": "weekly_weekdays_time_of_day_override",
+      "previous_start": "2026-07-29T10:00:00+00:00",
+      "now": "2026-07-29T10:00:00+00:00",
+      "patterns": [
+        {
+          "frequency": "weekly",
+          "weekdays": [
+            "FR"
+          ],
+          "time_of_day": "07:45:00"
+        }
+      ],
+      "expected": "2026-07-31T07:45:00+00:00"
+    },
+    {
+      "name": "monthly_clamps_to_month_end",
+      "previous_start": "2026-01-31T12:00:00+00:00",
+      "now": "2026-01-31T12:00:00+00:00",
+      "patterns": [
+        {
+          "frequency": "monthly"
+        }
+      ],
+      "expected": "2026-02-28T12:00:00+00:00"
+    },
+    {
+      "name": "yearly_clamps_leap_day",
+      "previous_start": "2024-02-29T00:00:00+00:00",
+      "now": "2024-02-29T00:00:00+00:00",
+      "patterns": [
+        {
+          "frequency": "yearly"
+        }
+      ],
+      "expected": "2025-02-28T00:00:00+00:00"
+    },
+    {
+      "name": "count_1_is_exhausted",
+      "previous_start": "2026-07-29T22:00:00+00:00",
+      "now": "2026-07-29T22:00:00+00:00",
+      "patterns": [
+        {
+          "frequency": "minutely",
+          "interval": 10,
+          "count": 1
+        }
+      ],
+      "expected": null
+    },
+    {
+      "name": "count_3_index_2_is_exhausted",
+      "previous_start": "2026-07-29T22:00:00+00:00",
+      "now": "2026-07-29T22:00:00+00:00",
+      "current_occurrence_index": 2,
+      "patterns": [
+        {
+          "frequency": "minutely",
+          "interval": 10,
+          "count": 3
+        }
+      ],
+      "expected": null
+    },
+    {
+      "name": "count_3_index_1_still_advances",
+      "previous_start": "2026-07-29T22:00:00+00:00",
+      "now": "2026-07-29T22:00:00+00:00",
+      "current_occurrence_index": 1,
+      "patterns": [
+        {
+          "frequency": "minutely",
+          "interval": 10,
+          "count": 3
+        }
+      ],
+      "expected": "2026-07-29T22:10:00+00:00"
+    },
+    {
+      "name": "until_allows_slot_inside_window",
+      "previous_start": "2026-07-29T22:00:00+00:00",
+      "now": "2026-07-29T22:00:00+00:00",
+      "patterns": [
+        {
+          "frequency": "minutely",
+          "interval": 10,
+          "until": "2026-07-29T22:15:00+00:00"
+        }
+      ],
+      "expected": "2026-07-29T22:10:00+00:00"
+    },
+    {
+      "name": "until_cuts_off_slot_outside_window",
+      "previous_start": "2026-07-29T22:00:00+00:00",
+      "now": "2026-07-29T22:00:00+00:00",
+      "patterns": [
+        {
+          "frequency": "minutely",
+          "interval": 10,
+          "until": "2026-07-29T22:05:00+00:00"
+        }
+      ],
+      "expected": null
+    },
+    {
+      "name": "naive_until_compares_against_aware_candidate",
+      "previous_start": "2026-07-29T22:00:00+00:00",
+      "now": "2026-07-29T22:00:00+00:00",
+      "patterns": [
+        {
+          "frequency": "minutely",
+          "interval": 10,
+          "until": "2026-07-29T22:15:00"
+        }
+      ],
+      "expected": "2026-07-29T22:10:00+00:00"
+    },
+    {
+      "name": "naive_previous_start_stays_naive",
+      "previous_start": "2026-07-29T22:00:00",
+      "now": "2026-07-29T22:00:00",
+      "patterns": [
+        {
+          "frequency": "minutely",
+          "interval": 10
+        }
+      ],
+      "expected": "2026-07-29T22:10:00"
+    },
+    {
+      "name": "full_day_daily_slots_normalize_to_minutely",
+      "previous_start": "2026-07-29T12:00:00+00:00",
+      "now": "2026-07-29T12:00:00+00:00",
+      "patterns": [
+        {
+          "frequency": "daily",
+          "time_of_day": "00:00:00"
+        },
+        {
+          "frequency": "daily",
+          "time_of_day": "06:00:00"
+        },
+        {
+          "frequency": "daily",
+          "time_of_day": "12:00:00"
+        },
+        {
+          "frequency": "daily",
+          "time_of_day": "18:00:00"
+        }
+      ],
+      "expected": "2026-07-29T18:00:00+00:00"
+    },
+    {
+      "name": "earliest_candidate_wins_across_patterns",
+      "previous_start": "2026-07-29T22:00:00+00:00",
+      "now": "2026-07-29T22:00:00+00:00",
+      "patterns": [
+        {
+          "frequency": "hourly",
+          "interval": 2
+        },
+        {
+          "frequency": "daily"
+        }
+      ],
+      "expected": "2026-07-30T00:00:00+00:00"
+    }
+  ],
+  "dispatch_jitter": [
+    {
+      "name": "no_budget_yields_zero",
+      "task_id": 12,
+      "slot": "2026-07-30T10:00:00+00:00",
+      "patterns": [
+        {
+          "frequency": "minutely",
+          "interval": 10
+        }
+      ],
+      "expected": 0.0
+    },
+    {
+      "name": "budget_300_task_12",
+      "task_id": 12,
+      "slot": "2026-07-30T10:00:00+00:00",
+      "patterns": [
+        {
+          "frequency": "minutely",
+          "interval": 10,
+          "jitter_seconds": 300
+        }
+      ],
+      "expected": 185.290703
+    },
+    {
+      "name": "budget_300_task_13_differs_by_task",
+      "task_id": 13,
+      "slot": "2026-07-30T10:00:00+00:00",
+      "patterns": [
+        {
+          "frequency": "minutely",
+          "interval": 10,
+          "jitter_seconds": 300
+        }
+      ],
+      "expected": 205.605679
+    },
+    {
+      "name": "budget_300_task_12_differs_by_slot",
+      "task_id": 12,
+      "slot": "2026-07-30T10:10:00+00:00",
+      "patterns": [
+        {
+          "frequency": "minutely",
+          "interval": 10,
+          "jitter_seconds": 300
+        }
+      ],
+      "expected": 87.145668
+    },
+    {
+      "name": "largest_budget_across_patterns_wins",
+      "task_id": 12,
+      "slot": "2026-07-30T10:00:00+00:00",
+      "patterns": [
+        {
+          "frequency": "hourly",
+          "jitter_seconds": 60
+        },
+        {
+          "frequency": "daily",
+          "jitter_seconds": 600
+        }
+      ],
+      "expected": 370.581407
+    }
+  ]
+}

--- a/tests/task_scheduler/test_project_task_occurrence.py
+++ b/tests/task_scheduler/test_project_task_occurrence.py
@@ -68,3 +68,19 @@ def test_a_starting_run_is_still_marked_running() -> None:
     body = _posted_body(post.call_args)
     assert body["state"] == "running"
     assert body["started_at"]
+
+
+def test_projection_carries_the_definitions_entrypoint() -> None:
+    """Dispatch reads the entrypoint from the materialized row.
+
+    A projected occurrence stored without one launched as agentic, and a
+    symbolic recurring task then refused its own successor at start —
+    "activation requested agentic execution, task row provides a symbolic
+    entrypoint" — so the series failed one occurrence after every re-arm.
+    """
+
+    with patch.object(machine_state, "_orchestra_admin_post") as post:
+        post.return_value = {"run": {"run_key": "k"}}
+        project_task_occurrence(_provenance(entrypoint=0))
+
+    assert _posted_body(post.call_args)["entrypoint"] == 0

--- a/tests/task_scheduler/test_repetition_vectors.py
+++ b/tests/task_scheduler/test_repetition_vectors.py
@@ -1,0 +1,61 @@
+"""Drift guard for the recurrence arithmetic mirrored into Orchestra.
+
+``unify/task_scheduler/types/repetition.py`` is deliberately copied into
+``orchestra/services/task_repetition.py``; the two must stay in lockstep or
+Orchestra's release-time head re-projection and Unify's dispatch-time successor
+projection would name different slots for the same series. Both repos check in
+a byte-identical ``repeat_projection_vectors.json`` and run their own
+implementation against every vector, so a change on either side that shifts
+the semantics fails here rather than in production.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from unify.task_scheduler.types.repetition import (
+    RepeatPattern,
+    deterministic_jitter_seconds,
+    next_repeated_start_at,
+)
+
+_VECTORS = json.loads(
+    Path(__file__)
+    .with_name("repeat_projection_vectors.json")
+    .read_text(
+        encoding="utf-8",
+    ),
+)
+
+
+@pytest.mark.parametrize(
+    "case",
+    _VECTORS["next_occurrence"],
+    ids=lambda case: case["name"],
+)
+def test_next_occurrence_matches_shared_vector(case: dict) -> None:
+    result = next_repeated_start_at(
+        previous_start=datetime.fromisoformat(case["previous_start"]),
+        patterns=[RepeatPattern.model_validate(p) for p in case["patterns"]],
+        current_occurrence_index=case.get("current_occurrence_index", 0),
+        now=datetime.fromisoformat(case["now"]),
+    )
+    assert (result.isoformat() if result else None) == case["expected"]
+
+
+@pytest.mark.parametrize(
+    "case",
+    _VECTORS["dispatch_jitter"],
+    ids=lambda case: case["name"],
+)
+def test_dispatch_jitter_matches_shared_vector(case: dict) -> None:
+    offset = deterministic_jitter_seconds(
+        task_id=case["task_id"],
+        slot=datetime.fromisoformat(case["slot"]),
+        patterns=[RepeatPattern.model_validate(p) for p in case["patterns"]],
+    )
+    assert offset == case["expected"]

--- a/unify/task_scheduler/machine_state.py
+++ b/unify/task_scheduler/machine_state.py
@@ -148,6 +148,10 @@ class TaskRunProvenance:
     task_description: str | None = None
     attempt_token: str | None = None
     dispatch_offset_seconds: float | None = None
+    # Symbolic function id the definition binds this occurrence to. Dispatch
+    # reads it from the materialized row, so a projected occurrence stored
+    # without it launches as agentic and a symbolic task refuses the run.
+    entrypoint: int | None = None
 
 
 @dataclass(frozen=True)
@@ -492,6 +496,7 @@ def _create_or_adopt_task_run(
                 "destination": provenance.destination,
                 "scheduled_for": provenance.scheduled_for,
                 "dispatch_offset_seconds": provenance.dispatch_offset_seconds,
+                "entrypoint": provenance.entrypoint,
                 "source_medium": provenance.source_medium,
                 "source_ref": provenance.source_ref,
                 "source_contact_id": provenance.source_contact_id,

--- a/unify/task_scheduler/offline_runner.py
+++ b/unify/task_scheduler/offline_runner.py
@@ -559,11 +559,11 @@ class _OfflineTaskExecutionDelegate:
                 f"activation requested {self._config.function_id}, "
                 f"task row provides {entrypoint}.",
             )
-        if not requested_symbolic and entrypoint is not None:
-            raise RuntimeError(
-                "Offline task entrypoint mismatch: activation requested "
-                "agentic execution, task row provides a symbolic entrypoint.",
-            )
+        # An activation with no function id is not a request for agentic
+        # execution — it is an activation with no opinion. The definition is
+        # the authored intent, so its entrypoint governs. Refusing here failed
+        # every projected successor of a symbolic recurring task, because those
+        # occurrences historically materialized without an entrypoint.
 
         task_guidelines = kwargs.pop("guidelines", None)
         entrypoint_kwargs = dict(kwargs.pop("entrypoint_kwargs", {}) or {})

--- a/unify/task_scheduler/task_scheduler.py
+++ b/unify/task_scheduler/task_scheduler.py
@@ -1552,6 +1552,7 @@ class TaskScheduler(BaseTaskScheduler):
                     destination=task.destination,
                     scheduled_for=scheduled_for,
                     dispatch_offset_seconds=dispatch_offset,
+                    entrypoint=task.entrypoint,
                     task_name=task.name,
                     task_description=task.description,
                 ),

--- a/unify/task_scheduler/types/repetition.py
+++ b/unify/task_scheduler/types/repetition.py
@@ -1,6 +1,15 @@
 """
 Schema describing how a task repeats over time. The model serializes to and
 from JSON for storage and transport.
+
+The recurrence subset (pattern schema, normalization, next-occurrence
+projection, deterministic dispatch jitter) is deliberately mirrored into
+``orchestra/services/task_repetition.py`` so Orchestra can re-project a future
+head for a repeating series whose worker died before dispatch. Any change to
+those semantics MUST be applied to both files in the same changeset; the two
+copies are pinned against each other by the shared
+``repeat_projection_vectors.json`` checked into each repo's test tree with
+byte-identical content.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Carries the entrypoint half of the projected-successor fix: provenance now
stores the definition's symbolic entrypoint on the row dispatch reads, and the
runner treats an activation with no function id as deferring to the definition
instead of refusing the run. Orchestra's side (accepting the field) is already
on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)