### PR TITLE
Release: staging → main (hosted proxy spending gate)

### DIFF
--- a/.github/workflows/flow-smoke.yml
+++ b/.github/workflows/flow-smoke.yml
@@ -296,12 +296,33 @@ jobs:
     # Same store the Tests matrix reads and the LLM cache refresh writes, so a
     # flow run replays anything those already paid for.
     - name: Restore .cache.ndjson
+      id: cache-read
       uses: actions/cache/restore@v4
       with:
         path: .cache.ndjson
         key: cache-ndjson-${{ runner.os }}-${{ github.run_id }}-${{ github.run_attempt }}
         restore-keys: |
           cache-ndjson-${{ runner.os }}-
+
+    # See the note in tests.yml: Actions cache is the hot layer, GCS the durable
+    # one behind it, read only when the hot layer misses. Set up whenever the
+    # bucket is configured, not just on a miss — this job also publishes at the
+    # end, on a path a cache hit still reaches.
+    - name: Set up gcloud
+      if: vars.LLM_CACHE_BUCKET != ''
+      uses: google-github-actions/setup-gcloud@v2
+
+    - name: Fall back to the durable LLM cache in GCS
+      if: steps.cache-read.outputs.cache-matched-key == '' && vars.LLM_CACHE_BUCKET != ''
+      run: |
+        obj="gs://${{ vars.LLM_CACHE_BUCKET }}/${{ runner.os }}/cache.ndjson"
+        # An absent object is the pre-first-publish state, not a failure.
+        if gcloud storage objects describe "$obj" >/dev/null 2>&1; then
+          gcloud storage cp "$obj" .cache.ndjson
+          echo "Restored $(grep -c . .cache.ndjson || true) entries from $obj"
+        else
+          echo "No durable cache at $obj yet; flows run fully live."
+        fi
 
     - name: Configure unify/unillm paths for CI
       run: |
@@ -414,6 +435,15 @@ jobs:
       with:
         path: .cache.ndjson
         key: cache-ndjson-${{ runner.os }}-${{ github.run_id }}-${{ github.run_attempt }}
+
+    # Flows buy live completions on every gate, so what they fold back belongs
+    # in the durable copy too, not only in the evictable one.
+    - name: Publish the durable LLM cache to GCS
+      if: always() && steps.consolidate.outputs.publish == 'true' && vars.LLM_CACHE_BUCKET != ''
+      run: |
+        obj="gs://${{ vars.LLM_CACHE_BUCKET }}/${{ runner.os }}/cache.ndjson"
+        gcloud storage cp .cache.ndjson "$obj"
+        echo "Published $(grep -c . .cache.ndjson || true) entries to $obj"
 
     - name: Stop local orchestra
       if: always()

--- a/.github/workflows/llm-cache-refresh.yml
+++ b/.github/workflows/llm-cache-refresh.yml
@@ -532,12 +532,42 @@ jobs:
         echo "Using cache-diff artifacts from run $RUN_ID"
 
     - name: Restore existing consolidated cache
+      id: cache-read
       uses: actions/cache/restore@v4
       with:
         path: .cache.ndjson
         key: cache-ndjson-${{ runner.os }}-${{ github.run_id }}-${{ github.run_attempt }}
         restore-keys: |
           cache-ndjson-${{ runner.os }}-
+
+    - name: Authenticate to Google Cloud
+      if: vars.LLM_CACHE_BUCKET != ''
+      uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed  # v2.1.13
+      with:
+        credentials_json: ${{ secrets.GCP_SERVICE_ACCOUNT_JSON }}
+
+    # Pinned rather than assumed off the runner image: the seed step below reads
+    # a missing object as an empty cache, and a missing gcloud would look
+    # exactly the same to it.
+    - name: Set up gcloud
+      if: vars.LLM_CACHE_BUCKET != ''
+      uses: google-github-actions/setup-gcloud@v2
+
+    # Consolidation is a merge onto whatever this job restored, so seeding it
+    # from the durable copy is what stops a refresh from *shrinking* the store.
+    # The 29 July refresh restored nothing, merged its own 52 entries, and
+    # published that over a 9586-entry history.
+    - name: Seed consolidation from the durable LLM cache in GCS
+      if: steps.cache-read.outputs.cache-matched-key == '' && vars.LLM_CACHE_BUCKET != ''
+      run: |
+        obj="gs://${{ vars.LLM_CACHE_BUCKET }}/${{ runner.os }}/cache.ndjson"
+        # An absent object is the pre-first-publish state, not a failure.
+        if gcloud storage objects describe "$obj" >/dev/null 2>&1; then
+          gcloud storage cp "$obj" .cache.ndjson
+          echo "Seeded $(grep -c . .cache.ndjson || true) entries from $obj"
+        else
+          echo "No durable cache at $obj yet; consolidating from this run only."
+        fi
 
     - name: Download cache diffs from matrix shards
       uses: actions/download-artifact@v4
@@ -578,3 +608,15 @@ jobs:
       with:
         path: .cache.ndjson
         key: cache-ndjson-${{ runner.os }}-${{ github.run_id }}-${{ github.run_attempt }}
+
+    # The durable copy. Everything bought here is paid for with real LLM spend,
+    # so it must outlive the evictable Actions cache. Publishers overwrite rather
+    # than merge remotely: each one consolidates on top of the store it restored,
+    # so two concurrent refreshes can cost one of them a re-buy, which is far
+    # cheaper than the read-modify-write round trip it would take to prevent.
+    - name: Publish the durable LLM cache to GCS
+      if: steps.consolidate.outputs.publish == 'true' && vars.LLM_CACHE_BUCKET != ''
+      run: |
+        obj="gs://${{ vars.LLM_CACHE_BUCKET }}/${{ runner.os }}/cache.ndjson"
+        gcloud storage cp .cache.ndjson "$obj"
+        echo "Published $(grep -c . .cache.ndjson || true) entries to $obj"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1138,6 +1138,33 @@ jobs:
         restore-keys: |
           cache-ndjson-${{ runner.os }}-
 
+    # The Actions cache is the hot layer: it lives beside the runners, so it is
+    # the fast restore and stays the default path. It is also evictable, and
+    # losing it leaves read-only tests with nothing to replay. GCS is the
+    # durable copy behind it, read only when the hot layer misses so that no
+    # job pays a cross-cloud transfer it did not need. Unset LLM_CACHE_BUCKET
+    # leaves the fallback inert and the hot layer behaving exactly as before.
+    # Pinned rather than assumed off the runner image: the fallback below reads
+    # a missing object as an empty cache, and a missing gcloud would look
+    # exactly the same to it.
+    - name: Set up gcloud
+      if: steps.cache-read.outputs.cache-matched-key == '' && vars.LLM_CACHE_BUCKET != ''
+      uses: google-github-actions/setup-gcloud@v2
+
+    - name: Fall back to the durable LLM cache in GCS
+      if: steps.cache-read.outputs.cache-matched-key == '' && vars.LLM_CACHE_BUCKET != ''
+      run: |
+        obj="gs://${{ vars.LLM_CACHE_BUCKET }}/${{ runner.os }}/cache.ndjson"
+        # An absent object is a cache miss, not an error: it is the state
+        # before the first refresh publishes. Any other failure is real and
+        # must surface rather than masquerade as an empty cache.
+        if gcloud storage objects describe "$obj" >/dev/null 2>&1; then
+          gcloud storage cp "$obj" .cache.ndjson
+          echo "Restored $(grep -c . .cache.ndjson || true) entries from $obj"
+        else
+          echo "No durable cache at $obj yet; tests run against an empty store."
+        fi
+
     # Cache orchestra's poetry dependencies keyed on orchestra's commit SHA
     - name: Cache orchestra poetry dependencies
       uses: actions/cache@v4

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -2186,7 +2186,7 @@
         "filename": "tests/gateway/channels/unillm/test_views.py",
         "hashed_secret": "e9a5f12a8ecbb3eb46eca5096b5c52aa5e7c9fdd",
         "is_verified": false,
-        "line_number": 285
+        "line_number": 306
       }
     ],
     "tests/gateway/channels/whatsapp/test_views.py": [
@@ -2380,5 +2380,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-02T00:52:52Z"
+  "generated_at": "2026-08-02T01:12:09Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -2089,7 +2089,7 @@
         "filename": "tests/conversation_manager/core/test_event_handlers.py",
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_verified": false,
-        "line_number": 4155
+        "line_number": 4157
       }
     ],
     "tests/conversation_manager/core/test_event_logging.py": [
@@ -2380,5 +2380,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-02T00:10:49Z"
+  "generated_at": "2026-08-02T00:52:52Z"
 }

--- a/tests/conversation_manager/core/test_brain.py
+++ b/tests/conversation_manager/core/test_brain.py
@@ -82,6 +82,7 @@ def _make_cm():
         ),
         # No Console presence in these sessions, so no orientation block.
         console_guidance=lambda detail="brief": "",
+        console_action_catalogue=lambda: "",
         assistant_job_title="",
         assistant_about="Operations assistant.",
         computer_fast_path_eligible=False,
@@ -160,6 +161,7 @@ class TestBrainSpecStateMessage:
                 hang_up_gate_reason=None,
             ),
             console_guidance=lambda detail="brief": "",
+            console_action_catalogue=lambda: "",
             assistant_job_title="",
             assistant_about="",
             computer_fast_path_eligible=False,

