### PR TITLE
Release: staging → main

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -66,6 +66,16 @@ WORKDIR /app
 # Remove git credentials after all git operations (security best practice)
 RUN git config --global --unset url."https://${GITHUB_TOKEN}@github.com/".insteadOf
 
+# UNITY_SHA is the commit of this source tree. A content-addressed COPY should
+# invalidate on its own, but the registry cache import has been observed serving
+# a stale /app layer: unity-base:latest shipped a deploy/entrypoint.sh 62 lines
+# behind the commit the image was tagged with, so a deploy succeeded end to end
+# while changing nothing in the running pods. Referencing the SHA in a RUN ahead
+# of the COPY moves the cache key with every commit, the same way DEP_REPOS_SHA
+# does for the cloned dependencies above.
+ARG UNITY_SHA=unknown
+RUN echo "unity_sha=${UNITY_SHA}"
+
 # Copy source and install unify with all dependencies
 COPY . /app
 RUN uv pip install --system --no-cache .

--- a/tests/function_manager/test_provider_integration_materialization.py
+++ b/tests/function_manager/test_provider_integration_materialization.py
@@ -112,7 +112,7 @@ def _fake_function_manager() -> FunctionManager:
         lambda app_keys: setattr(fm, "_deleted_apps", app_keys) or 0
     )
     fm._inserted_rows = []
-    fm._insert_primitives = lambda rows: fm._inserted_rows.extend(rows)
+    fm._insert_primitives = lambda rows: fm._inserted_rows.extend(rows) or True
     fm._count_provider_integration_rows_for_app = lambda **_kwargs: len(
         fm._inserted_rows,
     )
