### PR TITLE
Release: staging → main

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -66,16 +66,6 @@ WORKDIR /app
 # Remove git credentials after all git operations (security best practice)
 RUN git config --global --unset url."https://${GITHUB_TOKEN}@github.com/".insteadOf
 
-# UNITY_SHA is the commit of this source tree. A content-addressed COPY should
-# invalidate on its own, but the registry cache import has been observed serving
-# a stale /app layer: unity-base:latest shipped a deploy/entrypoint.sh 62 lines
-# behind the commit the image was tagged with, so a deploy succeeded end to end
-# while changing nothing in the running pods. Referencing the SHA in a RUN ahead
-# of the COPY moves the cache key with every commit, the same way DEP_REPOS_SHA
-# does for the cloned dependencies above.
-ARG UNITY_SHA=unknown
-RUN echo "unity_sha=${UNITY_SHA}"
-
 # Copy source and install unify with all dependencies
 COPY . /app
 RUN uv pip install --system --no-cache .

--- a/tests/task_scheduler/generate_repeat_projection_vectors.py
+++ b/tests/task_scheduler/generate_repeat_projection_vectors.py
@@ -1,0 +1,316 @@
+"""Generate ``repeat_projection_vectors.json`` from unify's implementation.
+
+The vector file is the drift guard for the recurrence arithmetic mirrored
+between ``unify/task_scheduler/types/repetition.py`` and
+``orchestra/services/task_repetition.py``. Expected values are always produced
+by the canonical unify code, so run this here after any deliberate
+recurrence-semantics change (applied to both repos in the same changeset):
+
+    uv run python tests/task_scheduler/generate_repeat_projection_vectors.py
+
+Then copy the regenerated file byte-identically into orchestra's test tree
+(``orchestra/tests/test_tasks/repeat_projection_vectors.json``). Each repo's
+``test_repetition_vectors.py`` runs its own implementation against every
+vector, so a semantic change ported to only one side fails there.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+
+from unify.task_scheduler.types.repetition import (
+    RepeatPattern,
+    deterministic_jitter_seconds,
+    next_repeated_start_at,
+)
+
+
+def _dt(value: str) -> datetime:
+    return datetime.fromisoformat(value)
+
+
+NEXT_OCCURRENCE_CASES = [
+    {
+        "name": "minutely_10_advances_one_slot",
+        "previous_start": "2026-07-29T22:00:00+00:00",
+        "now": "2026-07-29T22:00:00+00:00",
+        "patterns": [{"frequency": "minutely", "interval": 10}],
+    },
+    {
+        "name": "minutely_10_crash_catch_up_skips_to_first_future_slot",
+        "previous_start": "2026-07-29T22:10:00+00:00",
+        "now": "2026-07-30T09:47:23+00:00",
+        "patterns": [{"frequency": "minutely", "interval": 10}],
+    },
+    {
+        "name": "hourly_6",
+        "previous_start": "2026-07-29T05:15:00+00:00",
+        "now": "2026-07-29T05:15:00+00:00",
+        "patterns": [{"frequency": "hourly", "interval": 6}],
+    },
+    {
+        "name": "daily_preserves_clock_time",
+        "previous_start": "2026-07-29T08:30:00+00:00",
+        "now": "2026-07-29T08:30:00+00:00",
+        "patterns": [{"frequency": "daily"}],
+    },
+    {
+        "name": "daily_time_of_day_next_day_when_consumed",
+        "previous_start": "2026-07-29T09:00:00+00:00",
+        "now": "2026-07-29T09:00:00+00:00",
+        "patterns": [{"frequency": "daily", "time_of_day": "09:00:00"}],
+    },
+    {
+        "name": "daily_time_of_day_same_day_when_still_ahead",
+        "previous_start": "2026-07-29T03:00:00+00:00",
+        "now": "2026-07-29T03:00:00+00:00",
+        "patterns": [{"frequency": "daily", "time_of_day": "09:00:00"}],
+    },
+    {
+        "name": "weekly_interval_2_without_weekdays",
+        "previous_start": "2026-07-28T10:00:00+00:00",
+        "now": "2026-07-28T10:00:00+00:00",
+        "patterns": [{"frequency": "weekly", "interval": 2}],
+    },
+    {
+        "name": "weekly_weekdays_picks_next_allowed_day",
+        "previous_start": "2026-07-29T10:00:00+00:00",
+        "now": "2026-07-29T10:00:00+00:00",
+        "patterns": [{"frequency": "weekly", "weekdays": ["MO", "FR"]}],
+    },
+    {
+        "name": "weekly_weekdays_interval_2_respects_cadence",
+        "previous_start": "2026-07-31T10:00:00+00:00",
+        "now": "2026-07-31T10:00:00+00:00",
+        "patterns": [{"frequency": "weekly", "interval": 2, "weekdays": ["MO", "FR"]}],
+    },
+    {
+        "name": "weekly_weekdays_time_of_day_override",
+        "previous_start": "2026-07-29T10:00:00+00:00",
+        "now": "2026-07-29T10:00:00+00:00",
+        "patterns": [
+            {
+                "frequency": "weekly",
+                "weekdays": ["FR"],
+                "time_of_day": "07:45:00",
+            },
+        ],
+    },
+    {
+        "name": "monthly_clamps_to_month_end",
+        "previous_start": "2026-01-31T12:00:00+00:00",
+        "now": "2026-01-31T12:00:00+00:00",
+        "patterns": [{"frequency": "monthly"}],
+    },
+    {
+        "name": "yearly_clamps_leap_day",
+        "previous_start": "2024-02-29T00:00:00+00:00",
+        "now": "2024-02-29T00:00:00+00:00",
+        "patterns": [{"frequency": "yearly"}],
+    },
+    {
+        "name": "count_1_is_exhausted",
+        "previous_start": "2026-07-29T22:00:00+00:00",
+        "now": "2026-07-29T22:00:00+00:00",
+        "patterns": [{"frequency": "minutely", "interval": 10, "count": 1}],
+    },
+    {
+        "name": "count_3_index_2_is_exhausted",
+        "previous_start": "2026-07-29T22:00:00+00:00",
+        "now": "2026-07-29T22:00:00+00:00",
+        "current_occurrence_index": 2,
+        "patterns": [{"frequency": "minutely", "interval": 10, "count": 3}],
+    },
+    {
+        "name": "count_3_index_1_still_advances",
+        "previous_start": "2026-07-29T22:00:00+00:00",
+        "now": "2026-07-29T22:00:00+00:00",
+        "current_occurrence_index": 1,
+        "patterns": [{"frequency": "minutely", "interval": 10, "count": 3}],
+    },
+    {
+        "name": "until_allows_slot_inside_window",
+        "previous_start": "2026-07-29T22:00:00+00:00",
+        "now": "2026-07-29T22:00:00+00:00",
+        "patterns": [
+            {
+                "frequency": "minutely",
+                "interval": 10,
+                "until": "2026-07-29T22:15:00+00:00",
+            },
+        ],
+    },
+    {
+        "name": "until_cuts_off_slot_outside_window",
+        "previous_start": "2026-07-29T22:00:00+00:00",
+        "now": "2026-07-29T22:00:00+00:00",
+        "patterns": [
+            {
+                "frequency": "minutely",
+                "interval": 10,
+                "until": "2026-07-29T22:05:00+00:00",
+            },
+        ],
+    },
+    {
+        "name": "naive_until_compares_against_aware_candidate",
+        "previous_start": "2026-07-29T22:00:00+00:00",
+        "now": "2026-07-29T22:00:00+00:00",
+        "patterns": [
+            {
+                "frequency": "minutely",
+                "interval": 10,
+                "until": "2026-07-29T22:15:00",
+            },
+        ],
+    },
+    {
+        "name": "naive_previous_start_stays_naive",
+        "previous_start": "2026-07-29T22:00:00",
+        "now": "2026-07-29T22:00:00",
+        "patterns": [{"frequency": "minutely", "interval": 10}],
+    },
+    {
+        "name": "full_day_daily_slots_normalize_to_minutely",
+        "previous_start": "2026-07-29T12:00:00+00:00",
+        "now": "2026-07-29T12:00:00+00:00",
+        "patterns": [
+            {"frequency": "daily", "time_of_day": "00:00:00"},
+            {"frequency": "daily", "time_of_day": "06:00:00"},
+            {"frequency": "daily", "time_of_day": "12:00:00"},
+            {"frequency": "daily", "time_of_day": "18:00:00"},
+        ],
+    },
+    {
+        "name": "earliest_candidate_wins_across_patterns",
+        "previous_start": "2026-07-29T22:00:00+00:00",
+        "now": "2026-07-29T22:00:00+00:00",
+        "patterns": [
+            {"frequency": "hourly", "interval": 2},
+            {"frequency": "daily"},
+        ],
+    },
+    {
+        "name": "minutely_10_survives_a_month_long_outage",
+        "previous_start": "2026-06-29T22:10:00+00:00",
+        "now": "2026-07-30T09:47:23+00:00",
+        "patterns": [{"frequency": "minutely", "interval": 10}],
+    },
+    {
+        "name": "minutely_1_survives_a_multi_year_outage",
+        "previous_start": "2024-01-01T00:00:00+00:00",
+        "now": "2026-07-30T09:00:30+00:00",
+        "patterns": [{"frequency": "minutely", "interval": 1}],
+    },
+    {
+        "name": "hourly_6_survives_a_two_year_outage",
+        "previous_start": "2024-07-29T05:15:00+00:00",
+        "now": "2026-07-30T14:03:00+00:00",
+        "patterns": [{"frequency": "hourly", "interval": 6}],
+    },
+    {
+        "name": "outage_past_a_distant_until_is_exhausted",
+        "previous_start": "2026-01-01T00:00:00+00:00",
+        "now": "2026-07-30T00:00:00+00:00",
+        "patterns": [
+            {
+                "frequency": "minutely",
+                "interval": 10,
+                "until": "2026-02-01T00:00:00+00:00",
+            },
+        ],
+    },
+]
+
+JITTER_CASES = [
+    {
+        "name": "no_budget_yields_zero",
+        "task_id": 12,
+        "slot": "2026-07-30T10:00:00+00:00",
+        "patterns": [{"frequency": "minutely", "interval": 10}],
+    },
+    {
+        "name": "budget_300_task_12",
+        "task_id": 12,
+        "slot": "2026-07-30T10:00:00+00:00",
+        "patterns": [
+            {"frequency": "minutely", "interval": 10, "jitter_seconds": 300},
+        ],
+    },
+    {
+        "name": "budget_300_task_13_differs_by_task",
+        "task_id": 13,
+        "slot": "2026-07-30T10:00:00+00:00",
+        "patterns": [
+            {"frequency": "minutely", "interval": 10, "jitter_seconds": 300},
+        ],
+    },
+    {
+        "name": "budget_300_task_12_differs_by_slot",
+        "task_id": 12,
+        "slot": "2026-07-30T10:10:00+00:00",
+        "patterns": [
+            {"frequency": "minutely", "interval": 10, "jitter_seconds": 300},
+        ],
+    },
+    {
+        "name": "largest_budget_across_patterns_wins",
+        "task_id": 12,
+        "slot": "2026-07-30T10:00:00+00:00",
+        "patterns": [
+            {"frequency": "hourly", "jitter_seconds": 60},
+            {"frequency": "daily", "jitter_seconds": 600},
+        ],
+    },
+]
+
+
+def main() -> None:
+    next_occurrence = []
+    for case in NEXT_OCCURRENCE_CASES:
+        result = next_repeated_start_at(
+            previous_start=_dt(case["previous_start"]),
+            patterns=[RepeatPattern.model_validate(p) for p in case["patterns"]],
+            current_occurrence_index=case.get("current_occurrence_index", 0),
+            now=_dt(case["now"]),
+        )
+        next_occurrence.append(
+            {**case, "expected": result.isoformat() if result else None},
+        )
+
+    dispatch_jitter = []
+    for case in JITTER_CASES:
+        offset = deterministic_jitter_seconds(
+            task_id=case["task_id"],
+            slot=_dt(case["slot"]),
+            patterns=[RepeatPattern.model_validate(p) for p in case["patterns"]],
+        )
+        dispatch_jitter.append({**case, "expected": offset})
+
+    payload = {
+        "_contract": (
+            "Shared drift guard for the repeat-rule arithmetic mirrored between "
+            "unify/task_scheduler/types/repetition.py and "
+            "orchestra/services/task_repetition.py. This file is checked into "
+            "both repos with byte-identical content; each repo runs its own "
+            "implementation against every vector. Regenerate from unify and "
+            "copy to both repos when the semantics deliberately change."
+        ),
+        "next_occurrence": next_occurrence,
+        "dispatch_jitter": dispatch_jitter,
+    }
+    destination = (
+        Path(sys.argv[1])
+        if len(sys.argv) > 1
+        else Path(__file__).with_name("repeat_projection_vectors.json")
+    )
+    with open(destination, "w") as handle:
+        json.dump(payload, handle, indent=2)
+        handle.write("\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/task_scheduler/test_custom_tasks.py
+++ b/tests/task_scheduler/test_custom_tasks.py
@@ -21,6 +21,7 @@ _EXAMPLE_TASK_LINES = [
         "name": "Daily check",
         "description": "Run the daily operational check.",
         "repeat": [{"frequency": "daily"}],
+        "tags": ["ops", "daily"],
     },
     {
         "key": "ops/on-event",
@@ -203,3 +204,34 @@ async def test_sync_custom_tasks_deletes_removed_entries(
     names = {row.name for row in rows}
     assert "Daily check" not in names
     assert "On inbound email" in names
+
+
+def test_collect_custom_tasks_carries_tags(custom_tasks_dir):
+    """Tags declared in tasks.jsonl reach the planted definition row.
+
+    Tags are labels only — no scheduling semantics — but they must survive the
+    jsonl → reconcile → Tasks row path or the console has nothing to filter on.
+    A task without tags stays tagless rather than growing an empty list.
+    """
+
+    tasks = collect_custom_tasks(str(custom_tasks_dir))
+    assert tasks["ops/daily-check"]["tags"] == ["ops", "daily"]
+    assert tasks["ops/on-event"]["tags"] is None
+
+
+def test_tags_participate_in_the_sync_hash(custom_tasks_dir, tmp_path):
+    """Editing only a task's tags must count as a change reconcile applies."""
+
+    retagged = tmp_path / "retagged"
+    retagged.mkdir()
+    lines = []
+    for row in _EXAMPLE_TASK_LINES:
+        row = dict(row)
+        if row["key"] == "ops/daily-check":
+            row["tags"] = ["ops", "weekly"]
+        lines.append(json.dumps(row))
+    (retagged / TASKS_JSONL_FILENAME).write_text("\n".join(lines) + "\n")
+
+    original = collect_custom_tasks(str(custom_tasks_dir))["ops/daily-check"]
+    changed = collect_custom_tasks(str(retagged))["ops/daily-check"]
+    assert original["custom_hash"] != changed["custom_hash"]