--- a/tests/conversation_manager/core/test_console_actions.py
+++ b/tests/conversation_manager/core/test_console_actions.py
@@ -1,0 +1,118 @@
+"""
+tests/conversation_manager/core/test_console_actions.py
+=======================================================
+
+Pairing a spoken line with the console moves it narrates.
+
+The offsets these produce are what Console counts synchronized transcript
+characters against, so an off-by-one here moves the page on the wrong word. The
+positional assertions below slice the spoken text at each offset and check what
+was said up to that point, which is the property that actually matters.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from unify.conversation_manager.console_actions import (
+    parse_console_actions,
+    strip_markers,
+)
+
+pytestmark = pytest.mark.no_unify_context
+
+TARGETS = ["section:integrations", "route:/billing"]
+
+
+class TestMarkerStripping:
+    def test_markers_never_reach_the_spoken_text(self):
+        """A marker that survives is read aloud, so this is the load-bearing one."""
+        parsed = parse_console_actions("Open Integrations [[1]] now.", TARGETS)
+
+        assert "[[" not in parsed.spoken_text
+        assert "]]" not in parsed.spoken_text
+
+    def test_gap_left_by_a_marker_is_closed(self):
+        parsed = parse_console_actions("Open Integrations [[1]] and wait.", TARGETS)
+
+        assert parsed.spoken_text == "Open Integrations and wait."
+
+    def test_space_before_punctuation_is_closed(self):
+        parsed = parse_console_actions("Open Integrations [[1]], then wait.", TARGETS)
+
+        assert parsed.spoken_text == "Open Integrations, then wait."
+
+    def test_a_line_opening_with_a_marker_keeps_no_leading_space(self):
+        parsed = parse_console_actions("[[1]] Here we are.", TARGETS)
+
+        assert parsed.spoken_text == "Here we are."
+
+    def test_strip_markers_leaves_a_speakable_line(self):
+        assert strip_markers("Open it [[1]] now.") == "Open it now."
+
+    def test_a_line_without_markers_is_untouched(self):
+        assert strip_markers("Nothing to strip.") == "Nothing to strip."
+
+
+class TestOffsets:
+    def test_offset_lands_after_the_words_it_follows(self):
+        parsed = parse_console_actions(
+            "I'll open Integrations [[1]], and billing is here [[2]].",
+            TARGETS,
+        )
+
+        first, second = parsed.steps
+        assert parsed.spoken_text[: first.after_chars].endswith("Integrations")
+        assert parsed.spoken_text[: second.after_chars].endswith("here")
+
+    def test_every_offset_indexes_inside_the_spoken_text(self):
+        parsed = parse_console_actions(
+            "One [[1]] and two [[2]] done.",
+            TARGETS,
+        )
+
+        for step in parsed.steps:
+            assert 0 <= step.after_chars <= len(parsed.spoken_text)
+
+    def test_offsets_follow_marker_order(self):
+        parsed = parse_console_actions("A [[1]] B [[2]] C.", TARGETS)
+
+        offsets = [step.after_chars for step in parsed.steps]
+        assert offsets == sorted(offsets)
+
+    def test_targets_are_taken_in_marker_order_not_text_order(self):
+        """``[[2]]`` takes the second target even when it is spoken first."""
+        parsed = parse_console_actions("First [[2]] then [[1]].", TARGETS)
+
+        assert [step.target for step in parsed.steps] == [
+            "route:/billing",
+            "section:integrations",
+        ]
+
+
+class TestMismatches:
+    def test_marker_without_a_target_is_dropped_not_shifted(self):
+        """Miscounting must not silently move the user somewhere else."""
+        parsed = parse_console_actions("A [[1]] B [[2]].", ["section:integrations"])
+
+        assert [step.target for step in parsed.steps] == ["section:integrations"]
+        assert any("[[2]]" in note for note in parsed.dropped)
+
+    def test_target_without_a_marker_is_reported(self):
+        parsed = parse_console_actions("Just talking [[1]].", TARGETS)
+
+        assert len(parsed.steps) == 1
+        assert any("route:/billing" in note for note in parsed.dropped)
+
+    def test_line_is_still_speakable_when_everything_mismatches(self):
+        parsed = parse_console_actions("Nothing lines up [[9]].", [])
+
+        assert parsed.spoken_text == "Nothing lines up."
+        assert parsed.steps == ()
+
+    def test_no_targets_yields_a_clean_line_and_no_moves(self):
+        """The off-console path: speak the line, make no moves."""
+        parsed = parse_console_actions("Open Integrations [[1]] now.", [])
+
+        assert parsed.spoken_text == "Open Integrations now."
+        assert parsed.steps == ()

--- a/tests/conversation_manager/core/test_console_actions.py
+++ b/tests/conversation_manager/core/test_console_actions.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import pytest
 
 from unify.conversation_manager.console_actions import (
+    catalogue_form,
     parse_console_actions,
     strip_markers,
 )
@@ -116,3 +117,32 @@ class TestMismatches:
 
         assert parsed.spoken_text == "Open Integrations now."
         assert parsed.steps == ()
+
+
+class TestCatalogueLookup:
+    """Checking a target against the list Console published.
+
+    A control that takes a name is listed once, under a placeholder, because
+    there is one per connectable app. Looking up the specific name has to find
+    that line rather than an id the catalogue could never hold.
+    """
+
+    def test_a_named_control_looks_up_under_its_placeholder(self):
+        assert catalogue_form("leaf:integration:github") == "leaf:integration:<name>"
+
+    def test_a_fixed_control_looks_itself_up(self):
+        assert catalogue_form("leaf:add-integration") == "leaf:add-integration"
+
+    @pytest.mark.parametrize(
+        "target",
+        ["section:integrations", "route:/billing", "account:security"],
+    )
+    def test_navigation_targets_are_untouched(self, target):
+        assert catalogue_form(target) == target
+
+    def test_an_empty_name_is_left_to_fail_the_lookup(self):
+        """Not rewritten into a valid placeholder, so it is rejected upstream."""
+        assert catalogue_form("leaf:integration:") == "leaf:integration:"
+
+    def test_extra_segments_are_left_to_fail_the_lookup(self):
+        assert catalogue_form("leaf:integration:a:b") == "leaf:integration:a:b"

--- a/tests/conversation_manager/core/test_console_presence.py
+++ b/tests/conversation_manager/core/test_console_presence.py
@@ -44,6 +44,8 @@ class _PresenceHost:
 
     record_console_presence = cm_module.ConversationManager.record_console_presence
     console_guidance = cm_module.ConversationManager.console_guidance
+    console_is_open = cm_module.ConversationManager.console_is_open
+    console_action_catalogue = cm_module.ConversationManager.console_action_catalogue
 
     def __init__(self) -> None:
         self._console_guidance: dict[str, str] = {}
@@ -160,6 +162,64 @@ class TestHeartbeatPayload:
 
         assert host._console_presence_at is not None
         assert host.console_guidance("brief") == ""
+
+
+# =============================================================================
+# Navigation targets
+# =============================================================================
+
+
+CATALOGUE = "Places I can take my boss\n- `section:integrations` — Integrations"
+
+
+class TestActionCatalogue:
+    def test_catalogue_available_while_the_console_is_open(self, host):
+        host.record_console_presence(
+            version="v1",
+            brief=BRIEF,
+            full=FULL,
+            actions=CATALOGUE,
+        )
+
+        assert host.console_is_open() is True
+        assert host.console_action_catalogue() == CATALOGUE
+
+    def test_catalogue_withheld_once_presence_goes_stale(self, host, clock):
+        """The tool is gated on this, so a shut console withdraws the ability.
+
+        Taking someone to a page they are not looking at accomplishes nothing,
+        and narrating the move would be a plain falsehood.
+        """
+        host.record_console_presence(
+            version="v1",
+            brief=BRIEF,
+            full=FULL,
+            actions=CATALOGUE,
+        )
+        clock.advance(CONSOLE_PRESENCE_TTL_S + 1)
+
+        assert host.console_is_open() is False
+        assert host.console_action_catalogue() == ""
+
+    def test_no_catalogue_before_any_presence(self, host):
+        assert host.console_is_open() is False
+        assert host.console_action_catalogue() == ""
+
+    def test_catalogue_and_guidance_open_and_close_together(self, host, clock):
+        host.record_console_presence(
+            version="v1",
+            brief=BRIEF,
+            full=FULL,
+            actions=CATALOGUE,
+        )
+        assert bool(host.console_guidance("brief")) == bool(
+            host.console_action_catalogue(),
+        )
+
+        clock.advance(CONSOLE_PRESENCE_TTL_S + 1)
+        assert bool(host.console_guidance("brief")) == bool(
+            host.console_action_catalogue(),
+        )
 
 
 # =============================================================================

--- a/tests/conversation_manager/core/test_event_handlers.py
+++ b/tests/conversation_manager/core/test_event_handlers.py
@@ -2193,6 +2193,7 @@ class TestMeetInteractionEventHandlers:
             console_guidance_version="guidance-v2",
             console_guidance_brief="Console knowledge\nBrief.",
             console_guidance_full="Console knowledge\nFull.",
+            console_action_catalogue="- `section:chat` — Chat",
         )
         await EventHandler.handle_event(event, mock_cm)
 
@@ -2200,6 +2201,7 @@ class TestMeetInteractionEventHandlers:
             version="guidance-v2",
             brief="Console knowledge\nBrief.",
             full="Console knowledge\nFull.",
+            actions="- `section:chat` — Chat",
         )
 
     # --------------------------------------------------------------------- #

--- a/tests/flows/conftest.py
+++ b/tests/flows/conftest.py
@@ -90,6 +90,13 @@ if os.environ.get("UNILLM_CACHE_DIR", _repo_root) == _repo_root:
         if os.path.exists(_shared) and not os.path.lexists(_private):
             os.symlink(_shared, _private)
     os.environ["UNILLM_CACHE_DIR"] = _session_cache_dir
+    # The variable alone would not move anything. Backends bind their directory
+    # when their class body runs, and the root conftest imports unillm long
+    # before this file executes, so the session directory has to be applied
+    # through the API. The variable is still set for anything reading it fresh.
+    import unillm
+
+    unillm.set_cache_dir(_session_cache_dir)
 os.environ.setdefault("UNILLM_CACHE", "true")
 
 import contextlib

--- a/tests/gateway/channels/unillm/test_views.py
+++ b/tests/gateway/channels/unillm/test_views.py
@@ -4,6 +4,11 @@ Smallest channel; one endpoint (POST /chat/completions). Tests
 cover router contract + the two inlined auth helpers + both code
 paths (stream + non-stream). The actual UniLLM call is mocked --
 this is a transport / auth proxy test, not an LLM behaviour test.
+
+Spending enforcement is covered here too: this endpoint spends real
+money on a bare user API key, and it shipped for a time with no gates
+at all because the limit-check hook was never installed in a gateway
+process. The ``TestSpendingEnforcement`` cases pin that shut.
 """
 
 from __future__ import annotations