@@ -149,7 +149,14 @@ def test_materializes_connected_provider_tools_with_active_only_search(
     result = fm.sync_provider_integration_tools(app_slug="hubspot")
 
     assert result["status"] == "synced"
-    assert result["apps"] == [{"key": "composio:hubspot", "rows": 1, "rows_deleted": 0}]
+    assert result["apps"] == [
+        {
+            "key": "composio:hubspot",
+            "rows": 1,
+            "rows_deleted": 0,
+            "fully_inserted": True,
+        },
+    ]
     assert client.calls == [
         ("list_connections", (), {"owner_scope": "assistant", "assistant_id": 42}),
     ]
@@ -521,7 +528,12 @@ def test_one_app_mismatch_does_not_block_sibling_app_sync(monkeypatch) -> None:
         },
     ]
     assert result["apps"] == [
-        {"key": "composio:hubspot", "rows": 1, "rows_deleted": 0},
+        {
+            "key": "composio:hubspot",
+            "rows": 1,
+            "rows_deleted": 0,
+            "fully_inserted": True,
+        },
     ]
     assert {row["name"] for row in fm._inserted_rows} == {
         "primitives.integrations.hubspot.search_contacts",
@@ -606,7 +618,14 @@ def test_materialization_pages_app_scoped_provider_tools(monkeypatch) -> None:
     result = fm.sync_provider_integration_tools(app_slug="HubSpot", limit=1)
 
     assert result["status"] == "synced"
-    assert result["apps"] == [{"key": "composio:hubspot", "rows": 2, "rows_deleted": 0}]
+    assert result["apps"] == [
+        {
+            "key": "composio:hubspot",
+            "rows": 2,
+            "rows_deleted": 0,
+            "fully_inserted": True,
+        },
+    ]
     assert all(call[0] != "search_tools" for call in client.calls)
     assert catalog_calls == [{"canonical_app_slug": "hubspot", "limit": 1}]
     assert [row["name"] for row in fm._inserted_rows] == [
@@ -826,14 +845,19 @@ def test_insert_primitives_replaces_exact_function_ids(monkeypatch) -> None:
         "_delete_primitives_by_function_ids",
         lambda self, function_ids: deleted_ids.extend(function_ids),
     )
+
+    def _fake_create_logs(**kwargs):
+        captured.extend(kwargs["entries"])
+        return [SimpleNamespace(entries=entry) for entry in kwargs["entries"]]
+
     monkeypatch.setattr(
         "unify.function_manager.function_manager.unity_create_logs",
-        lambda **kwargs: captured.extend(kwargs["entries"]),
+        _fake_create_logs,
     )
     fm = _fake_function_manager()
     fm._primitives_ctx = "Functions/Primitives"
 
-    FunctionManager._insert_primitives(
+    fully_inserted = FunctionManager._insert_primitives(
         fm,
         [
             {
@@ -856,6 +880,59 @@ def test_insert_primitives_replaces_exact_function_ids(monkeypatch) -> None:
 
     assert deleted_ids == [123]
     assert captured[0]["function_id"] == 123
+    assert fully_inserted is True
+
+
+def test_insert_primitives_skips_already_catalogued_rows(monkeypatch) -> None:
+    """Provider-backed rows are connection-agnostic catalogue entries: a row
+    can already exist (e.g. seeded once system-wide) on an assistant's first
+    sync, and this session's delete can't remove a row it doesn't own. The
+    insert must ask Orchestra to skip already-existing rows instead of
+    failing the whole batch on the first collision, and must report back
+    that it didn't actually write anything -- so the caller knows not to
+    cache "fully synced" state it never confirmed.
+    """
+    captured_kwargs: list[dict] = []
+
+    monkeypatch.setattr(
+        FunctionManager,
+        "_delete_primitives_by_function_ids",
+        lambda self, function_ids: None,
+    )
+    monkeypatch.setattr(
+        "unify.function_manager.function_manager.unity_create_logs",
+        # Orchestra's on_duplicate="skip" path returns only the rows it
+        # actually wrote; every row here already existed, so nothing comes
+        # back.
+        lambda **kwargs: captured_kwargs.append(kwargs) or [],
+    )
+    fm = _fake_function_manager()
+    fm._primitives_ctx = "Functions/Primitives"
+
+    fully_inserted = FunctionManager._insert_primitives(
+        fm,
+        [
+            {
+                "name": "primitives.integrations.google_calendar.acl_delete",
+                "function_id": 903599057,
+                "argspec": "() -> dict",
+                "docstring": "Delete an ACL rule.",
+                "embedding_text": "Function Name: primitives.integrations.google_calendar.acl_delete",
+                "implementation": None,
+                "depends_on": [],
+                "precondition": None,
+                "verify": False,
+                "is_primitive": True,
+                "guidance_ids": [],
+                "primitive_class": "unify.integrations.primitives.IntegrationPrimitives",
+                "primitive_method": "google_calendar_acl_delete",
+            },
+        ],
+    )
+
+    assert len(captured_kwargs) == 1
+    assert captured_kwargs[0]["on_duplicate"] == "skip"
+    assert fully_inserted is False
 
 
 def test_function_manager_queries_do_not_call_integration_ops(monkeypatch) -> None:
@@ -944,6 +1021,44 @@ def test_materialization_hash_match_skips_delete_and_insert(monkeypatch) -> None
     assert result["apps"] == []
     assert result["unchanged_apps"] == [{"key": "composio:hubspot", "rows": 1}]
     assert fm._inserted_rows == []
+
+
+def test_materialization_does_not_cache_hash_when_rows_already_catalogued(
+    monkeypatch,
+) -> None:
+    """When _insert_primitives reports it didn't write every row itself
+    (some already existed under a shared, connection-agnostic catalogue
+    entry -- see _insert_primitives), the sync must still report success for
+    this call (the tools genuinely exist, per the row count) but must NOT
+    cache the per-assistant hash as "synced". Caching it would let this
+    assistant silently trust content it never actually confirmed -- if the
+    upstream tool definition later changes, a cached hash would mean this
+    assistant never notices and never retries.
+    """
+    client = FakeIntegrationOps()
+    monkeypatch.setattr(
+        "unify.integrations.ops.list_connections",
+        client.list_connections,
+    )
+    monkeypatch.setattr(
+        "unify.function_manager.function_manager.list_catalog_tools",
+        lambda **_kwargs: list(client.results),
+    )
+    fm = _fake_function_manager()
+    fm._insert_primitives = lambda rows: fm._inserted_rows.extend(rows) or False
+
+    result = fm.sync_provider_integration_tools(app_slug="hubspot")
+
+    assert result["status"] == "synced"
+    assert result["apps"] == [
+        {
+            "key": "composio:hubspot",
+            "rows": 1,
+            "rows_deleted": 0,
+            "fully_inserted": False,
+        },
+    ]
+    assert fm._stored_hashes == {}
 
 
 def test_disconnect_cleanup_removes_materialized_rows(monkeypatch) -> None:

--- a/tests/task_scheduler/repeat_projection_vectors.json
+++ b/tests/task_scheduler/repeat_projection_vectors.json
@@ -282,6 +282,55 @@
         }
       ],
       "expected": "2026-07-30T00:00:00+00:00"
+    },
+    {
+      "name": "minutely_10_survives_a_month_long_outage",
+      "previous_start": "2026-06-29T22:10:00+00:00",
+      "now": "2026-07-30T09:47:23+00:00",
+      "patterns": [
+        {
+          "frequency": "minutely",
+          "interval": 10
+        }
+      ],
+      "expected": "2026-07-30T09:50:00+00:00"
+    },
+    {
+      "name": "minutely_1_survives_a_multi_year_outage",
+      "previous_start": "2024-01-01T00:00:00+00:00",
+      "now": "2026-07-30T09:00:30+00:00",
+      "patterns": [
+        {
+          "frequency": "minutely",
+          "interval": 1
+        }
+      ],
+      "expected": "2026-07-30T09:01:00+00:00"
+    },
+    {
+      "name": "hourly_6_survives_a_two_year_outage",
+      "previous_start": "2024-07-29T05:15:00+00:00",
+      "now": "2026-07-30T14:03:00+00:00",
+      "patterns": [
+        {
+          "frequency": "hourly",
+          "interval": 6
+        }
+      ],
+      "expected": "2026-07-30T17:15:00+00:00"
+    },
+    {
+      "name": "outage_past_a_distant_until_is_exhausted",
+      "previous_start": "2026-01-01T00:00:00+00:00",
+      "now": "2026-07-30T00:00:00+00:00",
+      "patterns": [
+        {
+          "frequency": "minutely",
+          "interval": 10,
+          "until": "2026-02-01T00:00:00+00:00"
+        }
+      ],
+      "expected": null
     }
   ],
   "dispatch_jitter": [

--- a/unify/function_manager/function_manager.py
+++ b/unify/function_manager/function_manager.py
@@ -3280,7 +3280,7 @@ class FunctionManager(BaseFunctionManager):
                 len(rows),
             )
             try:
-                self._insert_primitives(rows)
+                fully_inserted = self._insert_primitives(rows)
             except Exception as exc:
                 logger.error(
                     "Provider integration sync insert failed key=%s rows=%d error=%s",
@@ -3318,9 +3318,30 @@ class FunctionManager(BaseFunctionManager):
                     },
                 )
                 continue