--- a/tests/task_scheduler/test_machine_state.py
+++ b/tests/task_scheduler/test_machine_state.py
@@ -1,5 +1,7 @@
 import hashlib
 
+import pytest
+
 from unify.task_scheduler import machine_state
 from unify.task_scheduler.machine_state import (
     TASK_MACHINE_STATE_PROJECT,
@@ -539,3 +541,97 @@ def test_task_machine_contexts_route_to_owner_team_for_team_owned():
         assistant_context="42",
     )
     assert explicit == "user123/42/Tasks/Executions"
+
+
+def _admin_post_env(monkeypatch):
+    monkeypatch.setattr(
+        machine_state.SETTINGS,
+        "ORCHESTRA_URL",
+        "https://orchestra.test/v0",
+    )
+    monkeypatch.setattr(
+        type(machine_state.SESSION_DETAILS),
+        "unify_key",
+        property(lambda self: "test-key"),
+        raising=False,
+    )
+    monkeypatch.setattr(machine_state.time, "sleep", lambda _s: None)
+
+
+class _Response:
+    def __init__(self, status_code: int, body: dict | None = None) -> None:
+        self.status_code = status_code
+        self._body = body or {}
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise machine_state.requests.HTTPError(
+                f"{self.status_code}",
+                response=self,
+            )
+
+    def json(self) -> dict:
+        return self._body
+
+
+def test_admin_post_retries_transient_failures(monkeypatch):
+    """One transient 500 must not end a series.
+
+    The occurrence that fails to project its successor is the only thing that
+    would ever project it, so a single unretried blip halts recurrence for
+    good — which is exactly how a ten-minute production tick died at 21:31.
+    """
+
+    _admin_post_env(monkeypatch)
+    responses = [
+        _Response(500),
+        machine_state.requests.ConnectionError("reset"),
+        _Response(200, {"run": {"run_key": "rk"}}),
+    ]
+
+    def _post(url, **kwargs):
+        result = responses.pop(0)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    monkeypatch.setattr(machine_state.requests, "post", _post)
+
+    body = machine_state._orchestra_admin_post("/task-execution/create-or-adopt", {})
+
+    assert body == {"run": {"run_key": "rk"}}
+    assert responses == []
+
+
+def test_admin_post_gives_up_after_exhausting_attempts(monkeypatch):
+    _admin_post_env(monkeypatch)
+    calls: list[int] = []
+
+    def _post(url, **kwargs):
+        calls.append(1)
+        return _Response(503)
+
+    monkeypatch.setattr(machine_state.requests, "post", _post)
+
+    with pytest.raises(machine_state.requests.HTTPError):
+        machine_state._orchestra_admin_post("/task-execution/create-or-adopt", {})
+
+    assert len(calls) == machine_state._TASK_RUN_HTTP_ATTEMPTS
+
+
+def test_admin_post_does_not_retry_contract_errors(monkeypatch):
+    """A 4xx is a wrong request, not a flaky backend; retrying hides bugs."""
+
+    _admin_post_env(monkeypatch)
+    calls: list[int] = []
+
+    def _post(url, **kwargs):
+        calls.append(1)
+        return _Response(422)
+
+    monkeypatch.setattr(machine_state.requests, "post", _post)
+
+    with pytest.raises(machine_state.requests.HTTPError):
+        machine_state._orchestra_admin_post("/task-execution/create-or-adopt", {})
+
+    assert len(calls) == 1