@@ -191,6 +196,22 @@ class TestAuthenticateUserApiKey:
 
 
 class TestChatCompletions:
+    @pytest.fixture(autouse=True)
+    def _limits_allowed(self):
+        """Hold the spending gate open for the transport/auth cases.
+
+        These assert proxying behaviour, not billing. Without this they
+        reach a real ``/user/spend`` and their outcome depends on whether
+        a local Orchestra happens to be up.
+        """
+        from unillm.limit_hooks import LimitCheckResponse
+
+        async def _allow(_request):
+            return LimitCheckResponse(allowed=True)
+
+        with patch("unillm.limit_hooks._LIMIT_CHECK_HOOK", _allow):
+            yield
+
     def test_missing_api_key_returns_401(
         self,
         client: TestClient,
@@ -363,3 +384,473 @@ class TestChatCompletions:
                 headers={"Authorization": "Bearer sk-test"},
             )
         assert MockAsync.call_args.kwargs["max_completion_tokens"] == 42
+
+
+# ---------------------------------------------------------------------------
+# Spending enforcement
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _hook_installed():
+    """Register the real limit-check callback for the duration of a test.
+
+    ``install_multi_tenant_limit_check_hook`` no-ops when platform billing
+    is off, so tests register directly rather than depending on the
+    ambient DEPLOY_ENV.
+    """
+    import unillm
+
+    from unify.spending_limits import check_spending_limits_callback
+
+    previous = unillm.get_limit_check_hook()
+    unillm.set_limit_check_hook(check_spending_limits_callback)
+    try:
+        yield
+    finally:
+        unillm.set_limit_check_hook(previous)
+
+
+def _denied(reason: str = "Insufficient credits: balance is $0.00."):
+    """Patch the limit hook to a flat denial."""
+    from unillm.limit_hooks import LimitCheckResponse
+
+    async def _hook(_request):
+        return LimitCheckResponse(allowed=False, reason=reason)
+
+    return patch("unillm.limit_hooks._LIMIT_CHECK_HOOK", _hook)
+
+
+class TestSpendingEnforcement:
+    def test_channel_import_installs_the_hook_when_billing_is_on(self) -> None:
+        """The module that mounts the route also installs the gates.
+
+        Without this the proxy silently enforces nothing, because UniLLM
+        treats a missing hook as 'allowed'. Re-invokes the installer
+        rather than relying on import order, since another test may have
+        swapped the hook out.
+        """
+        import unillm
+
+        from unify.spending_limits import (
+            check_spending_limits_callback,
+            install_multi_tenant_limit_check_hook,
+        )
+
+        previous = unillm.get_limit_check_hook()
+        unillm.set_limit_check_hook(None)
+        try:
+            with patch(
+                "unify.spending_limits._charges_billing",
+                return_value=True,
+            ):
+                install_multi_tenant_limit_check_hook()
+            assert unillm.get_limit_check_hook() is check_spending_limits_callback
+        finally:
+            unillm.set_limit_check_hook(previous)
+
+    def test_installer_does_not_require_a_process_unify_key(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The regression that caused the outage.
+
+        ``install_limit_check_hook`` bails when ``UNIFY_KEY`` is unset,
+        which is the normal state of a gateway process — the caller's key
+        arrives per request. The multi-tenant installer must not.
+        """
+        import unillm
+
+        from unify.spending_limits import install_multi_tenant_limit_check_hook
+
+        monkeypatch.delenv("UNIFY_KEY", raising=False)
+        previous = unillm.get_limit_check_hook()
+        unillm.set_limit_check_hook(None)
+        try:
+            with patch(
+                "unify.spending_limits._charges_billing",
+                return_value=True,
+            ):
+                install_multi_tenant_limit_check_hook()
+            assert unillm.get_limit_check_hook() is not None
+        finally:
+            unillm.set_limit_check_hook(previous)
+
+    def test_non_stream_denial_returns_402(
+        self,
+        client: TestClient,
+        _orchestra_settings: None,
+    ) -> None:
+        fake_client = MagicMock()
+        fake_client.generate = AsyncMock(
+            side_effect=AssertionError("LLM must not be called when denied"),
+        )
+
+        with (
+            patch(
+                "unify.gateway.channels.unillm.views.httpx.AsyncClient",
+                return_value=_async_httpx_client(_ok_orchestra_response()),
+            ),
+            patch(
+                "unify.gateway.channels.unillm.views.unillm.AsyncUnify",
+                return_value=fake_client,
+            ),
+            _denied(),
+        ):
+            resp = client.post(
+                "/unillm/chat/completions",
+                json={
+                    "model": "gpt-4o@openai",
+                    "messages": [{"role": "user", "content": "hi"}],
+                },
+                headers={"Authorization": "Bearer sk-test"},
+            )
+
+        assert resp.status_code == 402
+        assert "Insufficient credits" in resp.json()["detail"]
+
+    def test_stream_denial_returns_402_before_any_bytes(
+        self,
+        client: TestClient,
+        _orchestra_settings: None,
+    ) -> None:
+        """A denied stream must fail as a 402, not a 200 carrying an error.
+
+        Once StreamingResponse is returned the status line is committed,
+        so the gates run before the response object is constructed.
+        """
+        fake_client = MagicMock()
+        fake_client.generate = MagicMock(
+            side_effect=AssertionError("LLM must not be called when denied"),
+        )
+
+        with (
+            patch(
+                "unify.gateway.channels.unillm.views.httpx.AsyncClient",
+                return_value=_async_httpx_client(_ok_orchestra_response()),
+            ),
+            patch(
+                "unify.gateway.channels.unillm.views.unillm.AsyncUnify",
+                return_value=fake_client,
+            ),
+            _denied("Daily trial spend limit reached ($25.00 of $25.00 today)."),
+        ):
+            resp = client.post(
+                "/unillm/chat/completions",
+                json={
+                    "model": "gpt-4o@openai",
+                    "messages": [{"role": "user", "content": "hi"}],
+                    "stream": True,
+                },
+                headers={"Authorization": "Bearer sk-test"},
+            )
+
+        assert resp.status_code == 402
+        assert "Daily trial spend limit" in resp.json()["detail"]
+        assert "data:" not in resp.text
+
+    def test_limits_resolve_against_the_caller_not_the_process_key(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        client: TestClient,
+        _orchestra_settings: None,
+        _hook_installed: None,
+    ) -> None:
+        """The wallet checked must be the caller's, not the gateway's.
+
+        A shared process key would bill and gate every tenant against one
+        account, which on a public endpoint is the whole ballgame.
+        """
+        monkeypatch.setenv("UNIFY_KEY", "sk-gateway-process-key")
+        seen: dict = {}
+
+        async def _capture_user_limit(user_id, month):
+            from unify.spending_limits import _get_api_key
+
+            seen["api_key"] = _get_api_key()
+            seen["user_id"] = user_id
+            return SimpleNamespace(
+                exceeded=False,
+                credit_balance=10.0,
+                billing_mode="CREDITS",
+                account_suspended=False,
+                trial_daily_spend=None,
+                trial_daily_cap=None,
+                limit_type=None,
+                limit_value=None,
+                current_spend=None,
+                entity_id=None,
+                entity_name=None,
+            )
+
+        fake_response = MagicMock()
+        fake_response.model_dump.return_value = {"id": "chatcmpl-1"}
+        fake_client = MagicMock()
+        fake_client.generate = AsyncMock(return_value=fake_response)
+
+        with (
+            patch(
+                "unify.gateway.channels.unillm.views.httpx.AsyncClient",
+                return_value=_async_httpx_client(_ok_orchestra_response()),
+            ),
+            patch(
+                "unify.gateway.channels.unillm.views.unillm.AsyncUnify",
+                return_value=fake_client,
+            ),
+            patch(
+                "unify.spending_limits._check_user_limit",
+                _capture_user_limit,
+            ),
+        ):
+            resp = client.post(
+                "/unillm/chat/completions",
+                json={
+                    "model": "gpt-4o@openai",
+                    "messages": [{"role": "user", "content": "hi"}],
+                },
+                headers={"Authorization": "Bearer sk-caller"},
+            )
+
+        assert resp.status_code == 200
+        assert seen["api_key"] == "sk-caller"  # pragma: allowlist secret
+        assert seen["user_id"] == "u-1"
+
+    def test_caller_context_restores_the_process_key_on_exit(self) -> None:
+        """A leaked contextvar would mis-bill the next request on the loop."""
+        import asyncio
+
+        from unify.spending_limits import _get_api_key, caller_context
+
+        async def _run() -> tuple:
+            import os
+
+            os.environ["UNIFY_KEY"] = "sk-process"
+            async with caller_context("sk-tenant", user_id="u-9"):
+                inside = _get_api_key()
+            return inside, _get_api_key()
+
+        inside, after = asyncio.run(_run())
+        assert inside == "sk-tenant"
+        assert after == "sk-process"
+
+    def test_unverifiable_limits_fail_closed_for_a_proxy_caller(
+        self,
+        client: TestClient,
+        _orchestra_settings: None,
+        _hook_installed: None,
+    ) -> None:
+        """An Orchestra error must not become free LLM access.
+
+        The runtime fails open on the same error (availability for a
+        paying customer mid-task); a public endpoint spending against a
+        wallet it just failed to read must not.
+        """
+        from unisdk.async_admin import SpendRequestError
+
+        # Raised from inside the spend client so the real handler in
+        # ``_check_user_limit`` is what classifies it, not the gather.
+        async def _boom(month):
+            raise SpendRequestError(
+                url="/user/spend",
+                method="GET",
+                status=503,
+                body="upstream unavailable",
+            )
+
+        fake_client = MagicMock()
+        fake_client.generate = AsyncMock(
+            side_effect=AssertionError("LLM must not be called when unverified"),
+        )
+
+        with (
+            patch(
+                "unify.gateway.channels.unillm.views.httpx.AsyncClient",
+                return_value=_async_httpx_client(_ok_orchestra_response()),
+            ),
+            patch(
+                "unify.gateway.channels.unillm.views.unillm.AsyncUnify",
+                return_value=fake_client,
+            ),
+            patch(
+                "unify.spending_limits._get_spend_client",
+                return_value=SimpleNamespace(get_user_spend=_boom),
+            ),
+        ):
+            resp = client.post(
+                "/unillm/chat/completions",
+                json={
+                    "model": "gpt-4o@openai",
+                    "messages": [{"role": "user", "content": "hi"}],
+                },
+                headers={"Authorization": "Bearer sk-test"},
+            )
+
+        assert resp.status_code == 402
+        assert "verify account spending limits" in resp.json()["detail"]
+
+    def test_missing_limit_is_not_treated_as_a_failed_check(
+        self,
+        client: TestClient,
+        _orchestra_settings: None,
+        _hook_installed: None,
+    ) -> None:
+        """A clean 404 means 'no cap set', which must still allow the call.
+
+        Conflating it with an unreachable Orchestra would deny every
+        account that has never configured a spending limit.
+        """
+        from unisdk.async_admin import SpendRequestError
+
+        async def _not_found(month):
+            raise SpendRequestError(
+                url="/user/spend",
+                method="GET",
+                status=404,
+                body="no limit",
+            )
+
+        fake_response = MagicMock()
+        fake_response.model_dump.return_value = {"id": "chatcmpl-1"}
+        fake_client = MagicMock()
+        fake_client.generate = AsyncMock(return_value=fake_response)
+
+        with (
+            patch(
+                "unify.gateway.channels.unillm.views.httpx.AsyncClient",
+                return_value=_async_httpx_client(_ok_orchestra_response()),
+            ),
+            patch(
+                "unify.gateway.channels.unillm.views.unillm.AsyncUnify",
+                return_value=fake_client,
+            ),
+            patch(
+                "unify.spending_limits._get_spend_client",
+                return_value=SimpleNamespace(get_user_spend=_not_found),
+            ),
+        ):
+            resp = client.post(
+                "/unillm/chat/completions",
+                json={
+                    "model": "gpt-4o@openai",
+                    "messages": [{"role": "user", "content": "hi"}],
+                },
+                headers={"Authorization": "Bearer sk-test"},
+            )
+
+        assert resp.status_code == 200
+
+    def test_unverifiable_limits_still_fail_open_for_the_runtime(self) -> None:
+        """No caller context means the assistant runtime: availability wins."""
+        import asyncio
+
+        from unillm.limit_hooks import LimitCheckRequest
+
+        from unify.spending_limits import check_spending_limits_callback
+
+        async def _boom(user_id, month):
+            raise RuntimeError("orchestra down")
+
+        async def _run():
+            import os
+
+            os.environ["UNIFY_KEY"] = "sk-runtime"
+            with patch("unify.spending_limits._check_user_limit", _boom):
+                return await check_spending_limits_callback(
+                    LimitCheckRequest(model="gpt-4o@openai", endpoint="chat"),
+                )
+
+        assert asyncio.run(_run()).allowed is True
+
+    def test_free_tier_account_is_denied_api_access(
+        self,
+        client: TestClient,
+        _orchestra_settings: None,
+        _hook_installed: None,
+    ) -> None:
+        """Console-only free credits, enforced at the proxy.
+
+        Orchestra decides; the runtime just carries the verdict on the
+        existing spend payload.
+        """
+
+        async def _no_api_access(month):
+            return {
+                "cumulative_spend": 0,
+                "limit": None,
+                "credit_balance": 50.0,
+                "billing_mode": "CREDITS",
+                "account_suspended": False,
+                "api_access_allowed": False,
+            }
+
+        fake_client = MagicMock()
+        fake_client.generate = AsyncMock(
+            side_effect=AssertionError("LLM must not be called when denied"),
+        )
+
+        with (
+            patch(
+                "unify.gateway.channels.unillm.views.httpx.AsyncClient",
+                return_value=_async_httpx_client(_ok_orchestra_response()),
+            ),
+            patch(
+                "unify.gateway.channels.unillm.views.unillm.AsyncUnify",
+                return_value=fake_client,
+            ),
+            patch(
+                "unify.spending_limits._get_spend_client",
+                return_value=SimpleNamespace(get_user_spend=_no_api_access),
+            ),
+        ):
+            resp = client.post(
+                "/unillm/chat/completions",
+                json={
+                    "model": "gpt-4o@openai",
+                    "messages": [{"role": "user", "content": "hi"}],
+                },
+                headers={"Authorization": "Bearer sk-test"},
+            )
+
+        assert resp.status_code == 402
+        assert "only be spent through the Unify Console" in resp.json()["detail"]
+
+    def test_console_driven_runtime_work_is_never_api_gated(self) -> None:
+        """The gate must not touch the Console's own path.
+
+        The runtime has no caller context, so a false ``api_access_allowed``
+        has to be inert there — otherwise turning the flag on would stop
+        every free account from using the product at all, which is the
+        opposite of the intent.
+        """
+        import asyncio
+        import os
+
+        from unillm.limit_hooks import LimitCheckRequest
+
+        from unify.spending_limits import check_spending_limits_callback
+
+        async def _no_api_access(user_id, month):
+            return SimpleNamespace(
+                exceeded=False,
+                credit_balance=50.0,
+                billing_mode="CREDITS",
+                account_suspended=False,
+                trial_daily_spend=None,
+                trial_daily_cap=None,
+                check_failed=False,
+                api_access_allowed=False,
+                limit_type=None,
+                limit_value=None,
+                current_spend=None,
+                entity_id=None,
+                entity_name=None,
+            )
+
+        async def _run():
+            os.environ["UNIFY_KEY"] = "sk-runtime"
+            with patch("unify.spending_limits._check_user_limit", _no_api_access):
+                return await check_spending_limits_callback(
+                    LimitCheckRequest(model="gpt-4o@openai", endpoint="chat"),
+                )
+
+        assert asyncio.run(_run()).allowed is True

--- a/unify/conversation_manager/comms_manager.py
+++ b/unify/conversation_manager/comms_manager.py
@@ -1115,6 +1115,9 @@ class CommsManager:
                         console_guidance_full=str(
                             event.get("console_guidance_full") or "",
                         ),
+                        console_action_catalogue=str(
+                            event.get("console_action_catalogue") or "",
+                        ),
                     ),
                     "assistant_turn_injected": lambda r: _assistant_turn_injected_from_payload(
                         event,

--- a/unify/conversation_manager/console_actions.py
+++ b/unify/conversation_manager/console_actions.py
@@ -1,0 +1,105 @@
+"""Pairing a spoken line with the console moves it narrates.
+
+The slow brain writes ``[[1]]``, ``[[2]]`` into the line it wants spoken and
+lists the matching targets on ``show_in_console``. The markers never reach TTS:
+they are removed here, and what is kept is each one's position in the clean
+text, so Console can make the move on the words rather than on a timer.
+
+Positions are measured in characters of the spoken text because that is what
+Console can count as the synchronized transcript arrives. Anything time-based
+would drift with speech rate and would keep firing after a barge-in.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+# Doubled brackets: rare in speech, trivial to strip, and visibly wrong in a
+# transcript if a line ever escapes with one still in it.
+_MARKER = re.compile(r"\[\[(\d+)\]\]")
+
+
+@dataclass(frozen=True)
+class ConsoleActionStep:
+    target: str
+    after_chars: int
+
+
+@dataclass(frozen=True)
+class ParsedUtterance:
+    """A line ready to speak, and the moves to make while it plays."""
+
+    spoken_text: str
+    steps: tuple[ConsoleActionStep, ...]
+    #: Markers with no matching target, or targets with no marker. The line is
+    #: still spoken; only the unmatched moves are dropped.
+    dropped: tuple[str, ...]
+
+
+def parse_console_actions(message: str, targets: list[str]) -> ParsedUtterance:
+    """Strip markers from ``message`` and place ``targets`` at their positions.
+
+    Marker ``[[n]]`` takes the nth target, one-indexed, matching how the tool
+    documents itself. A marker without a target is dropped rather than shifting
+    the rest along: a mismatch means the model miscounted, and moving the user
+    somewhere it did not mean is worse than not moving them.
+    """
+    steps: list[ConsoleActionStep] = []
+    dropped: list[str] = []
+    used: set[int] = set()
+    # Leading whitespace goes before any offset is measured; tidying it later
+    # would shift every position already recorded.
+    spoken = message.lstrip()
+    out: list[str] = []
+    cursor = 0
+
+    for match in _MARKER.finditer(spoken):
+        out.append(spoken[cursor : match.start()])
+        cursor = match.end()
+        remainder = spoken[cursor:]
+        # A marker lifted from mid-sentence leaves either a doubled space or a
+        # space before punctuation. Close the gap now, so the offset recorded
+        # below indexes the text that will actually be spoken.
+        if out and out[-1].endswith(" ") and re.match(r"[\s,.!?;:]", remainder):
+            out[-1] = out[-1][:-1]
+        elif not any(out):
+            # Marker opened the line; drop the space it left in front. The
+            # offset recorded below stays 0 either way, which is the start.
+            cursor += len(remainder) - len(remainder.lstrip())
+
+        index = int(match.group(1))
+        if not 1 <= index <= len(targets):
+            dropped.append(f"marker [[{index}]] has no target")
+            continue
+        used.add(index)
+        steps.append(
+            ConsoleActionStep(
+                target=targets[index - 1],
+                after_chars=sum(len(part) for part in out),
+            ),
+        )
+
+    out.append(spoken[cursor:])
+    # Trailing whitespace only; every recorded offset sits before it.
+    spoken = "".join(out).rstrip()
+
+    for index, target in enumerate(targets, start=1):
+        if index not in used:
+            dropped.append(f"target {target} has no [[{index}]] marker")
+
+    return ParsedUtterance(
+        spoken_text=spoken,
+        steps=tuple(steps),
+        dropped=tuple(dropped),
+    )
+
+
+def strip_markers(message: str) -> str:
+    """Remove markers without pairing anything, for paths that only speak.
+
+    Used when a line carries markers but the moves cannot run — no Console open,
+    or ``show_in_console`` was never called. The line is still worth speaking;
+    the markers are not worth reading aloud.
+    """
+    return parse_console_actions(message, []).spoken_text

--- a/unify/conversation_manager/console_actions.py
+++ b/unify/conversation_manager/console_actions.py
@@ -95,6 +95,23 @@ def parse_console_actions(message: str, targets: list[str]) -> ParsedUtterance:
     )
 
 
