### PR TITLE
Release: staging → main (CI test collection)

### DIFF
--- a/.github/scripts/discover_test_paths.py
+++ b/.github/scripts/discover_test_paths.py
@@ -57,6 +57,21 @@ EXCLUDE_DIRS = {
 # editing entries reshapes the matrix; bumps to the GitHub Actions
 # concurrency directive may also be needed if the matrix grows
 # substantially.
+#
+# Groups do not have to enumerate the directory. Whatever a split leaves
+# unnamed is still collected, in LEFTOVER_GROUP_SIZE-file batches, because
+# the alternative was silence: naming ten of tests/task_scheduler's
+# fifty-eight files meant the other forty-eight had never run in CI at
+# all, and a broken call site sat in one of them through a green suite.
+# A missing *listed* file already raises; an unlisted one used to be
+# invisible, which is the worse direction for a config nobody re-reads.
+# How many unnamed files share one matrix slot. Small enough that a slow
+# batch does not stall the matrix, large enough that adding a test file
+# does not add a VM. Files that turn out to be heavy belong in a named
+# group above, weighed against the anchors — this is the safety net, not
+# the balancing mechanism.
+LEFTOVER_GROUP_SIZE = 12
+
 SPLIT_DIRS: dict[str, list[list[str]]] = {
     "tests/task_scheduler": [
         # Group A — the heaviest single file (23 funcs heavily
@@ -231,6 +246,38 @@ def has_test_subdirs(directory):
     return False
 
 
+def split_dir_entries(directory):
+    """Return the matrix entries for a directory registered in SPLIT_DIRS.
+
+    Every named group becomes one entry, and whatever the groups leave
+    unnamed follows in LEFTOVER_GROUP_SIZE-file batches so no test file in
+    the directory can go uncollected.
+    """
+    dir_key = str(directory)
+    entries = []
+    named = set()
+
+    for group in SPLIT_DIRS[dir_key]:
+        files = [directory / fname for fname in group]
+        missing = [f for f in files if not f.exists()]
+        if missing:
+            raise RuntimeError(
+                f"SPLIT_DIRS entry for {dir_key} references files "
+                f"that do not exist: {[str(m) for m in missing]}. "
+                f"Update SPLIT_DIRS in discover_test_paths.py or "
+                f"restore the files.",
+            )
+        named.update(group)
+        entries.append(" ".join(str(f) for f in files))
+
+    leftovers = [f for f in get_direct_test_files(directory) if f.name not in named]
+    for start in range(0, len(leftovers), LEFTOVER_GROUP_SIZE):
+        batch = leftovers[start : start + LEFTOVER_GROUP_SIZE]
+        entries.append(" ".join(str(f) for f in batch))
+
+    return entries
+
+
 def get_direct_test_files(directory):
     """Get test_*.py files directly in this directory (not recursive)."""
     return sorted(
@@ -251,19 +298,8 @@ def collect_paths(directory, paths):
     # in SPLIT_DIRS, emit one matrix entry per pre-defined file group
     # rather than the single leaf-bundle the default algorithm would
     # produce.
-    dir_key = str(directory)
-    if dir_key in SPLIT_DIRS:
-        for group in SPLIT_DIRS[dir_key]:
-            files = [directory / fname for fname in group]
-            missing = [f for f in files if not f.exists()]
-            if missing:
-                raise RuntimeError(
-                    f"SPLIT_DIRS entry for {dir_key} references files "
-                    f"that do not exist: {[str(m) for m in missing]}. "
-                    f"Update SPLIT_DIRS in discover_test_paths.py or "
-                    f"restore the files.",
-                )
-            paths.append(" ".join(str(f) for f in files))
+    if str(directory) in SPLIT_DIRS:
+        paths.extend(split_dir_entries(directory))
         return
 
     has_files = has_test_files(directory)
@@ -309,20 +345,8 @@ def expand_path(path_str):
         # SPLIT_DIRS override (see top-of-module rationale): emit one
         # matrix entry per pre-defined file group so a too-large cluster
         # fits in the per-job timeout budget.
-        dir_key = str(path)
-        if dir_key in SPLIT_DIRS:
-            for group in SPLIT_DIRS[dir_key]:
-                files = [path / fname for fname in group]
-                missing = [f for f in files if not f.exists()]
-                if missing:
-                    raise RuntimeError(
-                        f"SPLIT_DIRS entry for {dir_key} references files "
-                        f"that do not exist: {[str(m) for m in missing]}. "
-                        f"Update SPLIT_DIRS in discover_test_paths.py or "
-                        f"restore the files.",
-                    )
-                paths.append(" ".join(str(f) for f in files))
-            return paths
+        if str(path) in SPLIT_DIRS:
+            return split_dir_entries(path)
 
         # Check if this directory itself is a leaf or needs expansion
         has_files = has_test_files(path)

--- a/tests/actor/environments/test_sandbox_clarification_binding.py
+++ b/tests/actor/environments/test_sandbox_clarification_binding.py
@@ -109,3 +109,82 @@ def test_execute_code_and_execute_function_accept_clarification_kwargs():
     assert "_clarification_up_q: asyncio.Queue[str] | None = None" in src
     assert src.count("_clarification_up_q: asyncio.Queue[str] | None = None") >= 2
     assert "with self._sandbox_clarification_binding(" in src
+
+
+# ---------------------------------------------------------------------------
+# request_clarification, callable from inside generated code
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sandbox_request_clarification_blocks_until_answered():
+    """The call site suspends, and resumes with the answer as its value.
+
+    This is the property that makes asking from code meaningful. Without it a
+    program can only *emit* a question and carry on, which is indistinguishable
+    from not asking: the work proceeds on a guess that looks checked.
+    """
+    global_state: dict = {}
+    up_q: asyncio.Queue[str] = asyncio.Queue()
+    down_q: asyncio.Queue[str] = asyncio.Queue()
+    bind_sandbox_clarification_queues(global_state, up_q, down_q)
+
+    ask = global_state["request_clarification"]
+    task = asyncio.create_task(ask("Which Sarah — Chen or Okonkwo?"))
+
+    question = await asyncio.wait_for(up_q.get(), timeout=2)
+    assert question == "Which Sarah — Chen or Okonkwo?"
+
+    # Still suspended: nothing has answered yet.
+    await asyncio.sleep(0)
+    assert not task.done()
+
+    await down_q.put("Sarah Chen, in Finance.")
+    assert await asyncio.wait_for(task, timeout=2) == "Sarah Chen, in Finance."
+
+
+@pytest.mark.asyncio
+async def test_sandbox_request_clarification_reads_queues_at_call_time():
+    """Rebinding to a later tool call's queues redirects an existing handle.
+
+    The function is installed once per bind but must not capture the queues,
+    or code holding a reference from an earlier call would write into a
+    channel nobody is watching.
+    """
+    global_state: dict = {}
+    first_up: asyncio.Queue[str] = asyncio.Queue()
+    first_down: asyncio.Queue[str] = asyncio.Queue()
+    bind_sandbox_clarification_queues(global_state, first_up, first_down)
+    ask = global_state["request_clarification"]
+
+    second_up: asyncio.Queue[str] = asyncio.Queue()
+    second_down: asyncio.Queue[str] = asyncio.Queue()
+    bind_sandbox_clarification_queues(global_state, second_up, second_down)
+
+    task = asyncio.create_task(ask("which one?"))
+    assert await asyncio.wait_for(second_up.get(), timeout=2) == "which one?"
+    assert first_up.empty()
+    await second_down.put("the second")
+    assert await asyncio.wait_for(task, timeout=2) == "the second"
+
+
+@pytest.mark.asyncio
+async def test_sandbox_request_clarification_absent_without_a_channel():
+    """No channel, no tool — and a legible error if it is called anyway.
+
+    A loop without clarification queues must not appear to offer asking. The
+    contract is to proceed on a stated assumption instead.
+    """
+    global_state: dict = {}
+    assert "request_clarification" not in global_state
+
+    up_q: asyncio.Queue[str] = asyncio.Queue()
+    down_q: asyncio.Queue[str] = asyncio.Queue()
+    token = bind_sandbox_clarification_queues(global_state, up_q, down_q)
+    ask = global_state["request_clarification"]
+    restore_sandbox_clarification_queues(global_state, token)
+
+    # Restored away with the queues it belonged to.
+    assert "request_clarification" not in global_state
+    with pytest.raises(RuntimeError, match="No clarification channel"):
+        await ask("anyone there?")

--- a/tests/event_bus/test_payment_gated_providers.py
+++ b/tests/event_bus/test_payment_gated_providers.py
@@ -1,0 +1,128 @@
+"""Providers an account may only reach once it has real payment history.
+
+A signup's free grant is worth farming only if it buys something expensive,
+so the expensive providers are the ones held behind a payment. The gate runs
+at the spend boundary rather than at model selection, so it covers the
+Console and the public proxy with one rule and applies to assistants that
+chose the model before the gate existed.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from unillm.limit_hooks import LimitCheckRequest
+
+from unify.spending_limits import (
+    PAYMENT_GATED_PROVIDERS,
+    _payment_gated,
+    _provider_of,
+    check_spending_limits_callback,
+)
+
+#: A wallet with room and no cap — the "has paid" shape.
+_PAID = {"cumulative_spend": 0.0, "limit": None, "credit_balance": 100.0}
+
+#: Orchestra populates the trial cap only for accounts that never paid.
+_NEVER_PAID = {
+    **_PAID,
+    "trial_daily_spend": 0.0,
+    "trial_daily_cap": 25.0,
+}
+
+
+class TestProviderParsing:
+    def test_reads_the_trailing_segment(self):
+        assert _provider_of("claude-fable-5@anthropic") == "anthropic"
+
+    def test_model_half_may_contain_slashes(self):
+        assert _provider_of("openai/gpt-5.6-terra@openrouter") == "openrouter"
+
+    def test_bare_model_names_no_provider(self):
+        assert _provider_of("gpt-4") is None
+
+    def test_case_is_normalised(self):
+        assert _provider_of("claude-opus-5@Anthropic") == "anthropic"
+
+
+class TestGatePredicate:
+    def test_gated_provider_on_unpaid_account(self):
+        assert _payment_gated("claude-fable-5@anthropic", never_paid=True) is True
+
+    def test_same_call_allowed_once_paid(self):
+        assert _payment_gated("claude-fable-5@anthropic", never_paid=False) is False
+
+    def test_other_providers_unaffected(self):
+        assert _payment_gated("openai/gpt-5.6-sol@openrouter", never_paid=True) is False
+
+    def test_bare_model_is_not_gated(self):
+        assert _payment_gated("gpt-4", never_paid=True) is False
+
+    def test_anthropic_is_gated_by_default(self):
+        assert "anthropic" in PAYMENT_GATED_PROVIDERS
+
+
+def _run_callback(model: str, spend_data: dict):
+    """Drive the callback for a personal account with *spend_data*."""
+
+    async def _inner():
+        with patch("unify.spending_limits._get_api_key", return_value="test-key"):
+            with patch("unify.session_details.SESSION_DETAILS") as mock_session:
+                mock_session.assistant.agent_id = None
+                mock_session.user_id = "user_1"
+                mock_session.org_id = None
+                mock_session.assistant.timezone = "UTC"
+
+                with patch(
+                    "unify.spending_limits._get_spend_client",
+                ) as mock_get_client:
+                    client = MagicMock()
+                    client.closed = False
+                    client.get_user_spend = AsyncMock(return_value=spend_data)
+                    client.get_assistant_spend = AsyncMock(return_value=spend_data)
+                    client.notify_limit_reached = AsyncMock(
+                        return_value={"notified": False},
+                    )
+                    mock_get_client.return_value = client
+
+                    return await check_spending_limits_callback(
+                        LimitCheckRequest(model=model, endpoint="chat/completions"),
+                    )
+
+    return _inner()
+
+
+class TestGateAtTheSpendBoundary:
+    @pytest.mark.asyncio
+    async def test_denies_anthropic_for_a_never_paid_account(self):
+        response = await _run_callback("claude-fable-5@anthropic", _NEVER_PAID)
+
+        assert response.allowed is False
+        assert "payment method" in response.reason
+
+    @pytest.mark.asyncio
+    async def test_allows_anthropic_once_the_account_has_paid(self):
+        response = await _run_callback("claude-fable-5@anthropic", _PAID)
+
+        assert response.allowed is True
+
+    @pytest.mark.asyncio
+    async def test_included_models_stay_available_while_unpaid(self):
+        """The gate must not touch the platform default, or trials break."""
+        response = await _run_callback("openai/gpt-5.6-sol@openrouter", _NEVER_PAID)
+
+        assert response.allowed is True
+
+    @pytest.mark.asyncio
+    async def test_applies_to_the_runtime_not_just_the_proxy(self):
+        """No caller context is set here — this is the Console-driven path."""
+        response = await _run_callback("claude-opus-5@anthropic", _NEVER_PAID)
+
+        assert response.allowed is False
+
+    @pytest.mark.asyncio
+    async def test_reason_names_the_provider(self):
+        response = await _run_callback("claude-opus-5@anthropic", _NEVER_PAID)
+
+        assert "anthropic" in response.reason

--- a/unify/actor/environments/base.py
+++ b/unify/actor/environments/base.py
@@ -180,6 +180,20 @@ def _make_sandbox_clarification_fn(global_state: Dict[str, Any]):
 
     Queues are read at call time rather than captured, so the function stays
     correct across the bind/restore cycle.
+
+    Deadlock exposure is the same as the JSON ``request_clarification`` tool:
+    both put on the same per-call up-queue and await the same down-queue with
+    no timeout, drained by the same ``_handle_clarification`` →
+    ``handle._clar_q`` path. The sandbox call sits under more stack frames,
+    but it is one await on one queue either way, and whatever answers one
+    answers the other.
+
+    It does differ in one respect, and not in its favour: the JSON tool fires
+    ``on_request`` / ``on_answer``, which publish ``ManagerMethod`` events
+    carrying the call id. A clarification raised from code is therefore
+    invisible on the event bus while an identical one raised from the tool is
+    visible. Closing that needs the call id threaded down to this bind, which
+    is a separate change.
     """
 
     async def request_clarification(question: str) -> str:

--- a/unify/actor/environments/base.py
+++ b/unify/actor/environments/base.py
@@ -162,6 +162,45 @@ def _callable_accepts_clarification_kwargs(fn: Any) -> bool:
 _CLAR_GLOBAL_MISSING = object()
 
 
+def _make_sandbox_clarification_fn(global_state: Dict[str, Any]):
+    """An awaitable the sandbox can call to ask the user and block on it.
+
+    The queues already reached the sandbox as ``__clarification_up_q__`` /
+    ``__clarification_down_q__``, but nothing exposed a way to use them, so
+    generated code had no route to the clarification channel. Its only option
+    was to write the question out through whatever API the task happened to
+    describe — which asks without waiting, because a script cannot receive a
+    reply. The question goes out, execution continues, and the work proceeds
+    on a guess that looks like it was checked.
+
+    Awaiting this suspends the Python program at the call site, exactly as the
+    JSON tool suspends the loop. The actor is code-first, so an ambiguity
+    found halfway through a program should not require abandoning the program
+    to ask about it.
+
+    Queues are read at call time rather than captured, so the function stays
+    correct across the bind/restore cycle.
+    """
+
+    async def request_clarification(question: str) -> str:
+        """Ask the caller a question and wait for their answer.
+
+        Blocks this call site until an answer arrives and then returns it, so
+        the surrounding code resumes with the answer in hand.
+        """
+        up = global_state.get("__clarification_up_q__")
+        down = global_state.get("__clarification_down_q__")
+        if up is None or down is None:
+            raise RuntimeError(
+                "No clarification channel is available in this context — "
+                "proceed with a stated assumption instead of asking.",
+            )
+        await up.put(str(question))
+        return await down.get()
+
+    return request_clarification
+
+
 def bind_sandbox_clarification_queues(
     global_state: Dict[str, Any],
     up_q: asyncio.Queue[str],
@@ -184,11 +223,14 @@ def bind_sandbox_clarification_queues(
         global_state.get("__clarification_up_q__", _CLAR_GLOBAL_MISSING),
         global_state.get("__clarification_down_q__", _CLAR_GLOBAL_MISSING),
     )
+    previous_fn = global_state.get("request_clarification", _CLAR_GLOBAL_MISSING)
     global_state["__clarification_up_q__"] = up_q
     global_state["__clarification_down_q__"] = down_q
+    global_state["request_clarification"] = _make_sandbox_clarification_fn(global_state)
     return {
         "injectors": previous_injectors,
         "globals": previous_globals,
+        "fn": previous_fn,
     }
 
 
@@ -214,6 +256,11 @@ def restore_sandbox_clarification_queues(
         global_state.pop("__clarification_down_q__", None)
     else:
         global_state["__clarification_down_q__"] = prev_down
+    prev_fn = token.get("fn", _CLAR_GLOBAL_MISSING)
+    if prev_fn is _CLAR_GLOBAL_MISSING:
+        global_state.pop("request_clarification", None)
+    else:
+        global_state["request_clarification"] = prev_fn
 
 
 class _ClarificationQueueInjector:

--- a/unify/spending_limits.py
+++ b/unify/spending_limits.py
@@ -40,6 +40,23 @@ logger = logging.getLogger(__name__)
 
 LIMIT_CHECK_TIMEOUT = 5.0
 
+#: Providers an account may only reach once it has real payment history.
+#:
+#: These are the models whose per-call cost is high enough that a signup's
+#: free grant buys a meaningful amount of them, which makes them the ones
+#: worth farming an account for. Requiring payment first removes the return
+#: on creating the account at all, rather than trying to detect the misuse
+#: afterwards.
+#:
+#: Provider-scoped rather than model-scoped on purpose: a per-model list has
+#: to be revised every time a vendor ships, and the gap between the ship and
+#: the revision is the exposure.
+PAYMENT_GATED_PROVIDERS = frozenset(
+    p.strip().lower()
+    for p in os.environ.get("PAYMENT_GATED_PROVIDERS", "anthropic").split(",")
+    if p.strip()
+)
+
 _spend_client: Optional[AsyncSpendClient] = None
 _spend_client_key: Optional[str] = None
 
@@ -453,6 +470,28 @@ async def _notify_limit_reached(
         logger.warning(f"Failed to send spending limit notification: {e}")
 
 
+def _provider_of(model: str) -> Optional[str]:
+    """Extract the provider from a UniLLM ``model@provider`` endpoint.
+
+    The model half may itself contain ``/`` (``openai/gpt-5.6-terra``) and
+    the provider is always the trailing segment, so split on the last ``@``.
+    Returns ``None`` for a bare model name, which routes by UniLLM's own
+    default rather than naming a provider here.
+    """
+    _, sep, provider = model.rpartition("@")
+    if not sep:
+        return None
+    return provider.strip().lower() or None
+
+
+def _payment_gated(model: str, *, never_paid: bool) -> bool:
+    """Whether this call is for a paid-only provider on an unpaid account."""
+    if not never_paid:
+        return False
+    provider = _provider_of(model)
+    return provider is not None and provider in PAYMENT_GATED_PROVIDERS
+
+
 async def check_spending_limits_callback(
     request: "LimitCheckRequest",
 ) -> "LimitCheckResponse":
@@ -625,6 +664,28 @@ async def check_spending_limits_callback(
             reason=(
                 "This account is suspended. Add a payment method or "
                 "contact support to restore access."
+            ),
+        )
+
+    # Paid-only providers. ``trial_daily_cap`` is Orchestra's never-paid
+    # marker: it is populated only for accounts with no real payment
+    # history, and is already NULL for internal accounts and for orgs
+    # holding an admin-granted free trial, so those keep full model access
+    # without a second exemption list here.
+    #
+    # Unlike the Console-only gate above this applies on every surface,
+    # including the runtime. An account that has never paid cannot reach
+    # these providers from the Console either — that is the point, since
+    # the Console is where the free grant is meant to be spent and these
+    # models are what make spending it worthwhile.
+    if _payment_gated(request.model, never_paid=trial_daily_cap is not None):
+        provider = _provider_of(request.model)
+        return LimitCheckResponse(
+            allowed=False,
+            reason=(
+                f"{provider} models require a payment method on this "
+                "account. Add one to enable them, or switch this assistant "
+                "to one of the included models."
             ),
         )
 


### PR DESCRIPTION
Promotes `1b6a37271`.

`SPLIT_DIRS` emitted its named groups and returned, so any file a split did not name was silently dropped from the matrix. `tests/task_scheduler` ran 10 of its 58 files; `conversation_manager/core` lost 12. Tagging a commit with that directory reported success having run under a fifth of it — which is how a broken call site in `test_active_task_run_key.py` survived a green suite. Named groups still balance the heavy files; the remainder now follows in 12-file batches. Matrix grows 91 → 96 jobs.

This PR is also the live test of `7d35d7b94`: it and the push run for the same commit previously shared a concurrency group, and the PR run (one smoke file) cancelled the push run (the real matrix) ~3 seconds in. They should now sit in separate groups and both survive.