-            new_hashes[key] = expected_hash
+            if fully_inserted:
+                # Only cache "synced" when this call actually wrote every row
+                # itself. When some rows were already catalogued (skipped),
+                # this session never confirmed their content is current, so
+                # leaving the hash unset means the next sync re-checks
+                # instead of silently trusting a row it didn't write.
+                new_hashes[key] = expected_hash
+            else:
+                log_staging_diagnostic(
+                    logger,
+                    (
+                        "Provider integration sync key=%s: rows already "
+                        "catalogued, not caching hash so a future sync "
+                        "retries if the definition changes"
+                    ),
+                    key,
+                )
             changed_apps.append(
-                {"key": key, "rows": len(rows), "rows_deleted": deleted},
+                {
+                    "key": key,
+                    "rows": len(rows),
+                    "rows_deleted": deleted,
+                    "fully_inserted": fully_inserted,
+                },
             )
 
         if not normalized_app:
@@ -3399,10 +3420,30 @@ class FunctionManager(BaseFunctionManager):
                 logs=[log.id for log in logs],
             )
 
-    def _insert_primitives(self, primitives: List[Dict[str, Any]]) -> None:
-        """Insert primitive rows into the Primitives context with explicit IDs."""
+    def _insert_primitives(self, primitives: List[Dict[str, Any]]) -> bool:
+        """Insert primitive rows into the Primitives context with explicit IDs.
+
+        Provider-backed primitive rows are connection-agnostic catalogue
+        entries (see ``sync_provider_integration_tools``): the same tool
+        definition is shared, not duplicated per assistant, so it may already
+        exist (e.g. seeded once system-wide) even on an assistant's first
+        sync. The delete above can't remove a row this session doesn't own,
+        so re-inserting it would otherwise collide on the ``function_id``
+        unique key. ``on_duplicate="skip"`` inserts whichever rows are
+        genuinely new and leaves already-catalogued rows alone instead of
+        failing the whole batch on the first collision.
+
+        Returns ``True`` only when every row was freshly written by this
+        call. ``False`` means one or more rows already existed under their
+        ``function_id`` and were left untouched -- this session can't
+        confirm their content still matches what was requested (it may be
+        stale, or two distinct tools may have collided on the same
+        function_id hash), so callers must not cache "fully synced" state
+        for a ``False`` result; a future sync should keep retrying instead
+        of silently trusting a row it never actually wrote.
+        """
         if not primitives:
-            return
+            return True
 
         entries = [
             Function.model_validate(data).model_dump(include=set(data.keys()))
@@ -3417,14 +3458,44 @@ class FunctionManager(BaseFunctionManager):
                     if isinstance(entry.get("function_id"), int)
                 ],
             )