+def catalogue_form(target: str) -> str:
+    """The catalogue line a target should be looked up under.
+
+    Console lists a parameterized control once, as ``leaf:<id>:<name>``, because
+    the parameter is open-ended -- there is a card per connectable app. Naming a
+    specific one has to be checked against that placeholder rather than against
+    an id the catalogue could never contain.
+
+    This is the only shape Console's target grammar is known here. Everything
+    else is an opaque string that either appears in the catalogue or does not.
+    """
+    parts = target.split(":")
+    if target.startswith("leaf:") and len(parts) == 3 and parts[2]:
+        return f"leaf:{parts[1]}:<name>"
+    return target
+
+
 def strip_markers(message: str) -> str:
     """Remove markers without pairing anything, for paths that only speak.
 

--- a/unify/conversation_manager/conversation_manager.py
+++ b/unify/conversation_manager/conversation_manager.py
@@ -14,6 +14,10 @@ from unify.common.diagnostic_logging import staging_diagnostics_enabled
 from unify.session_details import SESSION_DETAILS
 from unify.coordinator_voice import resolve_runtime_voice
 from unify.settings import SETTINGS
+from unify.conversation_manager.console_actions import (
+    parse_console_actions,
+    strip_markers,
+)
 from unify.manager_registry import SingletonABCMeta
 from unify.common.async_tool_loop import SteerableToolHandle
 from unify.common.hierarchical_logger import SessionLogger
@@ -753,6 +757,7 @@ class ConversationManager(metaclass=SingletonABCMeta):
         version: str = "",
         brief: str = "",
         full: str = "",
+        actions: str = "",
     ) -> None:
         """Note that Console reported the user present, and keep any text it sent.
 