--- a/tests/task_scheduler/test_repetition.py
+++ b/tests/task_scheduler/test_repetition.py
@@ -200,7 +200,7 @@ def _capture_projected_occurrences(monkeypatch) -> list[str]:
 
     projected: list[str] = []
     monkeypatch.setattr(
-        "unify.task_scheduler.task_scheduler.create_or_adopt_live_task_run",
+        "unify.task_scheduler.task_scheduler.project_task_occurrence",
         lambda provenance: projected.append(provenance.scheduled_for),
     )
     monkeypatch.setattr(

--- a/unify/conversation_manager/comms_manager.py
+++ b/unify/conversation_manager/comms_manager.py
@@ -1020,6 +1020,7 @@ class CommsManager:
                     "is_coordinator": event.get("is_coordinator", False),
                     "is_multiplayer": event.get("is_multiplayer", False),
                     "update_kind": event.get("update_kind", "general"),
+                    "wake_reasons": event.get("wake_reasons") or [],
                 }
                 await publish(
                     "app:comms:assistant_update",

--- a/unify/conversation_manager/domains/event_handlers.py
+++ b/unify/conversation_manager/domains/event_handlers.py
@@ -3370,6 +3370,18 @@ async def _(event: AssistantUpdateEvent, cm: "ConversationManager", *args, **kwa
         cm._coordinator_state_checked_at = 0.0
         await cm._refresh_coordinator_onboarding_state()
 
+    # Updates can carry wake reasons too (e.g. the multiplayer flip's
+    # announcement for a pod that was already live). Replay through the
+    # same chain startup uses; when managers are still initializing the
+    # reasons queue up for the post-init replay instead.
+    if event.wake_reasons:
+        cm._startup_wake_reasons = [
+            *(getattr(cm, "_startup_wake_reasons", None) or []),
+            *event.wake_reasons,
+        ]
+        if cm.initialized:
+            await _consume_startup_wake_reasons(cm)
+
 
 @EventHandler.register(GetChatHistory)
 async def _(event: GetChatHistory, cm: "ConversationManager", *args, **kwargs):

--- a/unify/conversation_manager/domains/task_execution.py
+++ b/unify/conversation_manager/domains/task_execution.py
@@ -972,6 +972,56 @@ async def _dispatch_offline_explicit_candidate_local(
     }
 
 
+def _multiplayer_flipped_wake_reason(reason: object) -> dict | None:
+    """Return the flip payload when the wake reason announces multiplayer."""
+    if (
+        not isinstance(reason, dict)
+        or reason.get("type") != "coordinator_multiplayer_flipped"
+    ):
+        return None
+    return reason
+
+
+async def _handle_multiplayer_flipped_wake_reason(
+    reason: dict,
+    cm: "ConversationManager",
+) -> None:
+    """Surface the multiplayer transition so the brain announces it.
+
+    The flip retires the shared pool contact details out from under the
+    boss's address book, so the very first act of the multiplayer twin is
+    telling them where it now lives. The notification carries every fact
+    the message needs; the brain composes it in its own voice.
+    """
+    from unify.common.prompt_helpers import now as prompt_now
+    from unify.session_details import SESSION_DETAILS
+
+    alias_email = str(reason.get("alias_email") or "") or (
+        SESSION_DETAILS.assistant.email or ""
+    )
+    address_line = (
+        f"My new dedicated email address is {alias_email}. " if alias_email else ""
+    )
+    cm.notifications_bar.push_notif(
+        "System",
+        (
+            "Multiplayer mode is now active. "
+            f"{address_line}"
+            "The shared T-W1N contact details (the old shared email address, "
+            "phone number, and WhatsApp) no longer reach me. I must message "
+            "my boss RIGHT NOW with: my new email address, a heads-up that "
+            "the old shared contact details no longer work, and a pointer to "
+            "my Contact Details page in the Console if they want to add a "
+            "dedicated phone or WhatsApp number for me."
+        ),
+        prompt_now(),
+    )
+    await cm.request_llm_run(
+        delay=0,
+        triggering_contact_id=SESSION_DETAILS.boss_contact_id,
+    )
+
+
 async def _consume_startup_wake_reasons(cm: "ConversationManager") -> None:
     """Replay startup wake reasons once managers are initialized."""
 
@@ -1004,6 +1054,11 @@ async def _consume_startup_wake_reasons(cm: "ConversationManager") -> None:
         )
         if coordinator_delegate_event is not None:
             await _handle_coordinator_delegate_event(coordinator_delegate_event, cm)
+            continue
+
+        flipped_reason = _multiplayer_flipped_wake_reason(wake_reason)
+        if flipped_reason is not None:
+            await _handle_multiplayer_flipped_wake_reason(flipped_reason, cm)
             continue
 
         cm._session_logger.info(

--- a/unify/task_scheduler/custom_tasks.py
+++ b/unify/task_scheduler/custom_tasks.py
@@ -31,6 +31,7 @@ TASK_SYNC_FIELDS = (
     "max_runtime_seconds",
     "repeat",
     "priority",
+    "tags",
     "response_policy",
     "entrypoint_function",
     "offline",
@@ -51,6 +52,7 @@ class CustomTaskSourceEntry(BaseModel):
     max_runtime_seconds: Optional[int] = None
     repeat: Optional[List[Dict[str, Any]]] = None
     priority: str = "normal"
+    tags: Optional[List[str]] = None
     response_policy: Optional[str] = None
     entrypoint_function: Optional[str] = None
     offline: bool = False
@@ -187,6 +189,7 @@ def collect_custom_tasks(
             "max_runtime_seconds": entry.max_runtime_seconds,
             "repeat": entry.repeat,
             "priority": entry.priority,
+            "tags": entry.tags,
             "response_policy": entry.response_policy,
             "entrypoint_function": entry.entrypoint_function,
             "offline": entry.offline,

--- a/unify/task_scheduler/machine_state.py
+++ b/unify/task_scheduler/machine_state.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import time
 from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
 from typing import Any, Mapping
@@ -50,6 +51,7 @@ _TASK_OUTBOUND_OPERATION_CREATE_OR_ADOPT_PATH = (
 )
 _TASK_OUTBOUND_OPERATION_UPDATE_PATH = "/task-outbound-operation/update"
 _TASK_RUN_HTTP_TIMEOUT_SECONDS = 15
+_TASK_RUN_HTTP_ATTEMPTS = 4
 _EXECUTION_QUERY_FIELDS = [
     "assistant_id",
     "destination",
@@ -1064,15 +1066,36 @@ def _orchestra_admin_post(
             "Skipping task-execution persistence because ORCHESTRA_URL or UNIFY_KEY is missing.",
         )
         return None
-    response = requests.post(
-        f"{orchestra_url}{path}",
-        json=dict(payload),
-        headers={"Authorization": f"Bearer {unify_key}"},
-        timeout=_TASK_RUN_HTTP_TIMEOUT_SECONDS,
-    )
-    response.raise_for_status()
-    body = response.json()
-    return body if isinstance(body, dict) else None
+    # Every payload on this path is idempotent — create-or-adopt converges on
+    # run_key / operation_key, and updates are keyed patches — so a transient
+    # failure is retried rather than surfaced. A single 500 here once ended a
+    # recurring series for good: the occurrence that failed to project was the
+    # only thing that would ever project its successor.
+    last_error: Exception | None = None
+    for attempt in range(_TASK_RUN_HTTP_ATTEMPTS):
+        if attempt:
+            time.sleep(2 ** (attempt - 1))
+        try:
+            response = requests.post(
+                f"{orchestra_url}{path}",
+                json=dict(payload),
+                headers={"Authorization": f"Bearer {unify_key}"},
+                timeout=_TASK_RUN_HTTP_TIMEOUT_SECONDS,
+            )
+        except requests.RequestException as exc:
+            last_error = exc
+            continue
+        if response.status_code >= 500 or response.status_code == 429:
+            last_error = requests.HTTPError(
+                f"{response.status_code} from {path}",
+                response=response,
+            )
+            continue
+        response.raise_for_status()
+        body = response.json()
+        return body if isinstance(body, dict) else None
+    assert last_error is not None
+    raise last_error
 
 
 def _drop_none_values(payload: Mapping[str, Any]) -> dict[str, Any]:

--- a/unify/task_scheduler/types/task.py
+++ b/unify/task_scheduler/types/task.py
@@ -79,6 +79,14 @@ class TaskBase(AuthoredRow):
         description="Importance level of the task (low, normal, high, urgent)",
         json_schema_extra={"ui_editable": True},
     )
+    tags: Optional[List[str]] = Field(
+        default=None,
+        description=(
+            "Freeform labels for grouping and filtering tasks (e.g. 'gtm', "
+            "'community'). Tags carry no scheduling semantics."
+        ),
+        json_schema_extra={"ui_editable": True},
+    )
     response_policy: Optional[str] = Field(
         default=None,
         description=(


### PR DESCRIPTION
Ships the task-machine hardening and task tags:

- Retry transient failures when persisting task machine state — one unretried
  Orchestra 500 on create-or-adopt ended a production recurring series.
- Optional `tags` on task definitions, carried from tasks.jsonl through
  reconcile, for the console's new tag filtering.

Also carries the multiplayer-flip wake fix already green on staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)