-            unity_create_logs(
+            created = unity_create_logs(
                 context=self._primitives_ctx,
                 entries=entries,
                 stamp_authoring=True,
                 batched=True,
                 recompute_derived=True,
+                on_duplicate="skip",
             )
-            logger.debug(f"Inserted {len(entries)} primitives")
+            written_ids = (
+                {log.entries.get("function_id") for log in created}
+                if isinstance(created, list)
+                else {entry.get("function_id") for entry in entries}
+            )
+            skipped = [
+                (entry.get("function_id"), entry.get("name"))
+                for entry in entries
+                if entry.get("function_id") not in written_ids
+            ]
+            if skipped:
+                # Routine and expected: a non-owning assistant's first sync
+                # of an app the shared catalogue already has (see docstring)
+                # skips every time, forever, since the hash below is
+                # deliberately never cached for it -- info, not warning, to
+                # avoid paging on the steady-state case. A genuine
+                # function_id collision between two *different* tools would
+                # show up here as the same function_id recurring under a
+                # different name across log lines -- greppable, unlike a
+                # bare count.
+                logger.info(
+                    "Provider primitive insert: %d/%d already catalogued "
+                    "under an existing function_id, left in place: %s",
+                    len(skipped),
+                    len(entries),
+                    sorted(skipped),
+                )
+            else:
+                logger.debug(f"Inserted {len(entries)} primitives")
+            return not skipped
         except Exception as e:
             logger.error(f"Failed to insert primitives: {e}")
             raise

--- a/unify/task_scheduler/types/repetition.py
+++ b/unify/task_scheduler/types/repetition.py
@@ -260,6 +260,23 @@ def max_jitter_seconds(patterns) -> int:
     return best
 
 
+def _fixed_stride(pattern: RepeatPattern) -> timedelta | None:
+    """Exact step size for frequencies whose occurrences are evenly spaced.
+
+    Only minutely and hourly qualify: every other frequency re-derives its
+    candidates from the calendar (weekday scans, month and leap-day clamping,
+    time-of-day anchoring), where stepping k times is not the same as jumping
+    k steps at once. They are also the only frequencies whose slots are dense
+    enough to exhaust the iteration bound below within a plausible outage.
+    """
+
+    if pattern.frequency == Frequency.MINUTELY:
+        return timedelta(minutes=pattern.interval)
+    if pattern.frequency == Frequency.HOURLY:
+        return timedelta(hours=pattern.interval)
+    return None
+
+
 def _next_pattern_occurrence(
     *,
     previous_start: datetime,
@@ -273,6 +290,18 @@ def _next_pattern_occurrence(
     if pattern.count is not None and occurrence_count >= pattern.count:
         return None
     candidate = previous_start
+    # A pattern can be asked for its next slot long after the series stopped
+    # firing (a crashed worker released weeks later). Stepping one occurrence
+    # at a time from the last consumed slot would exhaust the iteration bound,
+    # so evenly spaced frequencies jump straight to the last slot at or before
+    # *now* and let the loop advance from there. The jump is exact (timedelta
+    # floor division) and a no-op unless *now* is ahead of the previous
+    # occurrence, which keeps dispatch-time projection — where the caller
+    # passes now=previous_start — byte-identical. `count` is unaffected: it is
+    # accounted against the occurrence index, never against steps taken here.
+    stride = _fixed_stride(pattern)
+    if stride is not None and reference_now > candidate:
+        candidate += stride * ((reference_now - candidate) // stride)
     for _ in range(2048):
         candidate = _advance_one_occurrence(candidate, pattern)
         if pattern.until is not None and candidate > _normalize_until(


### PR DESCRIPTION
Release PR from staging to main.

## Why now

`f141d07ee` fixes a silent build defect: the published base image did not
contain the source it was tagged with.

Probed directly in-cluster:

| Stage | `deploy/entrypoint.sh` |
|---|---|
| `unify` main | 262 lines, 3 matches |
| `unifyai/unity` mirror @ main | 262 lines, 3 matches |
| `unity-base:latest` | **200 lines, 0 matches** |
| `unity:latest` | **200 lines, 0 matches** |

The registry cache import served a stale `COPY . /app`, so the build went green,
the image was pushed, the tag advanced to the new SHA — and the running pods got
source predating the commit. Three consecutive deploys of the agent-service
entrypoint change therefore shipped nothing.

This is not specific to that change: **any unity commit that does not move a
dependency SHA can be silently dropped from the image.** A deploy that appears
to succeed while shipping nothing is worse than one that fails.

`DEP_REPOS_SHA` already exists for exactly this reason on the cloned
dependencies. This adds the equivalent guard for the app source: an
`ARG UNITY_SHA` referenced in a `RUN` immediately before the `COPY`, so the
cache key moves with every commit. The matching `--build-arg` is in
unify-deploy `b48f46c3`.

## Verification plan

After the cascade, probe `unity-base:latest` in-cluster and require
262 lines / 3 matches before trusting the deploy.

## Also included

- `4537fd0da` dense repeat pattern fast-forward
- `7719fa7b9` function_manager catalogue sync

(other sessions' work, not reviewed here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)