@@ -769,7 +774,24 @@ class ConversationManager(metaclass=SingletonABCMeta):
                 f"Console guidance updated to version {version}.",
             )
         self._console_guidance_version = version
-        self._console_guidance = {"brief": brief, "full": full}
+        self._console_guidance = {"brief": brief, "full": full, "actions": actions}
+
+    def console_is_open(self) -> bool:
+        """Whether Console reported the user present recently enough to count."""
+        if self._console_presence_at is None:
+            return False
+        return time.monotonic() - self._console_presence_at <= CONSOLE_PRESENCE_TTL_S
+
+    def console_action_catalogue(self) -> str:
+        """Navigation targets Console currently offers, or ``""`` when it is shut.
+
+        Gated with the orientation text and for the same reason, plus one of its
+        own: taking someone to a page they are not looking at accomplishes
+        nothing, so the tool that consumes this is withheld along with it.
+        """
+        if not self.console_is_open():
+            return ""
+        return self._console_guidance.get("actions", "")
 
     def console_guidance(self, detail: str = "brief") -> str:
         """Console orientation text, but only while the user is on the Console.
@@ -780,9 +802,7 @@ class ConversationManager(metaclass=SingletonABCMeta):
         keep-warm heartbeat so an idle-but-present user does not flicker in and
         out of it, since each flip costs a prompt-cache miss.
         """
-        if self._console_presence_at is None:
-            return ""
-        if time.monotonic() - self._console_presence_at > CONSOLE_PRESENCE_TTL_S:
+        if not self.console_is_open():
             return ""
         return self._console_guidance.get(detail, "")
 
@@ -1482,6 +1502,7 @@ class ConversationManager(metaclass=SingletonABCMeta):
         message: str,
         slow_brain_log_path: str = "",
         fast_brain_guidance: str = "",
+        console_steps: list[dict[str, Any]] | None = None,
     ) -> None:
         """Publish a slow-brain spoken line (``guide_voice_agent``) to the fast brain.
 
@@ -1501,6 +1522,7 @@ class ConversationManager(metaclass=SingletonABCMeta):
             source="slow_brain",
             llm_log_path=slow_brain_log_path,
             fast_brain_guidance=fast_brain_guidance,
+            console_steps=console_steps or [],
         )
         self._session_logger.info(
             "call_notification",
@@ -2477,12 +2499,37 @@ class ConversationManager(metaclass=SingletonABCMeta):
         if self.mode.is_voice:
             guidance_message = ""
             fast_brain_guidance = ""
+            console_targets: list[str] = []
             for tool_exec in result.tools:
                 if tool_exec.name == "guide_voice_agent":
                     args = tool_exec.args or {}
                     guidance_message = args.get("message", "")
                     fast_brain_guidance = args.get("fast_brain_guidance", "")
-                    break
+                elif tool_exec.name == "show_in_console":
+                    raw = (tool_exec.args or {}).get("targets") or []
+                    console_targets = [str(t) for t in raw if str(t).strip()]
+
+            # The spoken line may carry [[n]] markers naming console moves. They
+            # are stripped here either way -- a line that reaches TTS with one
+            # still in it gets read aloud -- and the moves survive only when the
+            # console is open to make them.
+            console_steps: list[dict[str, Any]] = []
+            if guidance_message and "[[" in guidance_message:
+                if console_targets and self.console_is_open():
+                    parsed = parse_console_actions(guidance_message, console_targets)
+                    guidance_message = parsed.spoken_text
+                    console_steps = [
+                        {"target": step.target, "afterChars": step.after_chars}
+                        for step in parsed.steps
+                    ]
+                    if parsed.dropped:
+                        self._session_logger.info(
+                            "console_actions",
+                            f"Dropped console moves: {'; '.join(parsed.dropped)}.",
+                        )
+                else:
+                    # Markers with nothing to drive them: still not speakable.
+                    guidance_message = strip_markers(guidance_message)
 
             # A pending hang-up (recorded by the hang_up tool this turn) must not
             # tear down the session until the spoken line has been delivered,
@@ -2503,6 +2550,7 @@ class ConversationManager(metaclass=SingletonABCMeta):
                     message=guidance_message,
                     slow_brain_log_path=slow_brain_log_path,
                     fast_brain_guidance=fast_brain_guidance,
+                    console_steps=console_steps,
                 )
                 # Stash the spoken line for a render-only overlay so the next run
                 # (which may start before the real `[You]` utterance is recorded)

--- a/unify/conversation_manager/domains/brain.py
+++ b/unify/conversation_manager/domains/brain.py
@@ -258,6 +258,7 @@ def build_brain_spec(
         console_guidance=cm.console_guidance(
             "full" if SESSION_DETAILS.is_coordinator else "brief",
         ),
+        console_action_catalogue=cm.console_action_catalogue(),
         coordinator_onboarding_active=cm.coordinator_onboarding_active,
         coordinator_onboarding_render=cm.coordinator_onboarding_render,
         coordinator_clicked_trigger_steps=cm.onboarding_clicked_trigger_steps,

--- a/unify/conversation_manager/domains/brain_action_tools.py
+++ b/unify/conversation_manager/domains/brain_action_tools.py
@@ -2309,6 +2309,55 @@ class ConversationManagerBrainActionTools:
         """
         return {"status": "guidance_noted"}
 
+    async def show_in_console(
+        self,
+        *,
+        targets: list[str],
+    ) -> dict[str, Any]:
+        """
+        Take my boss to a page in the console while I talk them through it.
+
+        I call this **alongside** ``guide_voice_agent`` and mark the moments in
+        that spoken line with ``[[1]]``, ``[[2]]``, … — one marker per target, in
+        order. The markers are removed before the line is spoken; each one is the
+        instant its move happens, so the console changes on the words rather than
+        before or after them::
+
+            guide_voice_agent(message="Sure — I'll open Integrations [[1]], and
+                              your billing page is over here [[2]].")
+            show_in_console(targets=["section:integrations", "route:/billing"])
+
+        Every target must be one of the ids listed for me under console
+        navigation targets. Those are the only places I can go; if what my boss
+        wants is not among them I say where it lives and let them click, rather
+        than moving them somewhere near it.
+
+        This moves the page my boss is looking at, so I use it while I am
+        actually showing them something — not to jump them somewhere unasked, and
+        not more than a few steps in one breath. If they interrupt me, the moves I
+        had not yet reached are dropped, which is what should happen.
+
+        Args:
+            targets: Navigation target ids, in the order their markers appear in
+                the spoken line. One per marker.
+        """
+        catalogue = self._cm.console_action_catalogue()
+        if not catalogue:
+            return {
+                "status": "error",
+                "error": "The console is not open, so there is nothing to show.",
+            }
+        unknown = [t for t in targets if f"`{t}`" not in catalogue]
+        if unknown:
+            return {
+                "status": "error",
+                "error": (
+                    f"Not navigation targets: {', '.join(unknown)}. "
+                    "Use an id from the console navigation targets list."
+                ),
+            }
+        return {"status": "showing", "targets": targets}
+
     def _whatsapp_contact_label(self, contact_id: int) -> str:
         """Human-friendly name for a contact in the window-status appendix."""
         contact = None
@@ -2520,6 +2569,11 @@ class ConversationManagerBrainActionTools:
                 tools["create_teams_meet"] = self.create_teams_meet
         if getattr(self._cm.mode, "is_voice", False):
             tools["guide_voice_agent"] = self.guide_voice_agent
+            # Only offered while a Console is open to be driven. Off-console
+            # sessions never see the tool, so the model cannot narrate a move
+            # nobody is looking at.
+            if self._cm.console_action_catalogue():
+                tools["show_in_console"] = self.show_in_console
         if self._cm.initialized:
             tools["act"] = self.act
             tools["ask_about_contacts"] = self.ask_about_contacts

--- a/unify/conversation_manager/domains/brain_action_tools.py
+++ b/unify/conversation_manager/domains/brain_action_tools.py
@@ -31,6 +31,7 @@ from unify.comms.outbound_origin import (
 )
 from unify.session_details import SESSION_DETAILS
 
+from unify.conversation_manager.console_actions import catalogue_form
 from unify.conversation_manager.domains import managers_utils
 from unify.conversation_manager.domains.onboarding_tool_gating import (
     masked_reference_quiz_tools,
@@ -2347,12 +2348,12 @@ class ConversationManagerBrainActionTools:
                 "status": "error",
                 "error": "The console is not open, so there is nothing to show.",
             }
-        unknown = [t for t in targets if f"`{t}`" not in catalogue]
+        unknown = [t for t in targets if f"`{catalogue_form(t)}`" not in catalogue]
         if unknown:
             return {
                 "status": "error",
                 "error": (
-                    f"Not navigation targets: {', '.join(unknown)}. "
+                    f"Not console targets: {', '.join(unknown)}. "
                     "Use an id from the console navigation targets list."
                 ),
             }

--- a/unify/conversation_manager/domains/event_handlers.py
+++ b/unify/conversation_manager/domains/event_handlers.py
@@ -3550,6 +3550,7 @@ async def _(
         version=event.console_guidance_version,
         brief=event.console_guidance_brief,
         full=event.console_guidance_full,
+        actions=event.console_action_catalogue,
     )
     if hasattr(cm, "_session_logger"):
         cm._session_logger.debug(

--- a/unify/conversation_manager/events.py
+++ b/unify/conversation_manager/events.py
@@ -1271,6 +1271,11 @@ class FastBrainNotification(Event):
     # give a basic direct reply to the caller's next message. Never spoken on its
     # own; an empty value clears any prior note.
     fast_brain_guidance: str = ""
+    # Console moves to make while this line plays, each as
+    # ``{"target": str, "afterChars": int}`` -- the position in ``message`` at
+    # which it should happen. Markers have already been stripped from
+    # ``message``; these are what they resolved to.
+    console_steps: list = field(default_factory=list)
 
 
 @dataclass
@@ -2108,6 +2113,7 @@ class AssistantPresenceObserved(Event):
     console_guidance_version: str = ""
     console_guidance_brief: str = ""
     console_guidance_full: str = ""
+    console_action_catalogue: str = ""
 
 
 @dataclass

--- a/unify/conversation_manager/medium_scripts/call.py
+++ b/unify/conversation_manager/medium_scripts/call.py
@@ -3301,6 +3301,41 @@ async def entrypoint(ctx: agents.JobContext):
     assistant._register_reply_continuation = _register_reply_continuation
     assistant._finalize_reply_hang_up = _finalize_reply_hang_up
 
+    # Console moves for the line about to be spoken, set when the slow brain's
+    # notification arrives. A single slot, because a newer slow-brain line
+    # supersedes an older one (see ``_queued_speech.clear()``) and its moves
+    # must be superseded with it rather than fire against the wrong words.
+    _pending_console_steps: list = []
+
+    def _publish_console_script(script_id: str, spoken_text: str) -> None:
+        """Hand Console the moves to make while this line plays.
+
+        Sent before playout begins and complete in one message, so the whole
+        sequence runs with no further round trip. Console aligns each move
+        against the synchronized transcript it is already receiving, which is
+        also what makes a barge-in drop the moves not yet reached.
+        """
+        nonlocal _pending_console_steps
+        steps = _pending_console_steps
+        _pending_console_steps = []
+        if not steps:
+            return
+
+        async def _send() -> None:
+            await ctx.room.local_participant.publish_data(
+                json.dumps(
+                    {
+                        "type": "console_script",
+                        "scriptId": script_id,
+                        "spokenText": spoken_text,
+                        "steps": steps,
+                    },
+                ).encode(),
+                topic="console_actions",
+            )
+
+        asyncio.create_task(_send())
+
     def _speak_now(
         text: "str | AsyncIterable[str]",
         notification_id: str,
@@ -3318,6 +3353,7 @@ async def entrypoint(ctx: agents.JobContext):
                 },
             )
             _log.notification_say(text, notification_source=notification_source)
+            _publish_console_script(notification_id, text)
             handle = session.say(text, allow_interruptions=True, add_to_chat_ctx=True)
             _register_interruptible_tts(
                 handle,
@@ -3527,6 +3563,7 @@ async def entrypoint(ctx: agents.JobContext):
     def on_notification(data: dict) -> None:
         """Handle notifications from conversation manager."""
         nonlocal assistant_screen_share_active, _agent_service_url
+        nonlocal _pending_console_steps
         if data.get("event_name") == "AssistantTurnInjected":
             payload = data.get("payload") or {}
             apply_assistant_turn_injection(str(payload.get("content") or ""))
@@ -3580,6 +3617,7 @@ async def entrypoint(ctx: agents.JobContext):
         # — and so a spoken turn without guidance clears any stale note.
         if notification_source == "slow_brain" and should_speak:
             assistant._fast_brain_guidance = payload.get("fast_brain_guidance", "")
+            _pending_console_steps = list(payload.get("console_steps") or [])
         notification_id = content_trace_id("guid", message or spoken_message)
         triggers_turn = notification_source not in (
             "meet_interaction",

--- a/unify/conversation_manager/prompt_builders.py
+++ b/unify/conversation_manager/prompt_builders.py
@@ -2547,6 +2547,7 @@ def build_system_prompt(
     is_org_workspace: bool = True,
     console_ui_present: bool = True,
     console_guidance: str = "",
+    console_action_catalogue: str = "",
     coordinator_onboarding_active: bool = True,
     coordinator_onboarding_render: dict[str, Any] | None = None,
     coordinator_clicked_trigger_steps: set[str] | None = None,
@@ -3120,6 +3121,12 @@ When contacts communicate in a non-English language, I match their language in m
     #     takes the deeper variant alongside its own orientation block.
     if not is_coordinator and console_guidance:
         parts.add(console_guidance)
+
+    # 13b. Navigation targets, present only while a Console is open to be
+    #      driven. Paired with the ``show_in_console`` tool, which is withheld
+    #      on the same condition.
+    if console_action_catalogue:
+        parts.add(console_action_catalogue)
 
     # 14. Onboarding reference (regular assistants only — the Coordinator bio
     #     carries this surface). The FAQ is omitted when no Console front-end

--- a/unify/gateway/channels/unillm/views.py
+++ b/unify/gateway/channels/unillm/views.py
@@ -31,13 +31,27 @@ import httpx
 import unillm
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import StreamingResponse
+from unillm.limit_hooks import SpendingLimitExceededError
 
 from unify.gateway.channels.unillm.schema import ChatCompletionRequest
 from unify.settings import SETTINGS
+from unify.spending_limits import (
+    caller_context,
+    install_multi_tenant_limit_check_hook,
+)
 
 logger = logging.getLogger("unify.gateway.channels.unillm")
 
 router = APIRouter()
+
+# This endpoint spends real money on a bare user API key, so it must run
+# under the same spending gates as the assistant runtime (credit balance,
+# trial daily burn ceiling, per-entity monthly caps). The runtime installs
+# them in ``unify.init()``, which no gateway process calls — so install
+# here, at the one import site that mounts this router. UniLLM treats a
+# missing hook as "allowed", which is how this path previously enforced
+# nothing at all.
+install_multi_tenant_limit_check_hook()
 
 
 # ---------------------------------------------------------------------------
@@ -115,20 +129,95 @@ async def chat_completions(
     (e.g. ``claude-sonnet-4-20250514@anthropic``, ``gpt-4o@openai``).
     """
     api_key = _extract_api_key(request)
-    await _authenticate_user_api_key(api_key)
+    user_info = await _authenticate_user_api_key(api_key)
 
     messages = [msg.model_dump(exclude_none=True) for msg in request_body.messages]
     _ensure_non_system_message(messages)
 
+    user_id = user_info.get("user_id")
+    # Absent on Orchestra builds predating the field; None is also the
+    # correct value for a personal key, and the user-spend check resolves
+    # the wallet server-side either way.
+    org_id = user_info.get("organization_id")
+
+    # Assert the gates here rather than relying on the equivalent check
+    # inside UniLLM's own call path. Two reasons: a denied stream has to
+    # fail before StreamingResponse commits the status line, and this
+    # endpoint's enforcement should not be contingent on the internal
+    # wiring of a callee — that contingency is precisely how it came to
+    # enforce nothing at all.
+    await _assert_within_limits(
+        model=request_body.model,
+        api_key=api_key,
+        user_id=user_id,
+        org_id=org_id,
+    )
+
     if request_body.stream:
-        return await _stream_response(request_body, messages, api_key)
-    return await _non_stream_response(request_body, messages, api_key)
+        return await _stream_response(
+            request_body,
+            messages,
+            api_key,
+            user_id=user_id,
+            org_id=org_id,
+        )
+    return await _non_stream_response(
+        request_body,
+        messages,
+        api_key,
+        user_id=user_id,
+        org_id=org_id,
+    )
+
+
+async def _assert_within_limits(
+    *,
+    model: str,
+    api_key: str,
+    user_id: str | None,
+    org_id: int | None,
+) -> None:
+    """Run the spending gates up-front, raising 402 if the caller is blocked.
+
+    UniLLM runs the same check inside ``generate()``; this duplicate exists
+    only so the streaming path can fail before any bytes are committed to
+    the response. No-op when no hook is installed (self-host, local dev).
+    """
+    from unillm.limit_hooks import (
+        LimitCheckRequest,
+        check_limits,
+        is_limit_check_enabled,
+    )
+
+    if not is_limit_check_enabled():
+        return
+
+    async with caller_context(api_key, user_id=user_id, org_id=org_id):
+        result = await check_limits(
+            LimitCheckRequest(model=model, endpoint="chat/completions"),
+        )
+
+    if not result.allowed:
+        raise _limit_denied(SpendingLimitExceededError(result))
+
+
+def _limit_denied(error: SpendingLimitExceededError) -> HTTPException:
+    """Map a spending-limit denial onto 402 Payment Required.
+
+    402 rather than 429: the caller is not being rate-limited, they are out
+    of money (or out of trial allowance). OpenAI-compatible clients surface
+    the body text, so the hook's reason string reaches the user unaltered.
+    """
+    return HTTPException(status_code=402, detail=str(error))
 
 
 async def _non_stream_response(
     request_body: ChatCompletionRequest,
     messages: list,
     api_key: str,
+    *,
+    user_id: str | None = None,
+    org_id: int | None = None,
 ) -> dict:
     """Handle non-streaming chat completion."""
     client = unillm.AsyncUnify(
@@ -149,7 +238,11 @@ async def _non_stream_response(
         return_full_completion=True,
     )
 
-    response = await client.generate(messages=messages)
+    async with caller_context(api_key, user_id=user_id, org_id=org_id):
+        try:
+            response = await client.generate(messages=messages)
+        except SpendingLimitExceededError as e:
+            raise _limit_denied(e) from e
     return response.model_dump()
 
 
@@ -157,6 +250,9 @@ async def _stream_response(
     request_body: ChatCompletionRequest,
     messages: list,
     api_key: str,
+    *,
+    user_id: str | None = None,
+    org_id: int | None = None,
 ) -> StreamingResponse:
     """Handle streaming chat completion with Server-Sent Events."""
 
@@ -181,9 +277,12 @@ async def _stream_response(
             return_full_completion=True,
         )
 
-        async for chunk in client.generate(messages=messages):
-            chunk_data = chunk.model_dump() if hasattr(chunk, "model_dump") else chunk
-            yield f"data: {json.dumps(chunk_data)}\n\n"
+        async with caller_context(api_key, user_id=user_id, org_id=org_id):
+            async for chunk in client.generate(messages=messages):
+                chunk_data = (
+                    chunk.model_dump() if hasattr(chunk, "model_dump") else chunk
+                )
+                yield f"data: {json.dumps(chunk_data)}\n\n"
 
         yield "data: [DONE]\n\n"
 

--- a/unify/spending_limits.py
+++ b/unify/spending_limits.py
@@ -25,9 +25,11 @@ import asyncio
 import logging
 import os
 import zoneinfo
+from contextlib import asynccontextmanager
+from contextvars import ContextVar
 from dataclasses import dataclass
 from datetime import datetime
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, AsyncIterator, List, Optional
 
 from unisdk.async_admin import AsyncSpendClient, SpendRequestError
 
@@ -42,6 +44,67 @@ _spend_client: Optional[AsyncSpendClient] = None
 _spend_client_key: Optional[str] = None
 
 
+@dataclass(frozen=True)
+class _CallerContext:
+    """Per-request caller identity for limit checks with no assistant session.
+
+    The assistant runtime identifies its caller process-wide (``UNIFY_KEY``
+    plus ``SESSION_DETAILS``), but a multi-tenant host — the gateway's
+    ``/unillm/chat/completions`` proxy — serves a different user on every
+    request and must not read either. Setting this contextvar redirects
+    :func:`_get_api_key` and :func:`_get_spend_client` at the caller for the
+    duration of one request.
+    """
+
+    api_key: str
+    user_id: Optional[str] = None
+    org_id: Optional[int] = None
+    client: Optional[AsyncSpendClient] = None
+
+
+_CALLER: ContextVar[Optional[_CallerContext]] = ContextVar(
+    "unify_limit_check_caller",
+    default=None,
+)
+
+
+@asynccontextmanager
+async def caller_context(
+    api_key: str,
+    *,
+    user_id: Optional[str] = None,
+    org_id: Optional[int] = None,
+) -> AsyncIterator[None]:
+    """Scope limit checks to one caller's API key for the enclosed block.
+
+    Wrap any host-side LLM call made on behalf of an authenticated third
+    party in this, so the balance / trial-cap / spending-cap gates resolve
+    against *their* wallet rather than the host process's ``UNIFY_KEY``.
+
+    The spend client is created and closed per request rather than cached
+    per key: a public endpoint sees unbounded distinct keys, and a keyed
+    cache would grow without limit and hold a connection pool open for
+    every caller that ever hit the process.
+    """
+    client = AsyncSpendClient(api_key=api_key, timeout=LIMIT_CHECK_TIMEOUT)
+    token = _CALLER.set(
+        _CallerContext(
+            api_key=api_key,
+            user_id=user_id,
+            org_id=org_id,
+            client=client,
+        ),
+    )
+    try:
+        yield
+    finally:
+        _CALLER.reset(token)
+        try:
+            await client.close()
+        except Exception as e:  # pragma: no cover - close is best-effort
+            logger.warning(f"Failed to close spend client: {type(e).__name__}: {e}")
+
+
 def _charges_billing() -> bool:
     """Whether Unify platform billing gates apply (mirrors Orchestra settings)."""
     from unify.settings import SETTINGS
@@ -51,16 +114,29 @@ def _charges_billing() -> bool:
 
 
 def _get_api_key() -> Optional[str]:
-    """Get the user API key for Orchestra calls."""
+    """Get the user API key for Orchestra calls.
+
+    An active :func:`caller_context` wins over the process key so a
+    multi-tenant host checks the caller's wallet, not its own.
+    """
+    caller = _CALLER.get()
+    if caller is not None:
+        return caller.api_key
     return os.getenv("UNIFY_KEY")
 
 
 def _get_spend_client() -> AsyncSpendClient:
-    """Get or create the shared AsyncSpendClient for limit checks.
+    """Get or create the AsyncSpendClient for limit checks.
 
-    Recreated when ``UNIFY_KEY`` changes so a client cached under a stale
-    key never authenticates later checks.
+    Inside a :func:`caller_context` this is that request's own client.
+    Otherwise it is the process-wide client, recreated when ``UNIFY_KEY``
+    changes so a client cached under a stale key never authenticates
+    later checks.
     """
+    caller = _CALLER.get()
+    if caller is not None and caller.client is not None:
+        return caller.client
+
     global _spend_client, _spend_client_key
     api_key = _get_api_key()
     if _spend_client is None or _spend_client.closed or _spend_client_key != api_key:
@@ -97,6 +173,12 @@ class _LimitCheckResult:
     # with no real payment history.
     trial_daily_spend: Optional[float] = None
     trial_daily_cap: Optional[float] = None
+    # The check could not be completed (Orchestra unreachable or errored).
+    # Distinct from a clean 404, which legitimately means "no limit set".
+    check_failed: bool = False
+    # Whether this account may spend outside the Console. Only the
+    # multi-tenant (proxy) path acts on it.
+    api_access_allowed: bool = True
 
 
 @dataclass(frozen=True)
@@ -136,6 +218,9 @@ def _parse_spend_result(
         "account_suspended": bool(data.get("account_suspended", False)),
         "trial_daily_spend": data.get("trial_daily_spend"),
         "trial_daily_cap": data.get("trial_daily_cap"),
+        # Defaults True so an Orchestra build predating the field — or an
+        # endpoint that doesn't carry it — never silently locks the API.
+        "api_access_allowed": bool(data.get("api_access_allowed", True)),
     }
 
     if limit is None:
@@ -245,10 +330,10 @@ async def _check_assistant_limit(
         if e.status == 404:
             return _LimitCheckResult(exceeded=False)
         logger.warning(f"Failed to check assistant limit: {type(e).__name__}: {e}")
-        return _LimitCheckResult(exceeded=False)
+        return _LimitCheckResult(exceeded=False, check_failed=True)
     except Exception as e:
         logger.warning(f"Failed to check assistant limit: {type(e).__name__}: {e}")
-        return _LimitCheckResult(exceeded=False)
+        return _LimitCheckResult(exceeded=False, check_failed=True)
 
 
 async def _check_user_limit(
@@ -264,10 +349,10 @@ async def _check_user_limit(
         if e.status == 404:
             return _LimitCheckResult(exceeded=False)
         logger.warning(f"Failed to check user limit: {type(e).__name__}: {e}")
-        return _LimitCheckResult(exceeded=False)
+        return _LimitCheckResult(exceeded=False, check_failed=True)
     except Exception as e:
         logger.warning(f"Failed to check user limit: {type(e).__name__}: {e}")
-        return _LimitCheckResult(exceeded=False)
+        return _LimitCheckResult(exceeded=False, check_failed=True)
 
 
 async def _check_member_limit(
@@ -293,10 +378,10 @@ async def _check_member_limit(
         if e.status == 404:
             return _LimitCheckResult(exceeded=False)
         logger.warning(f"Failed to check member limit: {type(e).__name__}: {e}")
-        return _LimitCheckResult(exceeded=False)
+        return _LimitCheckResult(exceeded=False, check_failed=True)
     except Exception as e:
         logger.warning(f"Failed to check member limit: {type(e).__name__}: {e}")
-        return _LimitCheckResult(exceeded=False)
+        return _LimitCheckResult(exceeded=False, check_failed=True)
 
 
 async def _check_org_limit(
@@ -317,10 +402,10 @@ async def _check_org_limit(
         if e.status == 404:
             return _LimitCheckResult(exceeded=False)
         logger.warning(f"Failed to check org limit: {type(e).__name__}: {e}")
-        return _LimitCheckResult(exceeded=False)
+        return _LimitCheckResult(exceeded=False, check_failed=True)
     except Exception as e:
         logger.warning(f"Failed to check org limit: {type(e).__name__}: {e}")
-        return _LimitCheckResult(exceeded=False)
+        return _LimitCheckResult(exceeded=False, check_failed=True)
 
 
 async def _notify_limit_reached(
@@ -397,6 +482,16 @@ async def check_spending_limits_callback(
     user_id = SESSION_DETAILS.user_id
     org_id = SESSION_DETAILS.org_id  # None for personal context
 
+    # A multi-tenant host (the gateway proxy) has no session; its caller
+    # identity arrives per request instead. SESSION_DETAILS is a process
+    # singleton there and would either be empty or — worse, if some other
+    # code path ever populated it — describe the wrong tenant.
+    caller = _CALLER.get()
+    if caller is not None:
+        user_id = caller.user_id or ""
+        org_id = caller.org_id
+        agent_id = None
+
     timezone = "UTC"
     if SESSION_DETAILS.assistant:
         timezone = SESSION_DETAILS.assistant.timezone or "UTC"
@@ -451,11 +546,17 @@ async def check_spending_limits_callback(
     account_suspended = False
     trial_daily_spend: Optional[float] = None
     trial_daily_cap: Optional[float] = None
+    check_failed = False
+    api_access_allowed = True
 
     for result in results:
         if isinstance(result, Exception):
             logger.warning(f"Limit check failed with exception: {result}")
+            check_failed = True
             continue
+
+        check_failed = check_failed or result.check_failed
+        api_access_allowed = api_access_allowed and result.api_access_allowed
 
         if credit_balance is None and result.credit_balance is not None:
             credit_balance = result.credit_balance
@@ -487,6 +588,34 @@ async def check_spending_limits_callback(
                 entity_id=result.entity_id,
                 entity_name=result.entity_name,
             )
+
+    # Fail closed for a multi-tenant caller whose limits could not be
+    # verified. The runtime deliberately fails open here — an Orchestra
+    # blip should not stall a paying customer's assistant mid-task — but
+    # on a public endpoint spending money against a wallet we just failed
+    # to read, "allow" is an abuse channel: induce the error, spend freely.
+    # Availability of someone else's trial credits is not worth protecting.
+    if check_failed and caller is not None:
+        return LimitCheckResponse(
+            allowed=False,
+            reason=(
+                "Unable to verify account spending limits. " "Please retry shortly."
+            ),
+        )
+
+    # Console-only free credits. Applies solely to the multi-tenant path:
+    # a caller context means someone reached the platform through the
+    # public API, and an account still on free money is not entitled to
+    # that route. The runtime has no caller context, so Console-driven
+    # work is untouched — spending free credits there is the point.
+    if caller is not None and not api_access_allowed:
+        return LimitCheckResponse(
+            allowed=False,
+            reason=(
+                "This account's free credits can only be spent through the "
+                "Unify Console. Add a payment method to enable API access."
+            ),
+        )
 
     # Hard deny for server-side frozen accounts (admin freeze, card-gate
     # sweep, abuse-fingerprint sweep).
@@ -559,6 +688,35 @@ def install_limit_check_hook() -> None:
         pass
     except Exception as e:
         logger.debug(f"Failed to install limit check hook: {e}")
+
+
+def install_multi_tenant_limit_check_hook() -> None:
+    """Install the limit-check hook in a host that serves many callers.
+
+    Identical to :func:`install_limit_check_hook` except that it does not
+    require a process-wide ``UNIFY_KEY``. A multi-tenant host (the
+    gateway's ``/unillm/chat/completions`` proxy) authenticates a
+    different user on every request and supplies that user's key through
+    :func:`caller_context`; there may be no process key at all.
+
+    Requiring one at install time is not a harmless extra check — it is
+    why the proxy shipped enforcing no spending limits whatsoever: the
+    hook was never installed, and UniLLM treats a missing hook as
+    "allowed".
+    """
+    if not _charges_billing():
+        logger.debug("Limit check hook not installed: platform billing disabled")
+        return
+
+    try:
+        import unillm
+
+        unillm.set_limit_check_hook(check_spending_limits_callback)
+        logger.info("Multi-tenant limit check hook installed")
+    except ImportError:
+        pass
+    except Exception as e:
+        logger.warning(f"Failed to install multi-tenant limit check hook: {e}")
 
 
 def uninstall_limit_check_hook() -> None:


### PR DESCRIPTION
Promotes staging to main.

Headline change: **the hosted `/unillm/chat/completions` proxy now enforces spending limits.** That endpoint spent real money on a bare user API key with no limit-check hook installed, and UniLLM treats a missing hook as `allowed` — so credit balance, trial daily ceiling and per-entity caps were all inert there. Accounts were observed running arbitrarily negative through it (80 negative-balance accounts, ~$777 overdrawn, at time of writing).

Also included, from concurrent staging work:
- `9c2e3a1ec` Let show_in_console name a control, not just a page
- `0bf09e092` Apply the flow session cache directory through the unillm API
- `930db1710` Let the assistant take its boss to a page while it says so
- `84cf88b70` Back the LLM cache with a durable copy in GCS