### PR TITLE
Release: staging → main

### DIFF
--- a/.agents/shared.txt
+++ b/.agents/shared.txt
@@ -11,6 +11,7 @@ no-test-info-in-production-code.md
 git-commit-safety.md
 worktree-direct-commits.md
 git-history-for-context.md
+staging-main-fail-closed-gates.md
 shared-agent-context.md
 
 openrouter-only-llm-access.md

--- a/.github/workflows/llm-cache-keepalive.yml
+++ b/.github/workflows/llm-cache-keepalive.yml
@@ -1,0 +1,70 @@
+name: LLM Cache Keepalive
+run-name: LLM cache keepalive
+
+# Artifact retention is the ceiling on how long the shared LLM cache survives
+# untouched: the Actions cache is evictable, and nothing else outlives it. Once
+# the last llm-cache-ndjson expires, every entry has to be bought again from a
+# paid provider.
+#
+# Rolling the store forward costs nothing, though. Republishing what already
+# exists starts a fresh retention window, so this pulls the newest unexpired
+# artifact and uploads it again. No tests run and no provider is called, which
+# is why this may sit on a schedule while the refresh workflow stays behind its
+# LLM_SPEND_OK gate.
+#
+# Monthly against 90-day retention leaves two missed runs of slack.
+
+on:
+  schedule:
+  - cron: '17 4 1 * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: llm-cache-keepalive
+  cancel-in-progress: false
+
+jobs:
+  keepalive:
+    name: Roll the cache artifact forward
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 1
+
+    - name: Hydrate from the newest artifact
+      id: hydrate
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        # Republishing nothing would mint an empty artifact that then becomes
+        # the newest match every reader resolves to, so the answer stays "do
+        # not publish" unless a non-empty store actually arrives.
+        echo "publish=false" >> "$GITHUB_OUTPUT"
+        .github/scripts/hydrate_llm_cache.sh
+        if [ -s .cache.ndjson ]; then
+          entries=$(grep -c . .cache.ndjson || true)
+          if [ "${entries:-0}" -gt 0 ]; then
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+            echo "Rolling ${entries} entries into a fresh retention window"
+          fi
+        else
+          echo "Nothing to roll forward: no unexpired artifact remains."
+          echo "::warning::No LLM cache artifact to keep alive. The store is gone and the next refresh will re-buy it."
+        fi
+
+    - name: Republish the cross-branch LLM cache artifact
+      if: steps.hydrate.outputs.publish == 'true'
+      uses: actions/upload-artifact@v4
+      with:
+        name: llm-cache-ndjson
+        path: .cache.ndjson
+        if-no-files-found: error
+        include-hidden-files: true
+        compression-level: 0
+        retention-days: 90

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1357,6 +1357,83 @@ If direct code analysis and debug logging (`CURSOR_DEBUG_LOG`) aren't yielding a
 - Don't read diffs commit-by-commit and mentally compose them; use the aggregate diff
 - Don't dump entire file histories; scope queries to the relevant path(s)
 
+# Staging→Main Release Gates Are Fail-Closed
+
+Every repo's `Staging->Main` ruleset requires at least one status check whose
+job makes an expensive or conditional run (full pytest matrix, paid LLM smoke
+tests, E2E). Those jobs don't run on every push — they're gated on a
+`[run-tests]`/`[run-flows]`-style commit-message tag, or on the PR event
+itself. As of **2026-07-31**, the required context for that job is published
+**unconditionally** on every push: an explicit pass or fail, never an
+implicit pass from a skip.
+
+## Why: the orchestra incident
+
+Before 2026-07-31, the required context was only published when the gated
+job actually ran; an ordinary push that skipped it published nothing, and
+**GitHub counts a skipped required check as satisfied**. A staging→main
+release PR shares its head SHA with whatever was last pushed to staging, so
+that stale implicit pass could satisfy branch protection before the real
+PR-triggered run finished. In orchestra this let four release PRs (#125,
+#127, #128, #129) merge into main carrying a skipped/failing suite — #125
+merged 83 seconds into an 11-minute test run that later came back failing,
+leaving a broken test on main for thirteen hours.
+
+The fix — "make the gate fail closed" — makes an aggregator job republish the
+required context unconditionally, so a push that didn't run the suite now
+reports that context **red**, not green-by-default.
+
+Rolled out the same week to: orchestra (`pytest`, [`0f040b6c`](https://github.com/unifyai/orchestra/commit/0f040b6c)),
+unillm (`pytest`, `c7b2351`), unify (`Flow smoke`, `e2bb461c7`), unify-deploy
+(`Integration smoke`, `0d886ad1`), console (`Push Gate`, `08cf9a9fd`). Check
+name and trigger tag differ per repo; the fail-closed shape is the same.
+unisdk, brain, docs, and landing-page have no equivalent expensive/conditional
+gate, so this doesn't currently apply there — but treat it as the default
+shape for any new staging→main required check in any repo.
+
+## The known follow-up flaw, and its fix
+
+Fail-closed on its own creates a new failure mode: **GitHub's required-check
+evaluation considers every check-run matching the required context name on a
+commit's SHA, not just the latest one.** If staging gets an untagged direct
+push, that push's run reports the context red. Opening the release PR then
+runs the real suite via the `pull_request` trigger and it can pass cleanly —
+but the earlier red run doesn't get superseded. The release PR is left
+**permanently blocked** on that SHA: re-running the failed job reproduces the
+same failure (the commit still lacks the tag), and the passing PR-triggered
+run sits right next to it, ignored.
+
+`unify` hit this within 36 hours of rolling out fail-closed and fixed it in
+[`05fbdcce9`](https://github.com/unifyai/unify/commit/05fbdcce9): scope the
+aggregator job to `pull_request`/`workflow_dispatch` only, so a plain push
+with no matching trigger publishes **no run at all** for that context
+(`pending`) instead of an explicit failure. Pending isn't a stale pass and
+isn't an unresolvable block — the PR-triggered run is free to become the
+only entry once it lands.
+
+As of this writing, only `unify` has this follow-up. orchestra, unillm,
+unify-deploy, and console still run the plain fail-closed version and can hit
+the stale-permanent-block failure mode above.
+
+## What to do when a release PR is stuck this way
+
+Recognize the shape first: `reviewDecision: APPROVED`, `mergeable: MERGEABLE`,
+`mergeStateStatus: BLOCKED`, and the required context shows both a `FAILURE`
+and a `SUCCESS` entry for the same PR head SHA, from two different workflow
+runs (one push-triggered, one pull_request-triggered). This is not a real
+test failure and not something to route around with an admin bypass — surface
+it and let the user choose:
+
+- **Get a clean SHA**: push a small commit (or empty commit) to staging
+  carrying the trigger tag, giving the release PR a fresh head with a single,
+  unambiguous run for that context.
+- **Port the `unify` follow-up**: scope that repo's aggregator job to
+  `pull_request`/`workflow_dispatch` the way `unify` did, so this stops
+  recurring for every untagged direct push to staging.
+
+Do not force-merge, disable the ruleset, or bypass the check to route around
+this — both remediations above satisfy the gate on its own terms.
+
 # Python Formatting & Pre-commit
 
 Every first-party Python repo (`orchestra`, `unify`, `unisdk`, `unillm`,

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -87,6 +87,35 @@ When `handle.interject("also check trains")` is called, the message is placed in
 
 This is how the user can redirect an agent mid-task without the overhead of stopping and restarting from scratch.
 
+### Steering code that is already running
+
+**File:** `unify/actor/execution/steering.py`
+
+Between LLM turns is not enough on its own for `execute_code` and
+`execute_function`, whose work happens *inside* one tool call — a correction
+arriving four sends into a five-send loop would otherwise be able to kill the
+block but not correct it.
+
+Those tools declare `_interject_queue`, which is what makes the loop
+synthesise an `interject_<tool>_<call_id>` helper for them while they are
+still running (`ToolsData` reads steerability off the signature at schedule
+time). Inside the sandbox, an AST pass adds checkpoints between top-level
+statements, at the top of every loop body at any depth, and a proxy adds one
+before every `primitives.*` call — covering dispatches that sit inside a
+single statement, such as a comprehension or a `gather`. Stored functions are
+covered too when their implementation is synthesised as a preamble, so the
+function's own body is instrumented rather than only the call to it.
+
+A checkpoint that finds a message suspends the block and emits a notification,
+which gives the model a turn with a progress report: the line reached and the
+calls that already completed, with arguments. The model then either resumes
+(any further interjection) or abandons (`stop_*`, unwinding through ordinary
+cancellation). The checkpoint never classifies the message itself.
+
+A checkpoint only runs when the block yields. A synchronous blocking call
+holds the event loop for its duration, during which the interjection cannot
+arrive either, since the tool loop receiving it runs on that same loop.
+
 ---
 
 ## Steerable handles

--- a/tests/actor/code_act/test_prompt_builders.py
+++ b/tests/actor/code_act/test_prompt_builders.py
@@ -332,7 +332,8 @@ def test_code_act_prompt_includes_reasoning_helper_decision_guidance():
     assert "ARC Prize leaderboard: https://arcprize.org/leaderboard" in prompt
     assert "Use `list_llms()` to inspect" in prompt
     assert "Supported UniLLM endpoints currently registered" not in prompt
-    assert "gpt-4.1-nano@openai" in prompt
+    assert "openai/gpt-5.4-mini@openrouter" in prompt
+    assert "Reach OpenAI models through `@openrouter`" in prompt
     assert "Do not put benchmark browsing or" in prompt
 
 
@@ -353,7 +354,7 @@ def test_code_act_prompt_includes_reasoning_examples_and_antipatterns():
         "deterministic pre-filter, semantic reasoning only for the hard subset"
         in prompt
     )
-    assert 'model="gpt-4.1-nano@openai"' in prompt
+    assert 'model="openai/gpt-5.4-mini@openrouter"' in prompt
 
 
 @pytest.mark.timeout(30)

--- a/tests/actor/environments/test_sandbox_clarification_binding.py
+++ b/tests/actor/environments/test_sandbox_clarification_binding.py
@@ -86,7 +86,7 @@ async def test_bound_injector_routes_manager_clar_to_per_call_queues():
             await call_down.put("acme/repo")
 
         answerer = asyncio.create_task(_answer())
-        with CodeActActor._sandbox_clarification_binding(
+        with CodeActActor._sandbox_call_binding(
             clarification_up_q=call_up,
             clarification_down_q=call_down,
         ):
@@ -108,7 +108,7 @@ def test_execute_code_and_execute_function_accept_clarification_kwargs():
     src = inspect.getsource(CodeActActor._build_tools)
     assert "_clarification_up_q: asyncio.Queue[str] | None = None" in src
     assert src.count("_clarification_up_q: asyncio.Queue[str] | None = None") >= 2
-    assert "with self._sandbox_clarification_binding(" in src
+    assert "with self._sandbox_call_binding(" in src
 
 
 # ---------------------------------------------------------------------------

--- a/tests/actor/execution/test_live_steering.py
+++ b/tests/actor/execution/test_live_steering.py
@@ -408,7 +408,198 @@ async def test_stored_function_body_is_steerable_when_synthesised():
     assert "only the first two" in channel.messages
 
 
-def test_dispatch_proxy_passes_non_callables_through():
+@pytest.mark.asyncio
+async def test_completed_calls_are_named_so_a_replacement_can_resume():
+    """The suspend notification must say what already happened, with arguments.
+
+    A block abandoned partway through has done real work that rewriting the
+    code cannot undo. The model decides what to skip, from a named list —
+    rather than a replay cache deciding for it, which would satisfy a
+    correction meaning "undo that" with a cache hit.
+    """
+    session = PythonExecutionSession()
+    interject_q: asyncio.Queue = asyncio.Queue()
+    notify_q: asyncio.Queue = asyncio.Queue()
+    channel = SteeringChannel(
+        interject_q=interject_q,
+        notification_q=notify_q,
+        suspend_timeout=5.0,
+    )
+    token = bind_sandbox_steering_channel(session.global_state, channel)
+
+    sent: list[str] = []
+
+    class _Comms:
+        async def send(self, to: str) -> str:
+            sent.append(to)
+            # A real primitive does I/O and yields here. Without a yield the
+            # whole block runs to completion before anything else on the loop
+            # gets a turn, so nothing could interject partway through.
+            await asyncio.sleep(0)
+            return f"sent:{to}"
+
+    class _Prims:
+        comms = _Comms()
+
+    # Raw, not pre-wrapped: the sandbox installs the steering proxy itself.
+    session.global_state["primitives"] = _Prims()
+
+    async def steer() -> None:
+        while len(sent) < 2:
+            await asyncio.sleep(0)
+        await interject_q.put("stop, the rest are wrong")
+        while channel.progress()["suspensions"] < 1:
+            await asyncio.sleep(0)
+        await interject_q.put("ok continue")
+
+    steerer = asyncio.create_task(steer())
+    try:
+        out = await session.execute(
+            "for v in ['ana', 'bo', 'cy', 'di']:\n"
+            "    await primitives.comms.send(v)\n",
+        )
+        await steerer
+    finally:
+        restore_sandbox_steering_channel(session.global_state, token)
+        await session.close()
+
+    assert out["error"] is None
+
+    payload = notify_q.get_nowait()
+    already = payload["progress"]["already_done"]
+    # The suspend fires before the third send, so exactly the first two are
+    # reported — and by recipient, which is what a replacement needs.
+    assert already == [
+        "primitives.comms.send('ana')",
+        "primitives.comms.send('bo')",
+    ]
+
+
+def test_completed_call_list_is_bounded_and_says_so():
+    """A loop over thousands of rows must not put its history in the transcript.
+
+    But truncating silently would read as "only these happened", which is the
+    opposite of what the list exists to convey — so the real total is stated
+    whenever the list is short of it.
+    """
+    from unify.actor.execution.steering import _MAX_RECORDED_CALLS
+
+    channel = SteeringChannel(interject_q=None)
+    for i in range(_MAX_RECORDED_CALLS + 25):
+        channel.record_completed(f"primitives.data.insert({i})")
+
+    report = channel.progress()
+    assert len(report["already_done"]) == _MAX_RECORDED_CALLS
+    assert report["already_done_total"] == _MAX_RECORDED_CALLS + 25
+
+
+def test_untruncated_report_omits_the_total():
+    """No total when the list is complete — it would only add noise."""
+    channel = SteeringChannel(interject_q=None)
+    channel.record_completed("primitives.comms.send('ana')")
+    assert "already_done_total" not in channel.progress()
+
+
+def test_long_arguments_are_truncated_in_the_report():
+    from unify.actor.execution.steering import _render_call
+
+    rendered = _render_call("primitives.comms.send", ("x" * 500,), {})
+    assert len(rendered) < 120
+    assert rendered.endswith("…)")
+
+
+@pytest.mark.asyncio
+async def test_dispatch_proxy_sees_through_the_context_forwarding_wrapper():
+    """The production stacking: steering outside context forwarding.
+
+    ``ContextForwardingProxy`` returns a synchronous ``functools.wraps``
+    wrapper around an async method, and ``iscoroutinefunction`` is False for
+    it. Believing that would put every primitive on the path that cannot
+    suspend, and would record a call as done before it had run — in exactly
+    the configuration production uses, since parent chat context is normally
+    present.
+    """
+    from unify.function_manager.primitives.context_proxy import (
+        ContextForwardingProxy,
+    )
+
+    order: list[str] = []
+
+    class _Comms:
+        async def send(
+            self,
+            to: str,
+            *,
+            _parent_chat_context: list | None = None,
+        ) -> str:
+            order.append(f"dispatch:{to}")
+            await asyncio.sleep(0)
+            return f"sent:{to}"
+
+    class _Prims:
+        comms = _Comms()
+
+    interject_q: asyncio.Queue = asyncio.Queue()
+    channel = SteeringChannel(interject_q=interject_q, suspend_timeout=0.2)
+    proxied = SteeringDispatchProxy(
+        ContextForwardingProxy(_Prims(), _parent_chat_context=[{"role": "user"}]),
+        channel,
+    )
+
+    interject_q.put_nowait("wait")
+    result = await proxied.comms.send("ana")
+
+    assert result == "sent:ana"
+    # Suspension proves the async branch was taken through the wrapper.
+    assert channel.progress()["suspensions"] == 1
+    # And the completion was recorded after the dispatch, not before it.
+    assert channel.progress()["already_done"] == ["primitives.comms.send('ana')"]
+    assert order == ["dispatch:ana"]
+
+
+@pytest.mark.asyncio
+async def test_progress_locates_a_failure_in_the_code_as_written():
+    """Instrumentation shifts traceback lines; the checkpoint's do not.
+
+    A "<string>" traceback carries no source text to cross-reference, and the
+    wrapper already offsets its line numbers before instrumentation adds to
+    the shift. ``last_line_reached`` stays in the coordinates of the code the
+    model wrote, which is why the report is worth attaching on failure.
+    """
+    session = PythonExecutionSession()
+    channel = SteeringChannel(interject_q=asyncio.Queue())
+    token = bind_sandbox_steering_channel(session.global_state, channel)
+    try:
+        out = await session.execute("a = 1\nb = 2\nc = a / 0\nd = 4\n")
+    finally:
+        restore_sandbox_steering_channel(session.global_state, token)
+        await session.close()
+
+    assert "ZeroDivisionError" in (out["error"] or "")
+    progress = channel.progress()
+    assert progress["last_line_reached"] == 3
+    assert progress["last_statement"] == "c = a / 0"
+
+
+def test_dispatch_proxy_does_not_stack_on_itself():
+    """Nesting would checkpoint and record each dispatch once per layer.
+
+    Reachable in production: a block that calls something which runs its own
+    block arrives here with the outer proxy already on the shared sandbox
+    globals.
+    """
+    channel = SteeringChannel(interject_q=None)
+
+    class _Prims:
+        pass
+
+    target = _Prims()
+    once = SteeringDispatchProxy(target, channel)
+    twice = SteeringDispatchProxy(once, channel)
+    assert twice._target is target
+
+
+def test_dispatch_proxy_passes_plain_values_through():
     channel = SteeringChannel(interject_q=None)
 
     class _Manager:
@@ -419,6 +610,40 @@ def test_dispatch_proxy_passes_non_callables_through():
 
     proxy = SteeringDispatchProxy(_Prims(), channel)
     assert proxy.contacts.label == "contacts"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_proxy_descends_into_nested_namespaces():
+    """Primitive families nest, and the nested ones do the irreversible work.
+
+    ``primitives.integrations.slack.send_message`` and
+    ``primitives.computer.web.new_session`` are the shapes that matter; a
+    proxy that stopped at one level would leave exactly those uncheckpointed.
+    """
+    interject_q: asyncio.Queue = asyncio.Queue()
+    channel = SteeringChannel(interject_q=interject_q, suspend_timeout=0.2)
+
+    class _Slack:
+        async def send_message(self, channel_name: str) -> str:
+            return f"posted:{channel_name}"
+
+    class _Integrations:
+        slack = _Slack()
+
+    class _Prims:
+        integrations = _Integrations()
+
+    proxy = SteeringDispatchProxy(_Prims(), channel)
+    interject_q.put_nowait("hold off on slack")
+
+    result = await proxy.integrations.slack.send_message("#eng")
+
+    assert result == "posted:#eng"
+    progress = channel.progress()
+    assert progress["suspensions"] == 1
+    assert progress["already_done"] == [
+        "primitives.integrations.slack.send_message('#eng')",
+    ]
 
 
 # ── the tool surface ───────────────────────────────────────────────────────

--- a/tests/actor/execution/test_live_steering.py
+++ b/tests/actor/execution/test_live_steering.py
@@ -1,0 +1,460 @@
+"""Deterministic contracts for steering code while it is still running.
+
+Locks the three pieces that let a correction reach a block mid-flight: the
+AST instrumentation that places checkpoints, the channel those checkpoints
+read, and the dispatch proxy that covers calls the instrumentation cannot
+see from outside a statement.
+
+Everything here is symbolic — no LLM is involved, so a failure is a
+regression in the machinery rather than a judgement call.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import inspect
+
+import pytest
+
+from unify.actor.code_act_actor import CodeActActor
+from unify.actor.execution import PythonExecutionSession
+from unify.actor.execution.steering import (
+    CHANNEL_GLOBAL,
+    CHECKPOINT_FN,
+    CHECKPOINT_SYNC_FN,
+    SteeringChannel,
+    SteeringDispatchProxy,
+    bind_sandbox_steering_channel,
+    current_channel,
+    instrument_for_steering,
+    restore_sandbox_steering_channel,
+)
+
+
+def _instrumented(source: str) -> str:
+    return ast.unparse(instrument_for_steering(ast.parse(source)))
+
+
+# ── instrumentation ────────────────────────────────────────────────────────
+def test_top_level_statements_are_bracketed():
+    out = _instrumented("a = 1\nb = 2\n")
+    assert out.count(f"await {CHECKPOINT_FN}") == 2
+
+
+def test_loop_bodies_are_instrumented():
+    # The failure this exists for: repeated side effects inside one
+    # statement, where a checkpoint placed only between top-level statements
+    # would never run while the work was happening.
+    out = _instrumented("for v in vendors:\n    send(v)\n")
+    assert f"for v in vendors:\n    await {CHECKPOINT_FN}" in out
+
+
+def test_checkpoint_precedes_the_iteration_body():
+    """A correction must land before the next side effect, not after it."""
+    out = _instrumented("for v in vendors:\n    send(v)\n")
+    body = out.split("for v in vendors:\n")[1].splitlines()
+    assert body[0].strip().startswith(f"await {CHECKPOINT_FN}")
+    assert body[1].strip() == "send(v)"
+
+
+def test_nested_loops_are_instrumented_at_every_depth():
+    out = _instrumented("for a in xs:\n    for b in ys:\n        f(a, b)\n")
+    assert out.count(f"await {CHECKPOINT_FN}") == 3  # top-level + two bodies
+
+
+def test_while_loops_are_instrumented():
+    out = _instrumented("while more():\n    step()\n")
+    assert f"while more():\n    await {CHECKPOINT_FN}" in out
+
+
+def test_sync_function_bodies_use_the_sync_checkpoint():
+    """A ``def`` cannot await, so it gets the variant that cannot suspend."""
+    out = _instrumented("def helper():\n    for i in xs:\n        f(i)\n")
+    inner = out.split("def helper")[1]
+    assert CHECKPOINT_SYNC_FN in inner
+    assert f"await {CHECKPOINT_FN}(" not in inner
+
+
+def test_async_function_bodies_use_the_async_checkpoint():
+    out = _instrumented("async def helper():\n    for i in xs:\n        f(i)\n")
+    inner = out.split("async def helper")[1]
+    assert f"await {CHECKPOINT_FN}" in inner
+
+
+def test_class_bodies_are_left_alone():
+    out = _instrumented("class C:\n    for i in xs:\n        pass\n")
+    assert CHECKPOINT_FN not in out.split("class C")[1]
+
+
+def test_instrumented_code_compiles_inside_the_async_wrapper():
+    """The sandbox indents the block into an ``async def``; awaits must fit."""
+    out = _instrumented(
+        "a = 1\nfor i in xs:\n    a += i\ndef h():\n    return a\nh()\n",
+    )
+    wrapped = "async def __w():\n" + "".join(f"    {ln}\n" for ln in out.splitlines())
+    compile(wrapped, "<test>", "exec")
+
+
+def test_empty_module_is_unchanged():
+    assert _instrumented("") == ""
+
+
+# ── the channel ────────────────────────────────────────────────────────────
+def test_drain_is_non_blocking_and_ordered():
+    q: asyncio.Queue = asyncio.Queue()
+    channel = SteeringChannel(interject_q=q)
+    q.put_nowait("first")
+    q.put_nowait("second")
+    channel.checkpoint_sync(line=1)
+    assert channel.messages == ["first", "second"]
+
+
+def test_channel_without_a_queue_is_inert():
+    channel = SteeringChannel(interject_q=None)
+    channel.checkpoint_sync(line=3)
+    assert channel.messages == []
+    assert channel.active is False
+
+
+def test_dict_payloads_are_reduced_to_their_text():
+    q: asyncio.Queue = asyncio.Queue()
+    channel = SteeringChannel(interject_q=q)
+    q.put_nowait({"content": "from a nested loop"})
+    channel.checkpoint_sync()
+    assert channel.messages == ["from a nested loop"]
+
+
+def test_progress_quotes_the_line_without_the_repl_return():
+    """REPL semantics rewrite a trailing expression; the model never wrote it."""
+    channel = SteeringChannel(interject_q=None)
+    channel.bind_source("x = compute()\nreturn summarise(x)")
+    channel.checkpoint_sync(line=2)
+    assert channel.progress()["last_statement"] == "summarise(x)"
+
+
+# ── binding ────────────────────────────────────────────────────────────────
+def test_bind_and_restore_leaves_globals_as_found():
+    global_state: dict = {"unrelated": 1}
+    channel = SteeringChannel(interject_q=None)
+    token = bind_sandbox_steering_channel(global_state, channel)
+    assert current_channel(global_state) is channel
+    assert callable(global_state[CHECKPOINT_FN])
+    restore_sandbox_steering_channel(global_state, token)
+    assert global_state == {"unrelated": 1}
+    assert current_channel(global_state) is None
+
+
+def test_nested_binding_restores_the_outer_channel():
+    global_state: dict = {}
+    outer = SteeringChannel(interject_q=None)
+    inner = SteeringChannel(interject_q=None)
+    outer_token = bind_sandbox_steering_channel(global_state, outer)
+    inner_token = bind_sandbox_steering_channel(global_state, inner)
+    assert current_channel(global_state) is inner
+    restore_sandbox_steering_channel(global_state, inner_token)
+    assert current_channel(global_state) is outer
+    restore_sandbox_steering_channel(global_state, outer_token)
+    assert global_state.get(CHANNEL_GLOBAL) is None
+
+
+# ── end to end through the sandbox ─────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_block_without_a_channel_is_not_instrumented():
+    """No channel means no checkpoints and no behaviour change at all."""
+    session = PythonExecutionSession()
+    try:
+        out = await session.execute(
+            "total = 0\nfor i in range(5):\n    total += i\ntotal",
+        )
+    finally:
+        await session.close()
+    assert out["error"] is None
+    assert out["result"] == 10
+
+
+@pytest.mark.asyncio
+async def test_interjection_reaches_a_running_loop():
+    session = PythonExecutionSession()
+    interject_q: asyncio.Queue = asyncio.Queue()
+    notify_q: asyncio.Queue = asyncio.Queue()
+    channel = SteeringChannel(
+        interject_q=interject_q,
+        notification_q=notify_q,
+        suspend_timeout=5.0,
+    )
+    token = bind_sandbox_steering_channel(session.global_state, channel)
+
+    reached: list[int] = []
+    session.global_state["record"] = reached.append
+
+    async def steer() -> None:
+        # Correct only once the loop is genuinely under way, then wait for the
+        # block to actually suspend before resuming it. Sending both together
+        # would let one drain take both, which is correct behaviour but tests
+        # nothing about the suspend.
+        while len(reached) < 2:
+            await asyncio.sleep(0)
+        await interject_q.put("narrow it to the EU vendors")
+        while channel.progress()["suspensions"] < 1:
+            await asyncio.sleep(0)
+        await interject_q.put("continue")
+
+    steerer = asyncio.create_task(steer())
+    try:
+        out = await session.execute(
+            "import asyncio\n"
+            "for i in range(6):\n"
+            "    record(i)\n"
+            "    await asyncio.sleep(0.02)\n",
+        )
+        await steerer
+    finally:
+        restore_sandbox_steering_channel(session.global_state, token)
+        await session.close()
+
+    assert out["error"] is None
+    assert channel.messages == ["narrow it to the EU vendors", "continue"]
+    progress = channel.progress()
+    assert progress["suspensions"] == 1
+    assert progress["last_line_reached"] is not None
+    # The loop ran to completion: resuming means resuming, not restarting.
+    assert reached == list(range(6))
+
+    payload = notify_q.get_nowait()
+    assert payload["type"] == "steering_checkpoint"
+    assert payload["interjections"] == ["narrow it to the EU vendors"]
+    assert payload["progress"]["last_line_reached"] is not None
+
+
+@pytest.mark.asyncio
+async def test_suspension_holds_the_block_until_a_decision_arrives():
+    """The point of suspending: no further side effect until the model rules."""
+    session = PythonExecutionSession()
+    interject_q: asyncio.Queue = asyncio.Queue()
+    channel = SteeringChannel(interject_q=interject_q, suspend_timeout=5.0)
+    token = bind_sandbox_steering_channel(session.global_state, channel)
+
+    sent: list[int] = []
+    session.global_state["send"] = sent.append
+    interject_q.put_nowait("wait")
+
+    exec_task = asyncio.create_task(
+        session.execute(
+            "import asyncio\nfor i in range(4):\n    send(i)\n    await asyncio.sleep(0)\n",
+        ),
+    )
+    try:
+        # The first checkpoint is at the top of the body, before any send.
+        await asyncio.sleep(0.1)
+        assert sent == [], "block ran past the checkpoint without a decision"
+
+        await interject_q.put("go ahead")
+        out = await exec_task
+    finally:
+        restore_sandbox_steering_channel(session.global_state, token)
+        await session.close()
+
+    assert out["error"] is None
+    assert sent == [0, 1, 2, 3]
+
+
+@pytest.mark.asyncio
+async def test_cancellation_unwinds_a_suspended_block():
+    """What ``stop_<tool>_<call_id>`` does: cancel the task under the await."""
+    session = PythonExecutionSession()
+    interject_q: asyncio.Queue = asyncio.Queue()
+    channel = SteeringChannel(interject_q=interject_q, suspend_timeout=30.0)
+    token = bind_sandbox_steering_channel(session.global_state, channel)
+    interject_q.put_nowait("stop what you are doing")
+
+    exec_task = asyncio.create_task(
+        session.execute(
+            "import asyncio\nfor i in range(50):\n    await asyncio.sleep(0.01)\n",
+        ),
+    )
+    try:
+        await asyncio.sleep(0.1)
+        exec_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await exec_task
+    finally:
+        restore_sandbox_steering_channel(session.global_state, token)
+        await session.close()
+
+    # Progress survives the cancellation, so the next turn is not blind.
+    assert channel.progress()["checkpoints_passed"] > 0
+    assert "stop what you are doing" in channel.messages
+
+
+@pytest.mark.asyncio
+async def test_suspension_resumes_rather_than_stranding_the_loop():
+    """A turn that answers in prose must not deadlock the block forever."""
+    session = PythonExecutionSession()
+    interject_q: asyncio.Queue = asyncio.Queue()
+    channel = SteeringChannel(interject_q=interject_q, suspend_timeout=0.2)
+    token = bind_sandbox_steering_channel(session.global_state, channel)
+    interject_q.put_nowait("something")
+
+    try:
+        out = await session.execute("x = 1\nx + 1")
+    finally:
+        restore_sandbox_steering_channel(session.global_state, token)
+        await session.close()
+
+    assert out["result"] == 2
+    assert any("no steering decision" in m for m in channel.messages)
+
+
+@pytest.mark.asyncio
+async def test_generated_code_can_read_the_interjections():
+    session = PythonExecutionSession()
+    interject_q: asyncio.Queue = asyncio.Queue()
+    channel = SteeringChannel(interject_q=interject_q, suspend_timeout=0.2)
+    token = bind_sandbox_steering_channel(session.global_state, channel)
+    interject_q.put_nowait("only the EU ones")
+
+    try:
+        out = await session.execute("x = 1\nlist(steering.messages)")
+    finally:
+        restore_sandbox_steering_channel(session.global_state, token)
+        await session.close()
+
+    assert out["error"] is None
+    assert "only the EU ones" in out["result"]
+
+
+@pytest.mark.asyncio
+async def test_dispatch_proxy_checkpoints_inside_a_comprehension():
+    """One statement, many dispatches — invisible to statement checkpoints."""
+    session = PythonExecutionSession()
+    interject_q: asyncio.Queue = asyncio.Queue()
+    channel = SteeringChannel(interject_q=interject_q, suspend_timeout=0.2)
+    token = bind_sandbox_steering_channel(session.global_state, channel)
+
+    sent: list[str] = []
+
+    class _Comms:
+        async def send(self, to: str) -> str:
+            sent.append(to)
+            return f"sent:{to}"
+
+    class _Prims:
+        comms = _Comms()
+
+    session.global_state["primitives"] = SteeringDispatchProxy(_Prims(), channel)
+    interject_q.put_nowait("hold on")
+
+    try:
+        out = await session.execute(
+            "vendors = ['a', 'b', 'c']\n"
+            "[await primitives.comms.send(v) for v in vendors]\n",
+        )
+    finally:
+        restore_sandbox_steering_channel(session.global_state, token)
+        await session.close()
+
+    assert out["error"] is None
+    assert channel.progress()["suspensions"] >= 1
+    assert sent == ["a", "b", "c"]
+
+
+@pytest.mark.asyncio
+async def test_stored_function_body_is_steerable_when_synthesised():
+    """A function's own loop is steerable, not just the call that starts it.
+
+    ``execute_function`` prepends the stored implementation as a preamble when
+    the function is not already in the namespace, so the ``def`` reaches the
+    sandbox as source and is instrumented like any other block. That makes the
+    inside of a long-running stored function reachable, rather than only the
+    boundary around it.
+    """
+    session = PythonExecutionSession()
+    interject_q: asyncio.Queue = asyncio.Queue()
+    channel = SteeringChannel(interject_q=interject_q, suspend_timeout=5.0)
+    token = bind_sandbox_steering_channel(session.global_state, channel)
+
+    sent: list[str] = []
+    session.global_state["record"] = sent.append
+    interject_q.put_nowait("only the first two")
+
+    preamble_style_code = (
+        "async def notify_all(targets):\n"
+        "    import asyncio\n"
+        "    for t in targets:\n"
+        "        record(t)\n"
+        "        await asyncio.sleep(0)\n"
+        "    return len(targets)\n"
+        "await notify_all(['a', 'b', 'c'])\n"
+    )
+
+    async def resume_once() -> None:
+        while channel.progress()["suspensions"] < 1:
+            await asyncio.sleep(0)
+        await interject_q.put("go on")
+
+    resumer = asyncio.create_task(resume_once())
+    try:
+        out = await session.execute(preamble_style_code)
+        await resumer
+    finally:
+        restore_sandbox_steering_channel(session.global_state, token)
+        await session.close()
+
+    assert out["error"] is None
+    assert out["result"] == 3
+    # The suspend happened inside the function body, before its first record.
+    assert channel.progress()["suspensions"] == 1
+    assert "only the first two" in channel.messages
+
+
+def test_dispatch_proxy_passes_non_callables_through():
+    channel = SteeringChannel(interject_q=None)
+
+    class _Manager:
+        label = "contacts"
+
+    class _Prims:
+        contacts = _Manager()
+
+    proxy = SteeringDispatchProxy(_Prims(), channel)
+    assert proxy.contacts.label == "contacts"
+
+
+# ── the tool surface ───────────────────────────────────────────────────────
+def test_execute_tools_declare_the_interject_queue():
+    """The loop keys steerability off the signature, before the tool returns.
+
+    ``ToolsData`` sets ``is_interjectable`` from ``_interject_queue`` being in
+    the signature at schedule time, which is what makes the dynamic
+    ``interject_<tool>_<call_id>`` helper exist while the block is still
+    running rather than only after it returns a handle.
+    """
+    actor = CodeActActor.__new__(CodeActActor)
+    for name in ("execute_code", "execute_function"):
+        fn = getattr(actor, name, None)
+        if fn is None:
+            continue
+        assert "_interject_queue" in inspect.signature(fn).parameters
+
+
+@pytest.mark.asyncio
+async def test_call_binding_yields_a_channel_and_restores_globals():
+    from unify.actor.execution import _CURRENT_SANDBOX
+
+    session = PythonExecutionSession()
+    sandbox_token = _CURRENT_SANDBOX.set(session)
+    interject_q: asyncio.Queue = asyncio.Queue()
+    try:
+        with CodeActActor._sandbox_call_binding(
+            clarification_up_q=None,
+            clarification_down_q=None,
+            interject_q=interject_q,
+            notification_q=None,
+        ) as channel:
+            assert isinstance(channel, SteeringChannel)
+            assert current_channel(session.global_state) is channel
+        assert current_channel(session.global_state) is None
+    finally:
+        _CURRENT_SANDBOX.reset(sandbox_token)
+        await session.close()

--- a/tests/conversation_manager/conftest.py
+++ b/tests/conversation_manager/conftest.py
@@ -352,6 +352,7 @@ def _reset_screen_share_state(cm: "CMStepDriver") -> None:
 
     cm.cm.user_screen_share_active = False
     cm.cm.assistant_screen_share_active = False
+    cm.cm.meet_screen_share_active = False
     cm.cm._screenshot_buffer.clear()
 
 

--- a/tests/conversation_manager/core/test_action_tool_registry_integrity.py
+++ b/tests/conversation_manager/core/test_action_tool_registry_integrity.py
@@ -65,12 +65,20 @@ def test_every_registered_tool_exists() -> None:
     assert not missing, f"registered but not defined: {missing}"
 
 
-def test_send_meet_chat_is_wired() -> None:
-    """Regression: this pair was split by a cleanup and shipped broken.
+def test_meet_tools_are_wired() -> None:
+    """Regression: a cleanup once split registration from definition here.
 
     The screenshare tools were removed in a contiguous cut that also swallowed
     ``send_meet_chat`` sitting between them, while its registration survived --
-    so every slow-brain turn raised AttributeError in staging.
+    so every slow-brain turn raised AttributeError in staging. The screenshare
+    pair is back, registered from the same block, so all three are pinned
+    together rather than leaving the same gap open next to them.
     """
-    assert _registered_tool_attributes().get("send_meet_chat") == "send_meet_chat"
-    assert hasattr(ConversationManagerBrainActionTools, "send_meet_chat")
+    registered = _registered_tool_attributes()
+    for name in (
+        "send_meet_chat",
+        "start_meet_screenshare",
+        "stop_meet_screenshare",
+    ):
+        assert registered.get(name) == name, f"{name} is not registered"
+        assert hasattr(ConversationManagerBrainActionTools, name)

--- a/tests/conversation_manager/core/test_console_script_result.py
+++ b/tests/conversation_manager/core/test_console_script_result.py
@@ -1,0 +1,153 @@
+"""
+tests/conversation_manager/core/test_console_script_result.py
+=============================================================
+
+Reading back what the console did with the moves that were asked for.
+
+The point of the report is that the assistant stops saying "and there it is"
+when the control was not there. So these are mostly about the difference
+between a move that failed, a move that correctly did not happen, and a move
+that landed -- because the assistant should say something different about each,
+and only one of them is worth a turn.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from unify.conversation_manager.domains.console_script_result import (
+    summarize_console_script,
+)
+from unify.conversation_manager.events import ConsoleScriptResult
+
+pytestmark = pytest.mark.no_unify_context
+
+
+def result(*outcomes: tuple[str, str]) -> ConsoleScriptResult:
+    return ConsoleScriptResult(
+        script_id="s1",
+        outcomes=[{"target": t, "outcome": o} for t, o in outcomes],
+    )
+
+
+class TestWhatWakesTheBrain:
+    def test_a_landed_move_does_not(self):
+        """A turn per successful click is cost with nothing to decide."""
+        _, needs_attention = summarize_console_script(
+            result(("section:integrations", "done")),
+        )
+
+        assert needs_attention is False
+
+    def test_a_missing_control_does(self):
+        """The assistant may have just described this as done."""
+        _, needs_attention = summarize_console_script(
+            result(("leaf:contact:42", "not-found")),
+        )
+
+        assert needs_attention is True
+
+    @pytest.mark.parametrize("outcome", ["unknown", "not-found", "not-interactive"])
+    def test_every_failure_does(self, outcome):
+        _, needs_attention = summarize_console_script(result(("x", outcome)))
+
+        assert needs_attention is True
+
+    @pytest.mark.parametrize("outcome", ["skipped", "blocked"])
+    def test_a_move_that_correctly_did_not_happen_does_not(self, outcome):
+        """Being interrupted, or told not to navigate, is not a fault to fix."""
+        _, needs_attention = summarize_console_script(result(("x", outcome)))
+
+        assert needs_attention is False
+
+    def test_one_failure_among_successes_still_does(self):
+        _, needs_attention = summarize_console_script(
+            result(
+                ("section:integrations", "done"),
+                ("leaf:integration:github", "not-found"),
+            ),
+        )
+
+        assert needs_attention is True
+
+
+class TestWhatTheAssistantIsTold:
+    def test_a_landed_move_is_named_so_it_can_be_referred_to(self):
+        summary, _ = summarize_console_script(
+            result(("section:integrations", "done")),
+        )
+
+        assert "section:integrations" in summary
+
+    def test_a_failure_says_not_to_claim_otherwise(self):
+        summary, _ = summarize_console_script(
+            result(("leaf:contact:42", "not-found")),
+        )
+
+        assert "leaf:contact:42" in summary
+        assert "not there" in summary
+        assert "should not say otherwise" in summary
+
+    def test_an_interruption_is_explained_as_such(self):
+        summary, _ = summarize_console_script(result(("route:/billing", "skipped")))
+
+        assert "interrupted" in summary
+        assert "should not say otherwise" not in summary
+
+    def test_being_switched_off_is_explained_as_such(self):
+        summary, _ = summarize_console_script(result(("route:/billing", "blocked")))
+
+        assert "turned off" in summary
+
+    def test_successes_and_failures_are_both_reported(self):
+        summary, _ = summarize_console_script(
+            result(
+                ("section:integrations", "done"),
+                ("leaf:integration:github", "not-found"),
+            ),
+        )
+
+        assert "section:integrations" in summary
+        assert "leaf:integration:github" in summary
+
+
+class TestMalformedReports:
+    def test_an_empty_report_says_nothing_and_wakes_nothing(self):
+        summary, needs_attention = summarize_console_script(result())
+
+        assert summary == ""
+        assert needs_attention is False
+
+    def test_entries_that_are_not_dicts_are_ignored(self):
+        event = ConsoleScriptResult(script_id="s1", outcomes=["nonsense", 42, None])
+        summary, needs_attention = summarize_console_script(event)
+
+        assert summary == ""
+        assert needs_attention is False
+
+    def test_an_entry_without_a_target_is_ignored(self):
+        event = ConsoleScriptResult(
+            script_id="s1",
+            outcomes=[{"outcome": "not-found"}],
+        )
+        summary, needs_attention = summarize_console_script(event)
+
+        assert summary == ""
+        assert needs_attention is False
+
+    def test_an_unrecognized_outcome_is_ignored_rather_than_guessed_at(self):
+        summary, needs_attention = summarize_console_script(
+            result(("x", "something-new")),
+        )
+
+        assert summary == ""
+        assert needs_attention is False
+
+
+class TestEventShape:
+    def test_the_report_is_not_logged_as_conversation(self):
+        """Ambient, like presence; it must not land in the transcript."""
+        assert ConsoleScriptResult.loggable is False
+
+    def test_outcomes_default_to_empty(self):
+        assert ConsoleScriptResult().outcomes == []

--- a/tests/conversation_manager/core/test_meet_screenshare_attribution.py
+++ b/tests/conversation_manager/core/test_meet_screenshare_attribution.py
@@ -7,6 +7,7 @@ label, so both are pinned here.
 """
 
 from datetime import datetime, timezone
+from types import SimpleNamespace
 
 from unify.common.prompt_helpers import PromptParts
 from unify.conversation_manager.cm_types.screenshot import (
@@ -90,3 +91,93 @@ def test_fast_brain_label_stays_fenced_when_attributed() -> None:
     assert labels
     for label in labels:
         assert label.startswith("=== ") and label.endswith(" ===")
+
+
+# ---------------------------------------------------------------------------
+# Share state must follow the share, not the meeting
+# ---------------------------------------------------------------------------
+
+
+def _meet_state(*, google_meet: bool = True, sharing: bool) -> str:
+    from unify.conversation_manager.domains.renderer import Renderer
+
+    return Renderer.render_meet_interaction_state(
+        google_meet_active=google_meet,
+        meet_screen_share_active=sharing,
+    )
+
+
+def test_a_live_share_is_announced_as_live() -> None:
+    state = _meet_state(sharing=True)
+    assert "status='live'" in state
+    assert "sharing their screen" in state
+
+
+def test_no_share_says_so_rather_than_going_quiet() -> None:
+    """Silence here was read as "the last screen I saw is still up".
+
+    The old block was emitted for the whole meeting under a name and status that
+    asserted an active visual, so the assistant kept describing a screen the
+    presenter had already taken down. Saying "nobody is sharing" out loud is what
+    replaces that.
+    """
+    state = _meet_state(sharing=False)
+    assert "status='none'" in state
+    assert "Nobody" in state
+    assert "history" in state
+
+
+def test_the_block_never_claims_a_visual_for_the_whole_meeting() -> None:
+    """The regression guard: a meeting in progress is not a share in progress."""
+    assert "google_meet_visual" not in _meet_state(sharing=False)
+    assert "google_meet_visual" not in _meet_state(sharing=True)
+
+
+def test_no_meeting_means_no_block_at_all() -> None:
+    from unify.conversation_manager.domains.renderer import Renderer
+
+    state = Renderer.render_meet_interaction_state(
+        google_meet_active=False,
+        teams_meet_active=False,
+        meet_screen_share_active=False,
+    )
+    assert "meet_shared_screen" not in state
+
+
+def test_unpaired_meet_frames_are_dropped_when_the_share_ends() -> None:
+    """Otherwise the next turn describes a screen that has been taken down."""
+    from unify.conversation_manager.conversation_manager import ConversationManager
+
+    cm = SimpleNamespace(
+        _screenshot_buffer=[
+            _entry("google_meet", "Ada"),
+            _entry("google_meet", "Ada")._replace(utterance=""),
+            _entry("user", None)._replace(utterance=""),
+        ],
+    )
+    # The first entry carries an utterance; the second does not.
+    cm._screenshot_buffer[0] = cm._screenshot_buffer[0]._replace(
+        utterance="what's that?",
+    )
+
+    drop = ConversationManager.drop_unpaired_screenshots.__get__(cm)
+    assert drop("google_meet") == 1
+
+    remaining = cm._screenshot_buffer
+    assert [e.source for e in remaining] == ["google_meet", "user"]
+    assert remaining[0].utterance == "what's that?"
+
+
+def test_dropping_keeps_frames_tied_to_a_question() -> None:
+    """A question asked about a screen stays answerable after the screen goes."""
+    from unify.conversation_manager.conversation_manager import ConversationManager
+
+    cm = SimpleNamespace(
+        _screenshot_buffer=[
+            _entry("google_meet", "Ada")._replace(utterance="read this"),
+        ],
+    )
+    drop = ConversationManager.drop_unpaired_screenshots.__get__(cm)
+
+    assert drop("google_meet") == 0
+    assert len(cm._screenshot_buffer) == 1

--- a/tests/conversation_manager/core/test_recall_client.py
+++ b/tests/conversation_manager/core/test_recall_client.py
@@ -525,3 +525,97 @@ async def test_realtime_endpoints_are_nested_under_recording_config() -> None:
     assert endpoints[0]["url"] == "wss://comms/meet/events?room=r&token=t"
     # The compliance pin shares this dict with three features now.
     assert payload["recording_config"]["retention"] is None
+
+
+# ---------------------------------------------------------------------------
+# Outbound screenshare (the assistant's own desktop)
+# ---------------------------------------------------------------------------
+
+
+def _request_call(session) -> tuple[str, str]:
+    """The (method, path) of the last request, with the region base stripped.
+
+    The client hands ``session.request`` a fully-qualified URL; the path is what
+    these tests are pinning.
+    """
+    method, url = session.request.call_args.args[:2]
+    return method, url.replace("https://us-west-2.recall.ai/api/v1", "")
+
+
+@pytest.mark.asyncio
+async def test_start_screenshare_never_names_the_camera() -> None:
+    """The camera is the page bridging audio, and must not be touched.
+
+    Merge-vs-replace on this endpoint is undocumented, so naming the camera at
+    all risks replacing or reloading the page carrying the assistant's voice.
+    Recall also states the camera cannot be turned off while output media is on,
+    so there is nothing to preserve by re-sending it. The withdrawn
+    implementation re-sent it on every change; losing audio mid-meeting is what
+    got it withdrawn.
+    """
+    session = _mock_session(body={"id": "bot_1"})
+    with patch("aiohttp.ClientSession", return_value=session):
+        await _client(session).start_screenshare(
+            "bot_1",
+            "https://comms/meet/desktop?t=x",
+        )
+
+    method, path = _request_call(session)
+    payload = _create_payload(session)
+    assert (method, path) == ("POST", "/bot/bot_1/output_media/")
+    assert set(payload) == {"screenshare"}, "camera must be absent"
+    assert payload["screenshare"]["kind"] == "webpage"
+    assert payload["screenshare"]["config"]["url"] == "https://comms/meet/desktop?t=x"
+
+
+@pytest.mark.asyncio
+async def test_stop_screenshare_deletes_only_the_screenshare_surface() -> None:
+    """DELETE with the surface named is the documented stop.
+
+    Clearing it by re-POSTing a camera-only body -- what the withdrawn version
+    did -- is undocumented and leans on the same merge behaviour.
+    """
+    session = _mock_session(status=204, text="")
+    with patch("aiohttp.ClientSession", return_value=session):
+        await _client(session).stop_screenshare("bot_1")
+
+    method, path = _request_call(session)
+    assert (method, path) == ("DELETE", "/bot/bot_1/output_media/")
+    assert _create_payload(session) == {"screenshare": True}
+
+
+@pytest.mark.asyncio
+async def test_a_desktop_capable_assistant_gets_render_headroom() -> None:
+    """Two rendered pages do not fit in the default variant's 250 millicores.
+
+    The variant is fixed for the bot's whole life, so it has to be chosen at join
+    -- there is no upgrading at the moment somebody asks to share.
+    """
+    session = _mock_session(body={"id": "bot_1"})
+    with patch("aiohttp.ClientSession", return_value=session):
+        await _client(session).create_bot(
+            meeting_url="https://meet.google.com/abc",
+            bot_name="Unify",
+            bridge_page_url="https://comms/meet/bridge?token=t",
+            may_screenshare=True,
+        )
+
+    payload = _create_payload(session)
+    assert payload["variant"]["google_meet"] == "web_4_core"
+    # Headroom only. Requesting participant video is a separate decision and must
+    # not ride along on it.
+    assert "video_separate_png" not in payload["recording_config"]
+
+
+@pytest.mark.asyncio
+async def test_an_assistant_with_no_desktop_pays_for_no_headroom() -> None:
+    """It can never share, so the surcharge would buy nothing."""
+    session = _mock_session(body={"id": "bot_1"})
+    with patch("aiohttp.ClientSession", return_value=session):
+        await _client(session).create_bot(
+            meeting_url="https://meet.google.com/abc",
+            bot_name="Unify",
+            bridge_page_url="https://comms/meet/bridge?token=t",
+        )
+
+    assert "variant" not in _create_payload(session)

--- a/tests/conversation_manager/core/test_recall_provider.py
+++ b/tests/conversation_manager/core/test_recall_provider.py
@@ -332,74 +332,104 @@ async def test_state_returns_none_on_api_failure() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _desktop_token_claims(provider) -> dict:
-    """Decode the LiveKit grant handed to the desktop page."""
+DESKTOP_ENV = {
+    "MEET_BRIDGE_PAGE_URL": BRIDGE,
+    "RECALL_RELAY_SECRET": "relay-secret",  # pragma: allowlist secret
+}
+
+
+def _presenting_provider():
+    """A provider whose managed desktop is entitled, healthy and reachable."""
+    provider = _provider()
+    provider._client.start_screenshare = AsyncMock()
+    return provider
+
+
+def _page_query(provider) -> dict:
     page_url = provider._client.start_screenshare.call_args.args[1]
-    query = parse_qs(urlparse(page_url).query)
-    return jwt.decode(
-        query["token"][0],
-        LIVEKIT_ENV["LIVEKIT_API_SECRET"],
-        algorithms=["HS256"],
-    )
+    return {k: v[0] for k, v in parse_qs(urlparse(page_url).query).items()}
 
 
 @pytest.mark.asyncio
-async def test_the_desktop_page_never_shares_the_bridge_identity() -> None:
-    """LiveKit evicts a duplicate identity, so this is not a cosmetic difference.
+async def test_present_frames_the_managed_desktop_liveview() -> None:
+    """The meeting sees the real desktop, not a reconstruction of it."""
+    provider = _presenting_provider()
+    with (
+        patch.dict("os.environ", DESKTOP_ENV, clear=False),
+        patch(
+            "unify.conversation_manager.domains.recall.provider.resolve_desktop_urls",
+            return_value=("https://vm.example.com", "https://vm.example.com"),
+        ),
+        patch(
+            "unify.conversation_manager.domains.recall.provider.desktop_proxy_healthy",
+            AsyncMock(return_value=True),
+        ),
+    ):
+        assert await provider.present(channel="google_meet", session_id="bot_1")
 
-    A desktop page joining under the bridge's name would kick the page carrying
-    audio out of the room and leave the assistant silent for the rest of the
-    meeting -- the failure that got the first screenshare implementation
-    withdrawn.
+    query = _page_query(provider)
+    assert query["liveview"] == "https://vm.example.com/desktop/custom.html"
+    assert query["sig"], "the page refuses an unsigned liveview"
+
+
+@pytest.mark.asyncio
+async def test_the_page_url_is_signed_so_it_cannot_frame_anything_else() -> None:
+    """The page is unauthenticated: Recall loads it with no credential of ours.
+
+    Unsigned, it would frame any URL anyone handed it on our own domain. The
+    signature must be reproducible by the page, and must cover the liveview -- a
+    signature over something else would let the URL be swapped.
     """
-    provider = _provider()
-    provider._client.start_screenshare = AsyncMock()
-    env = dict(LIVEKIT_ENV)
-    env["MEET_BRIDGE_PAGE_URL"] = BRIDGE
-    with patch.dict("os.environ", env, clear=False):
-        await provider.join(
-            channel="google_meet",
-            meeting_url="https://meet.google.com/abc",
-            display_name="Unify",
-            room_name="unity_25_gmeet",
-        )
-        assert await provider.present(
-            channel="google_meet",
-            session_id="bot_1",
-            room_name="unity_25_gmeet",
-        )
+    import hashlib
+    import hmac
 
-    bridge_url = provider._client.create_bot.call_args.kwargs["bridge_page_url"]
-    bridge_identity = jwt.decode(
-        parse_qs(urlparse(bridge_url).query)["token"][0],
-        LIVEKIT_ENV["LIVEKIT_API_SECRET"],
-        algorithms=["HS256"],
-    )["sub"]
+    provider = _presenting_provider()
+    with (
+        patch.dict("os.environ", DESKTOP_ENV, clear=False),
+        patch(
+            "unify.conversation_manager.domains.recall.provider.resolve_desktop_urls",
+            return_value=("https://vm.example.com", "https://vm.example.com"),
+        ),
+        patch(
+            "unify.conversation_manager.domains.recall.provider.desktop_proxy_healthy",
+            AsyncMock(return_value=True),
+        ),
+    ):
+        await provider.present(channel="google_meet", session_id="bot_1")
 
-    assert _desktop_token_claims(provider)["sub"] != bridge_identity
+    query = _page_query(provider)
+    payload = f"{query['liveview']}\x00{query.get('password', '')}".encode()
+    expected = hmac.new(
+        DESKTOP_ENV["RECALL_RELAY_SECRET"].encode(),
+        payload,
+        hashlib.sha256,
+    ).hexdigest()
+    assert query["sig"] == expected
 
 
 @pytest.mark.asyncio
-async def test_the_desktop_page_can_only_watch() -> None:
-    """It exists to display. Publish rights would let it put media in the call."""
-    provider = _provider()
-    provider._client.start_screenshare = AsyncMock()
-    env = dict(LIVEKIT_ENV)
-    env["MEET_BRIDGE_PAGE_URL"] = BRIDGE
-    with patch.dict("os.environ", env, clear=False):
-        assert await provider.present(
-            channel="google_meet",
-            session_id="bot_1",
-            room_name="unity_25_gmeet",
-        )
+async def test_present_refuses_when_the_desktop_is_not_serving() -> None:
+    """Entitlement is not liveness.
 
-    grants = _desktop_token_claims(provider)["video"]
-    assert grants["room"] == "unity_25_gmeet"
-    assert grants["roomJoin"] is True
-    assert grants.get("canSubscribe") is True
-    assert grants.get("canPublish") in (False, None)
-    assert grants.get("canPublishData") in (False, None)
-    assert grants.get("roomAdmin") in (False, None)
+    A dead VM would otherwise put noVNC's own error dialog on the meeting's main
+    stage, which reads as the assistant being broken rather than the desktop.
+    """
+    provider = _presenting_provider()
+    with (
+        patch.dict("os.environ", DESKTOP_ENV, clear=False),
+        patch(
+            "unify.conversation_manager.domains.recall.provider.resolve_desktop_urls",
+            return_value=("https://vm.example.com", "https://vm.example.com"),
+        ),
+        patch(
+            "unify.conversation_manager.domains.recall.provider.desktop_proxy_healthy",
+            AsyncMock(return_value=False),
+        ),
+    ):
+        assert (
+            await provider.present(channel="google_meet", session_id="bot_1") is False
+        )
+    provider._client.start_screenshare.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -410,16 +440,19 @@ async def test_present_reports_failure_rather_than_raising() -> None:
     """
     provider = _provider()
     provider._client.start_screenshare = AsyncMock(side_effect=RecallError("nope"))
-    env = dict(LIVEKIT_ENV)
-    env["MEET_BRIDGE_PAGE_URL"] = BRIDGE
-    with patch.dict("os.environ", env, clear=False):
+    with (
+        patch.dict("os.environ", DESKTOP_ENV, clear=False),
+        patch(
+            "unify.conversation_manager.domains.recall.provider.resolve_desktop_urls",
+            return_value=("https://vm.example.com", "https://vm.example.com"),
+        ),
+        patch(
+            "unify.conversation_manager.domains.recall.provider.desktop_proxy_healthy",
+            AsyncMock(return_value=True),
+        ),
+    ):
         assert (
-            await provider.present(
-                channel="google_meet",
-                session_id="bot_1",
-                room_name="unity_25_gmeet",
-            )
-            is False
+            await provider.present(channel="google_meet", session_id="bot_1") is False
         )
 
 

--- a/tests/conversation_manager/core/test_recall_provider.py
+++ b/tests/conversation_manager/core/test_recall_provider.py
@@ -325,3 +325,112 @@ async def test_state_returns_none_on_api_failure() -> None:
     provider = _provider()
     provider._client.get_bot = AsyncMock(side_effect=RecallError("nope"))
     assert await provider.state(channel="google_meet", session_id="bot_1") is None
+
+
+# ---------------------------------------------------------------------------
+# Outbound screenshare (the assistant's own desktop)
+# ---------------------------------------------------------------------------
+
+
+def _desktop_token_claims(provider) -> dict:
+    """Decode the LiveKit grant handed to the desktop page."""
+    page_url = provider._client.start_screenshare.call_args.args[1]
+    query = parse_qs(urlparse(page_url).query)
+    return jwt.decode(
+        query["token"][0],
+        LIVEKIT_ENV["LIVEKIT_API_SECRET"],
+        algorithms=["HS256"],
+    )
+
+
+@pytest.mark.asyncio
+async def test_the_desktop_page_never_shares_the_bridge_identity() -> None:
+    """LiveKit evicts a duplicate identity, so this is not a cosmetic difference.
+
+    A desktop page joining under the bridge's name would kick the page carrying
+    audio out of the room and leave the assistant silent for the rest of the
+    meeting -- the failure that got the first screenshare implementation
+    withdrawn.
+    """
+    provider = _provider()
+    provider._client.start_screenshare = AsyncMock()
+    env = dict(LIVEKIT_ENV)
+    env["MEET_BRIDGE_PAGE_URL"] = BRIDGE
+    with patch.dict("os.environ", env, clear=False):
+        await provider.join(
+            channel="google_meet",
+            meeting_url="https://meet.google.com/abc",
+            display_name="Unify",
+            room_name="unity_25_gmeet",
+        )
+        assert await provider.present(
+            channel="google_meet",
+            session_id="bot_1",
+            room_name="unity_25_gmeet",
+        )
+
+    bridge_url = provider._client.create_bot.call_args.kwargs["bridge_page_url"]
+    bridge_identity = jwt.decode(
+        parse_qs(urlparse(bridge_url).query)["token"][0],
+        LIVEKIT_ENV["LIVEKIT_API_SECRET"],
+        algorithms=["HS256"],
+    )["sub"]
+
+    assert _desktop_token_claims(provider)["sub"] != bridge_identity
+
+
+@pytest.mark.asyncio
+async def test_the_desktop_page_can_only_watch() -> None:
+    """It exists to display. Publish rights would let it put media in the call."""
+    provider = _provider()
+    provider._client.start_screenshare = AsyncMock()
+    env = dict(LIVEKIT_ENV)
+    env["MEET_BRIDGE_PAGE_URL"] = BRIDGE
+    with patch.dict("os.environ", env, clear=False):
+        assert await provider.present(
+            channel="google_meet",
+            session_id="bot_1",
+            room_name="unity_25_gmeet",
+        )
+
+    grants = _desktop_token_claims(provider)["video"]
+    assert grants["room"] == "unity_25_gmeet"
+    assert grants["roomJoin"] is True
+    assert grants.get("canSubscribe") is True
+    assert grants.get("canPublish") in (False, None)
+    assert grants.get("canPublishData") in (False, None)
+    assert grants.get("roomAdmin") in (False, None)
+
+
+@pytest.mark.asyncio
+async def test_present_reports_failure_rather_than_raising() -> None:
+    """The assistant must be able to say it could not share.
+
+    Claiming a screen is up when none is buys a participant hunting for it.
+    """
+    provider = _provider()
+    provider._client.start_screenshare = AsyncMock(side_effect=RecallError("nope"))
+    env = dict(LIVEKIT_ENV)
+    env["MEET_BRIDGE_PAGE_URL"] = BRIDGE
+    with patch.dict("os.environ", env, clear=False):
+        assert (
+            await provider.present(
+                channel="google_meet",
+                session_id="bot_1",
+                room_name="unity_25_gmeet",
+            )
+            is False
+        )
+
+
+@pytest.mark.asyncio
+async def test_stop_present_delegates_and_survives_a_gone_bot() -> None:
+    provider = _provider()
+    provider._client.stop_screenshare = AsyncMock()
+    assert await provider.stop_present(channel="google_meet", session_id="bot_1")
+    assert provider._client.stop_screenshare.call_args.args[0] == "bot_1"
+
+    provider._client.stop_screenshare = AsyncMock(side_effect=RecallError("gone"))
+    assert (
+        await provider.stop_present(channel="google_meet", session_id="bot_1") is False
+    )

--- a/tests/conversation_manager/core/test_renderer.py
+++ b/tests/conversation_manager/core/test_renderer.py
@@ -755,6 +755,28 @@ class TestRenderStateWithTracking:
         assert "<in_flight_actions>" in result.full_render
         assert "<active_conversations>" in result.full_render
 
+    def test_forwards_meet_screen_share_flag(
+        self,
+        renderer,
+        contact_index,
+        notification_bar,
+    ):
+        """render_state accepts and forwards meet_screen_share_active.
+
+        ConversationManager passes this kwarg on every snapshot; the meet
+        screenshare fix originally added it only to
+        render_meet_interaction_state, so every render_state call raised
+        TypeError and no slow-brain turn could render a prompt.
+        """
+        result = renderer.render_state(
+            contact_index,
+            notification_bar,
+            in_flight_actions={},
+            google_meet_active=True,
+            meet_screen_share_active=True,
+        )
+        assert "<meet_shared_screen status='live'>" in result.full_render
+
     def test_tracks_messages_in_conversation(
         self,
         renderer,

--- a/tests/conversation_manager/core/test_session_hydration.py
+++ b/tests/conversation_manager/core/test_session_hydration.py
@@ -27,6 +27,9 @@ from unify.conversation_manager.events import (
     FastBrainNotification,
     EmailReceived,
     EmailSent,
+    GoogleMeetChatMessage,
+    GoogleMeetChatSent,
+    InboundGoogleMeetUtterance,
     InboundPhoneUtterance,
     InboundUnifyMeetUtterance,
     OutboundPhoneUtterance,
@@ -35,6 +38,7 @@ from unify.conversation_manager.events import (
     PhoneCallStarted,
     SMSReceived,
     SMSSent,
+    TeamsMeetChatMessage,
     UnifyMessageReceived,
     UnifyMessageSent,
 )
@@ -488,3 +492,144 @@ class TestHydrationCrossCutting:
             await hydrate_global_thread(cm)
 
         assert len(cm.contact_index.global_thread) == 0
+
+
+# =============================================================================
+# Browser-meet chat hydration
+# =============================================================================
+
+
+class TestBrowserMeetChatHydration:
+    """Typed meeting-chat lines survive a restart, like the spoken ones.
+
+    Chat was recorded to the durable stores before it was rehydrated here, so
+    the gap was invisible in the transcript: only the brain's own thread came
+    back short, and only after a mid-meeting restart.
+    """
+
+    @pytest.mark.asyncio
+    async def test_inbound_chat_restored_under_the_meeting_medium(self):
+        cm = _make_mock_cm()
+        events = [
+            GoogleMeetChatMessage(
+                contact=ALICE,
+                sender_name="Bob Jones",
+                content="here is the doc",
+                timestamp=BASE_TIME,
+            ),
+        ]
+
+        with patch(
+            "unify.conversation_manager.domains.managers_utils.EVENT_BUS",
+        ) as mock_bus:
+            mock_bus.search = AsyncMock(return_value=_make_bus_events(events))
+            await hydrate_global_thread(cm)
+
+        msgs = cm.contact_index.get_messages_for_contact(2, Medium.GOOGLE_MEET)
+        assert len(msgs) == 1
+        assert msgs[0].role == "user"
+        # The marker is the only thing telling the brain this was typed: the
+        # thread is flat text, carrying none of the structure the stored rows do.
+        assert msgs[0].content == "<meeting chat> here is the doc"
+
+    @pytest.mark.asyncio
+    async def test_inbound_chat_credits_the_typist_not_the_call_contact(self):
+        """Anyone in the meeting can type, including a non-participant contact.
+
+        Every other case here derives the name from the contact; chat must not,
+        or a third participant's message is attributed to whoever the call is
+        with.
+        """
+        cm = _make_mock_cm()
+        events = [
+            GoogleMeetChatMessage(
+                contact=ALICE,
+                sender_name="Bob Jones",
+                content="dropping the link here",
+                timestamp=BASE_TIME,
+            ),
+        ]
+
+        with patch(
+            "unify.conversation_manager.domains.managers_utils.EVENT_BUS",
+        ) as mock_bus:
+            mock_bus.search = AsyncMock(return_value=_make_bus_events(events))
+            await hydrate_global_thread(cm)
+
+        msgs = cm.contact_index.get_messages_for_contact(2, Medium.GOOGLE_MEET)
+        assert msgs[0].name == "Bob Jones"
+
+    @pytest.mark.asyncio
+    async def test_teams_chat_lands_in_the_teams_thread(self):
+        """The two platforms share a handler, so the medium split needs pinning."""
+        cm = _make_mock_cm()
+        events = [
+            TeamsMeetChatMessage(
+                contact=ALICE,
+                sender_name="Bob Jones",
+                content="same but teams",
+                timestamp=BASE_TIME,
+            ),
+        ]
+
+        with patch(
+            "unify.conversation_manager.domains.managers_utils.EVENT_BUS",
+        ) as mock_bus:
+            mock_bus.search = AsyncMock(return_value=_make_bus_events(events))
+            await hydrate_global_thread(cm)
+
+        assert len(cm.contact_index.get_messages_for_contact(2, Medium.TEAMS_MEET)) == 1
+        assert cm.contact_index.get_messages_for_contact(2, Medium.GOOGLE_MEET) == []
+
+    @pytest.mark.asyncio
+    async def test_assistant_chat_restored_as_its_own(self):
+        """Without it the thread comes back holding questions and no answers."""
+        cm = _make_mock_cm()
+        events = [
+            GoogleMeetChatSent(
+                contact=ALICE,
+                content="https://example.com/doc",
+                timestamp=BASE_TIME,
+            ),
+        ]
+
+        with patch(
+            "unify.conversation_manager.domains.managers_utils.EVENT_BUS",
+        ) as mock_bus:
+            mock_bus.search = AsyncMock(return_value=_make_bus_events(events))
+            await hydrate_global_thread(cm)
+
+        msgs = cm.contact_index.get_messages_for_contact(2, Medium.GOOGLE_MEET)
+        assert len(msgs) == 1
+        assert msgs[0].role == "assistant"
+        assert msgs[0].content == "<meeting chat> https://example.com/doc"
+
+    @pytest.mark.asyncio
+    async def test_chat_and_speech_rehydrate_into_one_thread(self):
+        """They shared a medium live; a restart must not split them apart."""
+        cm = _make_mock_cm()
+        events = [
+            InboundGoogleMeetUtterance(
+                contact=ALICE,
+                content="did you get it?",
+                timestamp=BASE_TIME,
+            ),
+            GoogleMeetChatMessage(
+                contact=ALICE,
+                sender_name="Alice Smith",
+                content="here is the doc",
+                timestamp=BASE_TIME + timedelta(seconds=5),
+            ),
+        ]
+
+        with patch(
+            "unify.conversation_manager.domains.managers_utils.EVENT_BUS",
+        ) as mock_bus:
+            mock_bus.search = AsyncMock(return_value=_make_bus_events(events))
+            await hydrate_global_thread(cm)
+
+        msgs = cm.contact_index.get_messages_for_contact(2, Medium.GOOGLE_MEET)
+        assert [m.content for m in msgs] == [
+            "did you get it?",
+            "<meeting chat> here is the doc",
+        ]

--- a/tests/conversation_manager/voice/test_call_manager_meet_routing.py
+++ b/tests/conversation_manager/voice/test_call_manager_meet_routing.py
@@ -253,3 +253,83 @@ async def test_start_meet_join_failure_clears_state(monkeypatch):
     assert cleanup_calls == ["teams_meet"]
     assert len(captured["http_posts"]) == 1
     assert captured["http_posts"][0][0].endswith("/teamsmeet/join")
+
+
+# ---------------------------------------------------------------------------
+# Desktop screenshare state across meetings
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_presenting_state_does_not_survive_the_meeting(monkeypatch):
+    """This manager outlives individual meetings; the presenting flag must not.
+
+    Left set, the next meeting starts believing a share is already up: the start
+    tool is replaced by the stop tool, and ``start_meet_screenshare`` short-circuits
+    on its idempotence guard and reports success without putting anything on the
+    screenshare surface. The assistant then claims to be showing a screen nobody
+    can see.
+    """
+    cm = _build_call_manager()
+    cm._meet_session_id = "bot_1"
+    cm._call_channel = "google_meet"
+    cm._meet_presenting = True
+
+    monkeypatch.setattr(
+        call_manager_module,
+        "delete_livekit_room",
+        AsyncMock(),
+        raising=False,
+    )
+    monkeypatch.setattr(cm, "cleanup_call_proc", AsyncMock())
+    cm._meet_provider = MagicMock()
+    cm._meet_provider.leave = AsyncMock()
+
+    await cm._cleanup_meet("google_meet")
+
+    assert cm.is_presenting_to_meet is False
+    assert cm._meet_session_id is None
+
+
+@pytest.mark.asyncio
+async def test_starting_a_share_without_a_managed_desktop_is_refused(monkeypatch):
+    """Only the managed desktop is ever shared.
+
+    A user's own linked machine is not the assistant's to put in front of a room
+    of people, so this is refused rather than resolved to whatever desktop happens
+    to be reachable.
+    """
+    cm = _build_call_manager()
+    cm._meet_session_id = "bot_1"
+    cm._call_channel = "google_meet"
+    cm._meet_provider = MagicMock()
+    cm._meet_provider.present = AsyncMock(return_value=True)
+
+    monkeypatch.setattr(
+        call_manager_module.SESSION_DETAILS.assistant,
+        "desktop_mode",
+        "none",
+        raising=False,
+    )
+
+    assert await cm.start_meet_screenshare() is False
+    cm._meet_provider.present.assert_not_called()
+    assert cm.is_presenting_to_meet is False
+
+
+@pytest.mark.asyncio
+async def test_a_failed_stop_still_clears_the_flag() -> None:
+    """Otherwise the state is unrecoverable for the rest of the meeting.
+
+    A stop that fails leaves the surface up, but continuing to claim we are
+    presenting hides the start tool behind the idempotence guard with no way back.
+    """
+    cm = _build_call_manager()
+    cm._meet_session_id = "bot_1"
+    cm._call_channel = "google_meet"
+    cm._meet_presenting = True
+    cm._meet_provider = MagicMock()
+    cm._meet_provider.stop_present = AsyncMock(return_value=False)
+
+    assert await cm.stop_meet_screenshare() is False
+    assert cm.is_presenting_to_meet is False

--- a/tests/workflow_manager/test_bundle_and_fanout.py
+++ b/tests/workflow_manager/test_bundle_and_fanout.py
@@ -1,0 +1,245 @@
+"""Workflow bundles, the surface registry, and the install fan-out.
+
+Symbolic tests over in-memory surfaces. No backend and no LLM: these pin
+the invariants that make a bundle installable — that it can only reach
+source-scoped surfaces, that its content hash does not move with the
+settings someone installs it under, and that uninstall clears exactly the
+rows the bundle planted.
+"""
+
+from typing import Any, Dict, List
+
+import pytest
+
+from unify.workflow_manager.bundle import (
+    SurfaceRegistry,
+    UnscopedSurfaceError,
+    WorkflowBundle,
+)
+from unify.workflow_manager.types.workflow import WorkflowMode
+from unify.workflow_manager.workflow_manager import WorkflowManager
+
+WORKFLOW = "draft_email_replies"
+
+
+class RecordingSurface:
+    """Stands in for a manager's ``sync_custom``."""
+
+    def __init__(self, fail: bool = False) -> None:
+        self.calls: List[Dict[str, Any]] = []
+        self.fail = fail
+
+    def __call__(self, *, source_id: str, **kwargs: Any) -> bool:
+        if self.fail:
+            raise RuntimeError("surface exploded")
+        (source,) = kwargs.values()
+        self.calls.append({"source_id": source_id, "source": source})
+        return bool(source)
+
+
+def _registry(**surfaces: RecordingSurface) -> SurfaceRegistry:
+    registry = SurfaceRegistry()
+    for name, syncer in surfaces.items():
+        registry.register(
+            name,
+            syncer,
+            source_kwarg=f"source_{name}",
+            source_scoped=True,
+        )
+    return registry
+
+
+def _manager(registry: SurfaceRegistry) -> WorkflowManager:
+    """A manager wired to surfaces but not to any backend.
+
+    ``__init__`` resolves Orchestra contexts; the fan-out under test does
+    not touch them, so the instance is built directly.
+    """
+    manager = object.__new__(WorkflowManager)
+    manager._surfaces = registry
+    manager._catalogue = {}
+    return manager
+
+
+def _bundle(**kwargs: Any) -> WorkflowBundle:
+    defaults: Dict[str, Any] = {
+        "slug": WORKFLOW,
+        "name": "Draft email replies",
+        "version": "1.0.0",
+        "surfaces": {
+            "guidance": {"triage": {"custom_key": "triage", "custom_hash": "h1"}},
+            "tasks": {"morning": {"custom_key": "morning", "custom_hash": "h2"}},
+        },
+    }
+    defaults.update(kwargs)
+    return WorkflowBundle(**defaults)
+
+
+# --------------------------------------------------------------------- #
+# Registry                                                              #
+# --------------------------------------------------------------------- #
+def test_unscoped_surface_is_refused():
+    """An adapter that ignores source_id would prune its siblings' rows."""
+    registry = SurfaceRegistry()
+    with pytest.raises(UnscopedSurfaceError) as excinfo:
+        registry.register(
+            "contacts",
+            RecordingSurface(),
+            source_kwarg="source_contacts",
+            source_scoped=False,
+        )
+    assert excinfo.value.surface == "contacts"
+    assert "contacts" not in registry
+
+
+def test_bundle_cannot_claim_the_deployment_source_id():
+    with pytest.raises(ValueError, match="reserved"):
+        WorkflowBundle(slug="deployment", name="Impostor")
+
+
+def test_bundle_covering_an_unregistered_surface_is_refused_at_registration():
+    manager = _manager(_registry(guidance=RecordingSurface()))
+    with pytest.raises(KeyError, match="knowledge"):
+        manager.register_bundle(
+            _bundle(surfaces={"guidance": {}, "knowledge": {}}),
+        )
+
+
+# --------------------------------------------------------------------- #
+# Content hash                                                          #
+# --------------------------------------------------------------------- #
+def test_content_hash_ignores_params():
+    """Two people installing one bundle plant byte-identical rows.
+
+    Params are read at run time, never baked in, so folding them into the
+    hash would split one bundle into per-installation content and
+    foreclose ever federating a single pinned copy.
+    """
+    work = _bundle(params_schema={"mailbox": {"required": True}})
+    personal = _bundle(params_schema={"mailbox": {"required": True}})
+    assert work.content_hash() == personal.content_hash()
+
+
+def test_content_hash_moves_with_content():
+    before = _bundle()
+    after = _bundle(
+        surfaces={
+            "guidance": {"triage": {"custom_key": "triage", "custom_hash": "CHANGED"}},
+            "tasks": {"morning": {"custom_key": "morning", "custom_hash": "h2"}},
+        },
+    )
+    assert before.content_hash() != after.content_hash()
+
+
+# --------------------------------------------------------------------- #
+# Fan-out                                                               #
+# --------------------------------------------------------------------- #
+def test_install_stamps_every_surface_with_the_slug():
+    guidance, tasks = RecordingSurface(), RecordingSurface()
+    manager = _manager(_registry(guidance=guidance, tasks=tasks))
+
+    planted, failures = manager._plant(_bundle())
+
+    assert not failures
+    assert planted["guidance"]["entries"] == 1
+    assert planted["tasks"]["entries"] == 1
+    assert [c["source_id"] for c in guidance.calls] == [WORKFLOW]
+    assert [c["source_id"] for c in tasks.calls] == [WORKFLOW]
+    assert "triage" in guidance.calls[0]["source"]
+
+
+def test_uninstall_sends_an_empty_source_per_recorded_surface():
+    """Pruning is the engine's, scoped to the slug: an empty source removes
+    this bundle's rows and cannot reach anyone else's."""
+    guidance, tasks = RecordingSurface(), RecordingSurface()
+    manager = _manager(_registry(guidance=guidance, tasks=tasks))
+
+    removed, failures = manager._plant(_bundle(), empty=True)
+
+    assert not failures
+    assert guidance.calls[0]["source"] == {}
+    assert tasks.calls[0]["source"] == {}
+    assert removed["guidance"]["entries"] == 0
+
+
+def test_uninstall_uses_recorded_surfaces_not_the_current_bundle():
+    """A bundle that has since dropped a surface must still clear it."""
+    guidance, tasks = RecordingSurface(), RecordingSurface()
+    manager = _manager(_registry(guidance=guidance, tasks=tasks))
+
+    shrunk = _bundle(surfaces={"guidance": {}})
+    manager._plant(shrunk, surface_names=["guidance", "tasks"], empty=True)
+
+    assert len(guidance.calls) == 1
+    assert len(tasks.calls) == 1
+
+
+def test_one_failing_surface_does_not_stop_the_others():
+    guidance = RecordingSurface()
+    tasks = RecordingSurface(fail=True)
+    manager = _manager(_registry(guidance=guidance, tasks=tasks))
+
+    planted, failures = manager._plant(_bundle())
+
+    assert sorted(failures) == ["tasks"]
+    assert guidance.calls, "a failing surface must not skip the rest"
+    assert "error" in planted["tasks"]
+
+
+# --------------------------------------------------------------------- #
+# Params                                                                #
+# --------------------------------------------------------------------- #
+def test_missing_required_param_is_refused():
+    from unify.common.tool_outcome import ToolErrorException
+
+    bundle = _bundle(params_schema={"mailbox": {"required": True}})
+    with pytest.raises(ToolErrorException) as excinfo:
+        WorkflowManager._validate_params(bundle, {})
+    assert excinfo.value.payload["missing"] == ["mailbox"]
+
+
+def test_optional_params_are_not_required():
+    bundle = _bundle(params_schema={"tone": {"required": False}})
+    assert WorkflowManager._validate_params(bundle, {}) == {}
+
+
+def test_mode_default_is_seed():
+    """Seed is the safe default: pinned silently reverts local edits."""
+    assert _bundle().mode is WorkflowMode.seed
+
+
+# --------------------------------------------------------------------- #
+# Surface wiring                                                        #
+# --------------------------------------------------------------------- #
+def test_registered_kwargs_match_the_real_sync_signatures():
+    """The fan-out calls sync_custom by keyword, so a wrong name is a
+    TypeError at install time rather than anything the type checker sees.
+
+    KnowledgeManager takes ``source_claims`` while the others take
+    ``source_<surface>``; this pins that asymmetry so the mapping cannot
+    drift back to a guessed name.
+    """
+    import inspect
+
+    from unify.guidance_manager.guidance_manager import GuidanceManager
+    from unify.knowledge_manager.knowledge_manager import KnowledgeManager
+    from unify.task_scheduler.task_scheduler import TaskScheduler
+    from unify.workflow_manager.surfaces import SOURCE_SCOPED
+
+    managers = {
+        "guidance": GuidanceManager,
+        "knowledge": KnowledgeManager,
+        "tasks": TaskScheduler,
+    }
+    for surface, kwarg in SOURCE_SCOPED.items():
+        params = inspect.signature(managers[surface].sync_custom).parameters
+        assert kwarg in params, f"{surface}: sync_custom has no {kwarg!r}"
+        assert "source_id" in params, f"{surface}: sync_custom is not source-scoped"
+
+
+def test_pending_surfaces_are_not_registered():
+    """The unscoped managers must stay unreachable until their adapters
+    are scoped; listing one in both places would be the bug."""
+    from unify.workflow_manager.surfaces import PENDING_SCOPING, SOURCE_SCOPED
+
+    assert not set(PENDING_SCOPING) & set(SOURCE_SCOPED)

--- a/unify/actor/code_act_actor.py
+++ b/unify/actor/code_act_actor.py
@@ -2878,15 +2878,26 @@ class CodeActActor(BaseCodeActActor):
             pass
 
     @staticmethod
-    def _sandbox_clarification_binding(
+    def _sandbox_call_binding(
         *,
         clarification_up_q: asyncio.Queue[str] | None,
         clarification_down_q: asyncio.Queue[str] | None,
+        interject_q: asyncio.Queue | None = None,
+        notification_q: asyncio.Queue | None = None,
     ):
-        """Bind per-call clarification queues onto the live sandbox for one tool call.
+        """Bind one tool call's channels onto the live sandbox.
 
-        Nested manager clarifications then write into the outer tool's
-        ``clar_up_queue`` (mailbox A) watched by the async tool loop.
+        Two channels, both per-call and both restored on exit:
+
+        * clarification queues, so nested manager clarifications write into the
+          outer tool's ``clar_up_queue`` (mailbox A) watched by the async tool
+          loop
+        * a :class:`SteeringChannel`, so checkpoints inside the running block
+          can observe interjections aimed at this call and suspend for a
+          decision
+
+        Yields the steering channel so the caller can report progress once
+        execution ends, however it ended.
         """
         from contextlib import contextmanager
 
@@ -2894,26 +2905,39 @@ class CodeActActor(BaseCodeActActor):
             bind_sandbox_clarification_queues,
             restore_sandbox_clarification_queues,
         )
+        from unify.actor.execution.steering import (
+            SteeringChannel,
+            bind_sandbox_steering_channel,
+            restore_sandbox_steering_channel,
+        )
 
         @contextmanager
         def _binding():
-            if clarification_up_q is None or clarification_down_q is None:
-                yield
-                return
             try:
                 sb = _CURRENT_SANDBOX.get()
             except Exception:
-                yield
+                yield None
                 return
-            token = bind_sandbox_clarification_queues(
-                sb.global_state,
-                clarification_up_q,
-                clarification_down_q,
+
+            clar_token = None
+            if clarification_up_q is not None and clarification_down_q is not None:
+                clar_token = bind_sandbox_clarification_queues(
+                    sb.global_state,
+                    clarification_up_q,
+                    clarification_down_q,
+                )
+
+            channel = SteeringChannel(
+                interject_q=interject_q,
+                notification_q=notification_q,
             )
+            steer_token = bind_sandbox_steering_channel(sb.global_state, channel)
             try:
-                yield
+                yield channel
             finally:
-                restore_sandbox_clarification_queues(sb.global_state, token)
+                restore_sandbox_steering_channel(sb.global_state, steer_token)
+                if clar_token is not None:
+                    restore_sandbox_clarification_queues(sb.global_state, clar_token)
 
         return _binding()
 
@@ -2941,6 +2965,7 @@ class CodeActActor(BaseCodeActActor):
             _notification_up_q: asyncio.Queue[dict] | None = None,
             _clarification_up_q: asyncio.Queue[str] | None = None,
             _clarification_down_q: asyncio.Queue[str] | None = None,
+            _interject_queue: asyncio.Queue | None = None,
             _parent_chat_context: list[dict] | None = None,
         ) -> Any:
             """
@@ -3021,6 +3046,29 @@ class CodeActActor(BaseCodeActActor):
             allowlist. Static API keys and provider SDKs that read credentials
             from the environment may still use ``os.environ`` after checking
             available secret names.
+
+            Steering while the block runs
+            -----------------------------
+            Python blocks are steerable in flight. Checkpoints sit between
+            top-level statements, at the top of every loop body, and before
+            every ``primitives.*`` call, so a correction arriving partway
+            through can reach the block instead of only being able to kill it.
+
+            When one arrives, the block suspends at its next checkpoint and
+            you are given a turn with a report of how far it got. Two ways
+            forward: ``stop_execute_code_<call_id>`` abandons the block so you
+            can write a corrected one, or interjecting again resumes it as
+            written. Prefer stopping when the correction changes what the
+            remaining work should do, and resuming when it does not.
+
+            Generated code may read ``steering.messages`` for the interjection
+            texts delivered so far, which lets a long loop adapt without being
+            abandoned. Blocks that ignore it behave exactly as written.
+
+            A checkpoint can only run when the block yields. A synchronous
+            call that blocks — ``time.sleep``, non-async HTTP, a tight compute
+            loop — holds execution until it returns, so prefer async calls in
+            work that may need correcting partway through.
 
             For in-process Python execution with rich output, the result is wrapped in an
             ExecutionResult object (a Pydantic model implementing FormattedToolResult).
@@ -3175,11 +3223,14 @@ class CodeActActor(BaseCodeActActor):
                     pass
 
                 _pcc_token = _PARENT_CHAT_CONTEXT.set(_parent_chat_context)
+                _steering = None
                 try:
-                    with self._sandbox_clarification_binding(
+                    with self._sandbox_call_binding(
                         clarification_up_q=_clarification_up_q,
                         clarification_down_q=_clarification_down_q,
-                    ):
+                        interject_q=_interject_queue,
+                        notification_q=notification_q,
+                    ) as _steering:
                         try:
                             out = await self._session_executor.execute(
                                 code=code,
@@ -3210,6 +3261,12 @@ class CodeActActor(BaseCodeActActor):
                             }
                 finally:
                     _PARENT_CHAT_CONTEXT.reset(_pcc_token)
+
+                # Only when something actually steered this block. An
+                # uninterrupted run reports nothing, so the common case costs
+                # no transcript weight.
+                if _steering is not None and _steering.messages:
+                    out["steering"] = _steering.progress()
 
                 # Enrich with session name.
                 if out.get("session_id") is not None:
@@ -3691,6 +3748,7 @@ class CodeActActor(BaseCodeActActor):
                 _notification_up_q: asyncio.Queue[dict] | None = None,
                 _clarification_up_q: asyncio.Queue[str] | None = None,
                 _clarification_down_q: asyncio.Queue[str] | None = None,
+                _interject_queue: asyncio.Queue | None = None,
                 _parent_chat_context: list[dict] | None = None,
             ) -> Any:
                 """
@@ -3749,6 +3807,18 @@ class CodeActActor(BaseCodeActActor):
                     sandbox (e.g. ``"primitives.contacts.ask"``).
                 call_kwargs : dict, optional
                     Keyword arguments to pass to the function.
+
+                Steering while the function runs
+                -------------------------------
+                Steerable in flight, like ``execute_code``. When the stored
+                implementation is synthesised into the sandbox, checkpoints
+                are placed inside the function's own body as well, so a long
+                loop within a stored function can be corrected partway through
+                rather than only before it starts or after it finishes.
+
+                A correction suspends the call at its next checkpoint and
+                gives you a turn: ``stop_execute_function_<call_id>`` abandons
+                it, interjecting again resumes it.
 
                 Returns
                 -------
@@ -3948,9 +4018,11 @@ class CodeActActor(BaseCodeActActor):
                     except Exception:
                         pass
 
-                    with self._sandbox_clarification_binding(
+                    with self._sandbox_call_binding(
                         clarification_up_q=_clarification_up_q,
                         clarification_down_q=_clarification_down_q,
+                        interject_q=_interject_queue,
+                        notification_q=notification_q,
                     ):
                         if (
                             isinstance(function_data, dict)

--- a/unify/actor/code_act_actor.py
+++ b/unify/actor/code_act_actor.py
@@ -3262,10 +3262,16 @@ class CodeActActor(BaseCodeActActor):
                 finally:
                     _PARENT_CHAT_CONTEXT.reset(_pcc_token)
 
-                # Only when something actually steered this block. An
-                # uninterrupted run reports nothing, so the common case costs
-                # no transcript weight.
-                if _steering is not None and _steering.messages:
+                # Only when something actually steered this block, or when it
+                # failed — an uninterrupted success reports nothing, so the
+                # common case costs no transcript weight.
+                #
+                # On failure the report earns its place: instrumentation shifts
+                # the line numbers in a "<string>" traceback, which carries no
+                # source text to cross-reference, whereas the checkpoint's
+                # ``last_line_reached`` is in the coordinates of the code as
+                # written.
+                if _steering is not None and (_steering.messages or out.get("error")):
                     out["steering"] = _steering.progress()
 
                 # Enrich with session name.
@@ -4018,12 +4024,13 @@ class CodeActActor(BaseCodeActActor):
                     except Exception:
                         pass
 
+                    _ef_steering = None
                     with self._sandbox_call_binding(
                         clarification_up_q=_clarification_up_q,
                         clarification_down_q=_clarification_down_q,
                         interject_q=_interject_queue,
                         notification_q=notification_q,
-                    ):
+                    ) as _ef_steering:
                         if (
                             isinstance(function_data, dict)
                             and function_data.get("is_primitive")
@@ -4250,6 +4257,16 @@ class CodeActActor(BaseCodeActActor):
                                 f"returning bare handle (no side output)",
                             )
                             return _ef_result_val
+
+                    # Same contract as execute_code: report only when something
+                    # actually steered this call. The bare-handle return above
+                    # is exempt — that value is a handle the loop adopts, and
+                    # steering continues through it rather than ending here.
+                    if _ef_steering is not None and _ef_steering.messages:
+                        if isinstance(out, dict):
+                            out["steering"] = _ef_steering.progress()
+                        else:
+                            out.steering = _ef_steering.progress()
 
                     _ef_log.debug(
                         f"⏱️ [execute_function +{_ef_ms()}] returning result",

--- a/unify/actor/execution/session.py
+++ b/unify/actor/execution/session.py
@@ -32,6 +32,11 @@ from unify.function_manager.primitives import ComputerPrimitives
 from unify.common.hierarchical_logger import DEFAULT_ICON
 
 from .capture import _stdout_parts, capture_sandbox_output
+from .steering import (
+    SteeringDispatchProxy,
+    current_channel,
+    instrument_for_steering,
+)
 from .types import TextPart
 
 if TYPE_CHECKING:
@@ -656,6 +661,17 @@ class PythonExecutionSession:
                     ast.fix_missing_locations(tree)
                     code = ast.unparse(tree)
 
+                # Steering checkpoints, only when a tool call attached a
+                # channel. Without one the block is unsteerable anyway, so it
+                # runs exactly as it did before and pays nothing.
+                steering_channel = current_channel(self.global_state)
+                if steering_channel is not None:
+                    # Bind and re-parse against the same text so a reported
+                    # line number indexes the source the model is shown.
+                    steering_channel.bind_source(code)
+                    tree = instrument_for_steering(ast.parse(code))
+                    code = ast.unparse(tree)
+
                 async_code = "async def __exec_wrapper():\n"
                 if top_level_assign_targets:
                     async_code += f"    global {', '.join(sorted(list(top_level_assign_targets)))}\n"
@@ -716,15 +732,27 @@ class PythonExecutionSession:
                 # chat context is available, so inner tool loops receive it.
                 _pcc = _PARENT_CHAT_CONTEXT.get()
                 _orig_prims = self.global_state.get("primitives")
-                if _pcc is not None and _orig_prims is not None:
+                _wrapped_prims = _orig_prims
+                if _pcc is not None and _wrapped_prims is not None:
                     from unify.function_manager.primitives.context_proxy import (
                         ContextForwardingProxy,
                     )
 
-                    self.global_state["primitives"] = ContextForwardingProxy(
-                        _orig_prims,
+                    _wrapped_prims = ContextForwardingProxy(
+                        _wrapped_prims,
                         _parent_chat_context=_pcc,
                     )
+                # Outermost, so a checkpoint runs before context forwarding and
+                # before the primitive itself. Reaches dispatches the statement
+                # and loop-body checkpoints cannot see, such as a primitive
+                # called inside a comprehension or gathered concurrently.
+                if steering_channel is not None and _wrapped_prims is not None:
+                    _wrapped_prims = SteeringDispatchProxy(
+                        _wrapped_prims,
+                        steering_channel,
+                    )
+                if _wrapped_prims is not _orig_prims:
+                    self.global_state["primitives"] = _wrapped_prims
 
                 spawned_handles: list[Any] = []
                 spawned_token = _SANDBOX_SPAWNED_HANDLES.set(spawned_handles)

--- a/unify/actor/execution/steering.py
+++ b/unify/actor/execution/steering.py
@@ -1,0 +1,430 @@
+"""Steering for code while it is still running.
+
+A code block dispatched through ``execute_code`` or ``execute_function`` used
+to be opaque once scheduled: the async tool loop raced interjections against
+pending tool tasks and gave the model a turn, but the only lever that turn
+offered over a running block was ``stop_*``, which cancels it outright. A
+correction arriving four sends into a five-send loop could not reach the loop
+— it could only kill it, losing the send that was already correct along with
+the one that was not.
+
+This module supplies the missing half: a channel into the running program, and
+checkpoints where the program looks at it.
+
+Checkpoints
+-----------
+The AST transformer in :func:`instrument_for_steering` inserts a checkpoint
+between top-level statements and at the top of every loop body, at any nesting
+depth. Loop bodies matter more than top-level statements — repeated work is
+where a correction has something left to change, and a block that sends to a
+list of vendors spends its whole life inside one statement.
+
+Reaching a checkpoint with an empty channel costs a queue peek and an
+immediate return. The instrumentation itself costs ~25 microseconds per
+instrumented statement, which a block pays once per execution against LLM
+latency measured in seconds.
+
+What a checkpoint does not do
+-----------------------------
+It never classifies the interjection. Deciding whether "actually, stop" means
+abandon-the-block is the model's judgement, made on a real turn with the
+transcript in front of it, not a string comparison run inside the sandbox. So
+a checkpoint that finds a message suspends and hands the decision up:
+
+* resuming is any message arriving on the same channel — the block continues
+  and the text is readable from ``steering.messages``
+* abandoning is ``stop_<tool>_<call_id>``, an existing tool that cancels the
+  task and unwinds the block through ordinary cancellation
+
+Neither path parses intent, and the two are different tools rather than two
+readings of one string.
+
+The blocking-call boundary
+--------------------------
+A checkpoint can only run when the sandbox coroutine yields. Measured against
+the real sandbox: ``await``-bearing code yields reliably, while
+``time.sleep``, synchronous HTTP, and tight CPU loops hold the event loop for
+their full duration. During such a call the interjection cannot even arrive —
+the tool loop that would receive it runs on the same event loop — so this is a
+property of the runtime rather than a limit these checkpoints introduce.
+Instrumentation is placed to bracket those calls, which is the most that can
+be observed without moving execution off the loop thread.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+from typing import Any, Dict, List, Optional
+
+#: Names the instrumented program calls. Chosen to be unlikely to collide with
+#: anything a model writes, and stripped from tracebacks shown to the model.
+CHECKPOINT_FN = "__steering_checkpoint__"
+CHECKPOINT_SYNC_FN = "__steering_checkpoint_sync__"
+CHANNEL_GLOBAL = "__steering_channel__"
+
+#: How long a suspended checkpoint waits for the model to decide before giving
+#: up and resuming. A suspend that never returns would strand the block and,
+#: with it, the loop; the model reliably takes a turn because the notification
+#: sets ``llm_turn_required``, but a turn that answers in prose rather than
+#: calling a tool would otherwise hang here forever.
+DEFAULT_SUSPEND_TIMEOUT_S = 180.0
+
+
+class SteeringChannel:
+    """The sandbox side of one tool call's interjection queue.
+
+    Instances live in sandbox globals under :data:`CHANNEL_GLOBAL` for the
+    duration of a single ``execute_code`` / ``execute_function`` call, and are
+    reachable from generated code as ``steering``.
+    """
+
+    def __init__(
+        self,
+        *,
+        interject_q: Optional[asyncio.Queue],
+        notification_q: Optional[asyncio.Queue] = None,
+        suspend_timeout: float = DEFAULT_SUSPEND_TIMEOUT_S,
+    ) -> None:
+        self._interject_q = interject_q
+        self._notification_q = notification_q
+        self._suspend_timeout = suspend_timeout
+        self._messages: List[str] = []
+        self._line: Optional[int] = None
+        self._checkpoints = 0
+        self._suspensions = 0
+        self._source_lines: List[str] = []
+
+    # ── what generated code may read ──────────────────────────────────────
+    @property
+    def messages(self) -> List[str]:
+        """Interjections delivered so far, oldest first.
+
+        Code that wants to adapt rather than be re-planned can read this; code
+        that ignores it behaves exactly as it did before instrumentation.
+        """
+        return list(self._messages)
+
+    @property
+    def active(self) -> bool:
+        """Whether a steering channel is attached to this execution."""
+        return self._interject_q is not None
+
+    # ── what the tool reads back after execution ──────────────────────────
+    def progress(self) -> Dict[str, Any]:
+        """How far the block got, for the model's next turn.
+
+        Reported whether the block finished, was interrupted, or was
+        cancelled, so a turn taken mid-block is never guessing about what has
+        already happened.
+        """
+        report: Dict[str, Any] = {
+            "checkpoints_passed": self._checkpoints,
+            "suspensions": self._suspensions,
+        }
+        if self._line is not None:
+            report["last_line_reached"] = self._line
+            source = self._source_at(self._line)
+            if source:
+                report["last_statement"] = source
+        if self._messages:
+            report["interjections_received"] = list(self._messages)
+        return report
+
+    def bind_source(self, code: str) -> None:
+        """Record the block's source so progress can quote the line reached."""
+        self._source_lines = code.splitlines()
+
+    def _source_at(self, line: int) -> str:
+        if not 1 <= line <= len(self._source_lines):
+            return ""
+        # REPL semantics rewrite a trailing expression into a ``return`` before
+        # this source is bound. Quoting it back with the ``return`` would show
+        # the model a line it did not write.
+        return self._source_lines[line - 1].strip().removeprefix("return ")
+
+    # ── the checkpoint itself ─────────────────────────────────────────────
+    def _drain(self) -> List[str]:
+        """Take everything waiting. Synchronous and non-blocking by design.
+
+        A checkpoint must be cheap enough to sit inside a loop body, so the
+        empty case costs one ``QueueEmpty`` and no trip through the scheduler.
+        """
+        if self._interject_q is None:
+            return []
+        found: List[str] = []
+        while True:
+            try:
+                item = self._interject_q.get_nowait()
+            except asyncio.QueueEmpty:
+                return found
+            found.append(_as_text(item))
+
+    async def checkpoint(self, line: Optional[int] = None) -> None:
+        """Look at the channel, and suspend if anything is waiting."""
+        self._checkpoints += 1
+        if line is not None:
+            self._line = line
+        incoming = self._drain()
+        if not incoming:
+            return
+        self._messages.extend(incoming)
+        await self._suspend(incoming)
+
+    def checkpoint_sync(self, line: Optional[int] = None) -> None:
+        """Checkpoint for a synchronous scope, which cannot suspend.
+
+        A ``def`` body inside the block has no way to await, so this records
+        the interjection and lets execution continue to the next point that
+        can suspend. The message is still visible to the model in
+        :meth:`progress`, so the turn taken after the block is not blind to it.
+        """
+        self._checkpoints += 1
+        if line is not None:
+            self._line = line
+        self._messages.extend(self._drain())
+
+    async def _suspend(self, incoming: List[str]) -> None:
+        """Hold the block and give the model a turn to decide about it.
+
+        The notification sets ``llm_turn_required`` in the async tool loop, so
+        the model speaks next with the interjection and the progress report in
+        front of it. Resuming is any further message on the channel; abandoning
+        is ``stop_*``, whose cancellation unwinds straight through this await.
+        """
+        self._suspensions += 1
+        if self._notification_q is not None:
+            payload = {
+                "type": "steering_checkpoint",
+                "message": (
+                    "Execution is suspended at a checkpoint after an "
+                    "interjection arrived. Decide whether the running code "
+                    "should continue as written or be abandoned and replaced."
+                ),
+                "interjections": list(incoming),
+                "progress": self.progress(),
+            }
+            try:
+                self._notification_q.put_nowait(payload)
+            except asyncio.QueueFull:
+                pass
+
+        if self._interject_q is None:
+            return
+        try:
+            decision = await asyncio.wait_for(
+                self._interject_q.get(),
+                timeout=self._suspend_timeout,
+            )
+        except asyncio.TimeoutError:
+            self._messages.append(
+                "[no steering decision arrived; execution resumed as written]",
+            )
+            return
+        self._messages.append(_as_text(decision))
+
+
+def _as_text(item: Any) -> str:
+    """Interjections arrive as bare strings from the loop, dicts from nesting."""
+    if isinstance(item, dict):
+        for key in ("content", "message", "text"):
+            value = item.get(key)
+            if value:
+                return str(value)
+        return str(item)
+    return str(item)
+
+
+# ---------------------------------------------------------------------------
+# AST instrumentation
+# ---------------------------------------------------------------------------
+class _CheckpointInserter(ast.NodeTransformer):
+    """Insert checkpoints between statements and at the top of loop bodies.
+
+    Tracks whether the scope being rewritten can await, because a ``def`` body
+    cannot and needs the synchronous variant.
+    """
+
+    def __init__(self) -> None:
+        self._async_scope = True
+
+    # A nested ``def`` cannot await; an ``async def`` can. Class bodies run at
+    # definition time and are left alone.
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> ast.AST:  # noqa: N802
+        previous, self._async_scope = self._async_scope, False
+        try:
+            self.generic_visit(node)
+        finally:
+            self._async_scope = previous
+        return node
+
+    def visit_AsyncFunctionDef(  # noqa: N802
+        self,
+        node: ast.AsyncFunctionDef,
+    ) -> ast.AST:
+        previous, self._async_scope = self._async_scope, True
+        try:
+            self.generic_visit(node)
+        finally:
+            self._async_scope = previous
+        return node
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> ast.AST:  # noqa: N802
+        return node
+
+    def visit_For(self, node: ast.For) -> ast.AST:  # noqa: N802
+        self.generic_visit(node)
+        node.body = self._prefixed(node.body)
+        return node
+
+    def visit_AsyncFor(self, node: ast.AsyncFor) -> ast.AST:  # noqa: N802
+        self.generic_visit(node)
+        node.body = self._prefixed(node.body)
+        return node
+
+    def visit_While(self, node: ast.While) -> ast.AST:  # noqa: N802
+        self.generic_visit(node)
+        node.body = self._prefixed(node.body)
+        return node
+
+    def _prefixed(self, body: List[ast.stmt]) -> List[ast.stmt]:
+        """Put a checkpoint at the top of a loop body.
+
+        Placed before the body rather than after it so a correction lands
+        before the next iteration's side effect, not after it.
+        """
+        if not body:
+            return body
+        return [_checkpoint_stmt(body[0].lineno, self._async_scope), *body]
+
+
+def _checkpoint_stmt(line: int, is_async: bool) -> ast.stmt:
+    call = ast.Call(
+        func=ast.Name(
+            id=CHECKPOINT_FN if is_async else CHECKPOINT_SYNC_FN,
+            ctx=ast.Load(),
+        ),
+        args=[ast.Constant(value=line)],
+        keywords=[],
+    )
+    value: ast.expr = ast.Await(value=call) if is_async else call
+    return ast.Expr(value=value)
+
+
+def instrument_for_steering(tree: ast.Module) -> ast.Module:
+    """Rewrite *tree* so it reports progress and observes the channel.
+
+    Checkpoints go between top-level statements and at the top of every loop
+    body. The module's final expression is deliberately left as the last
+    statement: the sandbox turns it into the block's return value, and a
+    checkpoint appended after it would not run anyway.
+    """
+    tree = _CheckpointInserter().visit(tree)
+
+    instrumented: List[ast.stmt] = []
+    for statement in tree.body:
+        instrumented.append(_checkpoint_stmt(statement.lineno, True))
+        instrumented.append(statement)
+    tree.body = instrumented
+    ast.fix_missing_locations(tree)
+    return tree
+
+
+# ---------------------------------------------------------------------------
+# Binding into sandbox globals
+# ---------------------------------------------------------------------------
+_STEERING_MISSING = object()
+
+
+def bind_sandbox_steering_channel(
+    global_state: Dict[str, Any],
+    channel: SteeringChannel,
+) -> Dict[str, Any]:
+    """Expose *channel* and its checkpoints to a sandbox for one tool call.
+
+    Mirrors the clarification binding: values are installed on the live
+    globals and the previous values returned as a token, so nested calls
+    restore rather than clobber.
+    """
+    previous = {
+        key: global_state.get(key, _STEERING_MISSING)
+        for key in (CHANNEL_GLOBAL, CHECKPOINT_FN, CHECKPOINT_SYNC_FN, "steering")
+    }
+    global_state[CHANNEL_GLOBAL] = channel
+    global_state[CHECKPOINT_FN] = channel.checkpoint
+    global_state[CHECKPOINT_SYNC_FN] = channel.checkpoint_sync
+    global_state["steering"] = channel
+    return previous
+
+
+def restore_sandbox_steering_channel(
+    global_state: Dict[str, Any],
+    token: Dict[str, Any],
+) -> None:
+    """Undo :func:`bind_sandbox_steering_channel`."""
+    for key, value in token.items():
+        if value is _STEERING_MISSING:
+            global_state.pop(key, None)
+        else:
+            global_state[key] = value
+
+
+def current_channel(global_state: Dict[str, Any]) -> Optional[SteeringChannel]:
+    """The channel bound to *global_state*, if a tool call installed one."""
+    channel = global_state.get(CHANNEL_GLOBAL)
+    return channel if isinstance(channel, SteeringChannel) else None
+
+
+# ---------------------------------------------------------------------------
+# Dispatch-boundary checkpoints
+# ---------------------------------------------------------------------------
+class _SteeringManagerProxy:
+    """Checkpoints one manager's methods on the way in."""
+
+    __slots__ = ("_manager", "_channel")
+
+    def __init__(self, manager: Any, channel: SteeringChannel) -> None:
+        self._manager = manager
+        self._channel = channel
+
+    def __getattr__(self, name: str) -> Any:
+        attr = getattr(self._manager, name)
+        if not callable(attr):
+            return attr
+
+        if asyncio.iscoroutinefunction(attr):
+
+            async def _checked(*args: Any, **kwargs: Any) -> Any:
+                await self._channel.checkpoint()
+                return await attr(*args, **kwargs)
+
+        else:
+
+            def _checked(*args: Any, **kwargs: Any) -> Any:  # type: ignore[misc]
+                self._channel.checkpoint_sync()
+                return attr(*args, **kwargs)
+
+        return _checked
+
+
+class SteeringDispatchProxy:
+    """Checkpoint every primitive call, wherever it sits in the source.
+
+    Statement and loop-body checkpoints cannot reach inside a single
+    expression, so ``[await send(v) for v in vendors]`` and
+    ``asyncio.gather(*calls)`` dispatch a whole batch between two checkpoints.
+    Checking at the dispatch boundary covers those, because the checkpoint
+    runs inside each call rather than around the statement containing them.
+
+    Stored functions invoked as bare callables are not covered by this proxy;
+    they are reached through statement and loop-body checkpoints only.
+    """
+
+    __slots__ = ("_target", "_channel")
+
+    def __init__(self, target: Any, channel: SteeringChannel) -> None:
+        self._target = target
+        self._channel = channel
+
+    def __getattr__(self, name: str) -> Any:
+        return _SteeringManagerProxy(getattr(self._target, name), self._channel)

--- a/unify/actor/execution/steering.py
+++ b/unify/actor/execution/steering.py
@@ -55,6 +55,9 @@ from __future__ import annotations
 
 import ast
 import asyncio
+import functools
+import inspect
+from contextlib import suppress
 from typing import Any, Dict, List, Optional
 
 #: Names the instrumented program calls. Chosen to be unlikely to collide with
@@ -69,6 +72,15 @@ CHANNEL_GLOBAL = "__steering_channel__"
 #: sets ``llm_turn_required``, but a turn that answers in prose rather than
 #: calling a tool would otherwise hang here forever.
 DEFAULT_SUSPEND_TIMEOUT_S = 180.0
+
+#: Ceiling on the completed-call list in a progress report. A block looping
+#: over thousands of rows would otherwise put its whole history in the
+#: transcript; the first calls are the ones a replacement needs to skip.
+_MAX_RECORDED_CALLS = 50
+
+#: Ceiling on one rendered argument, so a call carrying a document body does
+#: not dominate the report it appears in.
+_MAX_ARG_CHARS = 60
 
 
 class SteeringChannel:
@@ -94,6 +106,8 @@ class SteeringChannel:
         self._checkpoints = 0
         self._suspensions = 0
         self._source_lines: List[str] = []
+        self._completed: List[str] = []
+        self._completed_count = 0
 
     # ── what generated code may read ──────────────────────────────────────
     @property
@@ -109,6 +123,23 @@ class SteeringChannel:
     def active(self) -> bool:
         """Whether a steering channel is attached to this execution."""
         return self._interject_q is not None
+
+    def record_completed(self, call: str) -> None:
+        """Note a dispatch that finished, so a replacement block can skip it.
+
+        A block abandoned partway through has already done part of its work,
+        and that work cannot be undone by rewriting the code. Naming the calls
+        that completed — with their arguments — is what lets the model write a
+        replacement that resumes rather than repeats.
+
+        This is deliberately a report rather than a replay cache. Memoising a
+        side effect records that it happened, not that it is cheap to redo, so
+        having the model decide what to skip keeps a correction that meant
+        "undo that" from being satisfied by a cache hit.
+        """
+        self._completed_count += 1
+        if len(self._completed) < _MAX_RECORDED_CALLS:
+            self._completed.append(call)
 
     # ── what the tool reads back after execution ──────────────────────────
     def progress(self) -> Dict[str, Any]:
@@ -129,6 +160,12 @@ class SteeringChannel:
                 report["last_statement"] = source
         if self._messages:
             report["interjections_received"] = list(self._messages)
+        if self._completed:
+            report["already_done"] = list(self._completed)
+            # Silent truncation would read as "only these happened", which is
+            # the opposite of what the list is for. Say the real total.
+            if self._completed_count > len(self._completed):
+                report["already_done_total"] = self._completed_count
         return report
 
     def bind_source(self, code: str) -> None:
@@ -378,32 +415,113 @@ def current_channel(global_state: Dict[str, Any]) -> Optional[SteeringChannel]:
 # ---------------------------------------------------------------------------
 # Dispatch-boundary checkpoints
 # ---------------------------------------------------------------------------
+def _is_async_callable(fn: Any) -> bool:
+    """Whether *fn* ultimately dispatches a coroutine.
+
+    ``ContextForwardingProxy`` hands back a synchronous ``functools.wraps``
+    wrapper that returns the coroutine produced by an async method, and
+    ``iscoroutinefunction`` reports False for it because it inspects the
+    wrapper's own code flags rather than following ``__wrapped__``. Taking
+    that at face value would put every primitive on the synchronous path in
+    production, where parent chat context is normally present — checkpoints
+    that cannot suspend, and a completion recorded before the call had run.
+    """
+    seen: set[int] = set()
+    while fn is not None and id(fn) not in seen:
+        if asyncio.iscoroutinefunction(fn):
+            return True
+        seen.add(id(fn))
+        fn = getattr(fn, "__wrapped__", None)
+    return False
+
+
+def _render_call(path: str, args: tuple, kwargs: Dict[str, Any]) -> str:
+    """A one-line rendering of a dispatch, short enough for a report."""
+
+    def _short(value: Any) -> str:
+        text = repr(value)
+        if len(text) > _MAX_ARG_CHARS:
+            return text[: _MAX_ARG_CHARS - 1] + "…"
+        return text
+
+    rendered = [_short(a) for a in args]
+    rendered += [f"{k}={_short(v)}" for k, v in kwargs.items()]
+    return f"{path}({', '.join(rendered)})"
+
+
+#: Attribute values handed back untouched rather than treated as a namespace
+#: worth descending into. Everything else that is not callable is assumed to
+#: be a sub-namespace, because primitive families nest: the real side effects
+#: include ``primitives.integrations.slack.send_message`` and
+#: ``primitives.computer.web.new_session``, which stopping at one level would
+#: leave uncheckpointed.
+_PASSTHROUGH_TYPES = (
+    str,
+    bytes,
+    bytearray,
+    int,
+    float,
+    bool,
+    complex,
+    type(None),
+    list,
+    tuple,
+    dict,
+    set,
+    frozenset,
+)
+
+
 class _SteeringManagerProxy:
-    """Checkpoints one manager's methods on the way in."""
+    """Checkpoints one manager's methods on the way in, and records the way out.
 
-    __slots__ = ("_manager", "_channel")
+    Descends through nested namespaces so a call several levels down is
+    covered by the same checkpoint as a top-level one.
+    """
 
-    def __init__(self, manager: Any, channel: SteeringChannel) -> None:
+    __slots__ = ("_manager", "_channel", "_namespace")
+
+    def __init__(self, manager: Any, channel: SteeringChannel, namespace: str) -> None:
         self._manager = manager
         self._channel = channel
+        self._namespace = namespace
 
     def __getattr__(self, name: str) -> Any:
         attr = getattr(self._manager, name)
         if not callable(attr):
-            return attr
+            if isinstance(attr, _PASSTHROUGH_TYPES):
+                return attr
+            return _SteeringManagerProxy(
+                attr,
+                self._channel,
+                f"{self._namespace}.{name}",
+            )
 
-        if asyncio.iscoroutinefunction(attr):
+        path = f"primitives.{self._namespace}.{name}"
+
+        if _is_async_callable(attr):
 
             async def _checked(*args: Any, **kwargs: Any) -> Any:
                 await self._channel.checkpoint()
-                return await attr(*args, **kwargs)
+                result = attr(*args, **kwargs)
+                if inspect.isawaitable(result):
+                    result = await result
+                self._channel.record_completed(_render_call(path, args, kwargs))
+                return result
 
         else:
 
             def _checked(*args: Any, **kwargs: Any) -> Any:  # type: ignore[misc]
                 self._channel.checkpoint_sync()
-                return attr(*args, **kwargs)
+                result = attr(*args, **kwargs)
+                self._channel.record_completed(_render_call(path, args, kwargs))
+                return result
 
+        # Keep the wrapped signature visible: anything introspecting this
+        # proxy — including the context-forwarding layer, if the wrapping
+        # order ever changes — decides what to inject from the parameters.
+        with suppress(AttributeError, TypeError, ValueError):
+            functools.wraps(attr)(_checked)
         return _checked
 
 
@@ -418,13 +536,27 @@ class SteeringDispatchProxy:
 
     Stored functions invoked as bare callables are not covered by this proxy;
     they are reached through statement and loop-body checkpoints only.
+
+    Completed calls are recorded on the way back out, so a block abandoned
+    partway through can tell the model exactly which side effects already
+    landed and with what arguments.
     """
 
     __slots__ = ("_target", "_channel")
 
     def __init__(self, target: Any, channel: SteeringChannel) -> None:
+        # Never stack on another steering layer. A block that calls something
+        # which runs its own block reaches this with the outer proxy already
+        # installed on the shared sandbox globals, and nesting would checkpoint
+        # and record each dispatch once per layer.
+        while isinstance(target, SteeringDispatchProxy):
+            target = target._target
         self._target = target
         self._channel = channel
 
     def __getattr__(self, name: str) -> Any:
-        return _SteeringManagerProxy(getattr(self._target, name), self._channel)
+        return _SteeringManagerProxy(
+            getattr(self._target, name),
+            self._channel,
+            name,
+        )

--- a/unify/actor/execution/types.py
+++ b/unify/actor/execution/types.py
@@ -168,6 +168,10 @@ class ExecutionResult(BaseModel):
     venv_id: Optional[int] = None
     session_created: Optional[bool] = None
     duration_ms: Optional[int] = None
+    #: Where the block got to when something steered it mid-flight. Set only
+    #: when an interjection actually reached this execution, so an ordinary
+    #: run carries no extra weight in the transcript.
+    steering: Optional[Dict[str, Any]] = None
 
     model_config = {"arbitrary_types_allowed": True}
 
@@ -199,6 +203,8 @@ class ExecutionResult(BaseModel):
             meta["session_created"] = self.session_created
         if self.duration_ms is not None:
             meta["duration_ms"] = self.duration_ms
+        if self.steering is not None:
+            meta["steering"] = self.steering
 
         # Add metadata block if present
         if meta:

--- a/unify/actor/prompt_builders.py
+++ b/unify/actor/prompt_builders.py
@@ -236,6 +236,32 @@ _EXECUTION_RULES = textwrap.dedent("""
     `KnowledgeManager_add_knowledge`, …) directly, not
     `execute_function` / `execute_code`.
 
+    ### Responding to a steering checkpoint
+
+    A running block suspends when a correction reaches it, and you get a
+    turn carrying the interjection and a report of how far it got —
+    which line it reached and how many checkpoints it passed. Read that
+    report before deciding: work already done has already happened, and
+    a replacement block must not repeat it.
+
+    Two ways forward, and the choice is yours to make each time:
+
+    - `stop_<tool>_<call_id>` — abandon the block, then write a
+      replacement that starts from where the report says it stopped.
+      Choose this when the correction changes what the *remaining* work
+      should do: a different recipient, a narrower set, a step that
+      should no longer happen.
+    - `interject_<tool>_<call_id>` — resume the block as written, with
+      the text available to it via `steering.messages`. Choose this when
+      the correction does not change the remaining work: an
+      acknowledgement, context for later, or a note about something
+      already handled.
+
+    Do not let a block finish just because stopping feels disruptive. An
+    irreversible step that the correction was meant to prevent is worse
+    than a discarded plan. Equally, do not stop on every interjection —
+    a block torn down and rebuilt repeats work and loses its own state.
+
     ### Execution Surface: where code runs
 
     `execute_code` runs on the **local** host by default. To run a shell

--- a/unify/actor/prompt_examples.py
+++ b/unify/actor/prompt_examples.py
@@ -161,7 +161,7 @@ async def classify_with_small_model(email_text: str):
     return await query_llm(
         email_text,
         system="Return a compact category and confidence for email triage.",
-        model="openai/gpt-4.1-nano@openrouter",
+        model="openai/gpt-5.4-mini@openrouter",
         temperature=0.0,
     )
 
@@ -195,7 +195,7 @@ async def draft_replies_for_messages(messages: list[dict]) -> list[dict]:
             f"From: {message.get('from')}\n\n"
             f"{message.get('body')}",
             response_format=DraftDecision,
-            model="openai/gpt-4.1-nano@openrouter",
+            model="openai/gpt-5.4-mini@openrouter",
             temperature=0.0,
         )
         drafts.append({

--- a/unify/common/reasoning.py
+++ b/unify/common/reasoning.py
@@ -63,8 +63,8 @@ def list_llms(provider: str | None = None) -> list[str]:
     """Return supported UniLLM endpoint strings available in this runtime.
 
     Endpoint strings use ``model@provider`` form, such as
-    ``"openai/gpt-4.1-nano@openrouter"``. Pass ``provider`` to filter to one provider,
-    e.g. ``list_llms("openai")``.
+    ``"openai/gpt-5.4-mini@openrouter"``. Pass ``provider`` to filter to one
+    provider, e.g. ``list_llms("openrouter")``.
 
     Use this helper when choosing a concrete ``model=`` value for
     ``query_llm(...)``. Do not hardcode assumptions about which endpoints are
@@ -98,7 +98,14 @@ def get_llm_model_selection_context() -> str:
         ### Choosing A Model For `query_llm(...)`
 
         Pass model overrides as UniLLM endpoint strings, e.g.
-        `model="openai/gpt-4.1-nano@openrouter"`.
+        `model="openai/gpt-5.4-mini@openrouter"`.
+
+        Reach OpenAI models through `@openrouter`, never through `@openai`.
+        The two suffixes are different providers: `@openai` is a native OpenAI
+        endpoint, and that account is inactive, so those calls burn a minute of
+        retries against a billing error before failing. `list_llms()` reports
+        every endpoint the runtime knows about, including native `@openai`
+        ones — being listed is not the same as being routable.
 
         For durable or recurring stored functions, choose `model=` deliberately.
         Do not silently inherit the default high-reasoning model for bounded,
@@ -118,8 +125,8 @@ def get_llm_model_selection_context() -> str:
         model shopping inside the hot path of a recurring task.
 
         Use `list_llms()` to inspect the supported endpoint strings registered
-        in the current runtime. Use `list_llms("openai")` or another provider
-        name when you only need endpoints for one provider.
+        in the current runtime. Use `list_llms("openrouter")` or another
+        provider name when you only need endpoints for one provider.
 
         Practical defaults:
         - Use cheap/fast models for bounded classification, routing, extraction,
@@ -245,7 +252,7 @@ async def query_llm(
             "in the user's voice. Return null for draft_reply when no reply is needed.\\n"
             f"Subject: {subject}\\nFrom: {sender}\\nBody: {body}",
             response_format=EmailDraftDecision,
-            model="openai/gpt-4.1-nano@openrouter",
+            model="openai/gpt-5.4-mini@openrouter",
         )
 
     Custom rubric with ``system`` for consistent bulk classification::

--- a/unify/conversation_manager/comms_manager.py
+++ b/unify/conversation_manager/comms_manager.py
@@ -1099,6 +1099,10 @@ class CommsManager:
                         event,
                         message=r,
                     ),
+                    "console_script_result": lambda r: ConsoleScriptResult(
+                        script_id=str(event.get("script_id") or ""),
+                        outcomes=list(event.get("outcomes") or []),
+                    ),
                     "assistant_presence_observed": lambda r: AssistantPresenceObserved(
                         reason=str(
                             event.get("reason") or r or "User presence observed.",

--- a/unify/conversation_manager/conversation_manager.py
+++ b/unify/conversation_manager/conversation_manager.py
@@ -430,6 +430,11 @@ class ConversationManager(metaclass=SingletonABCMeta):
         # meet interaction state (screen share / webcam / remote control)
         self.assistant_screen_share_active: bool = False
         self.user_screen_share_active: bool = False
+        # Someone in a browser meeting is sharing a screen with us. Kept apart
+        # from ``user_screen_share_active`` because that one also gates the
+        # desktop fast path and web-session listing, which should not switch on
+        # because a stranger in a Google Meet put up a slide.
+        self.meet_screen_share_active: bool = False
         self.user_webcam_active: bool = False
         self.user_remote_control_active: bool = False
         # Flag names above that a frontend has reported on. A frontend is
@@ -911,6 +916,23 @@ class ConversationManager(metaclass=SingletonABCMeta):
         peek) are preserved for the next turn.
         """
         del self._screenshot_buffer[:count]
+
+    def drop_unpaired_screenshots(self, source: str) -> int:
+        """Forget buffered frames from *source* that no utterance depends on.
+
+        Called when a visual source goes away. An unpaired frame is "what this
+        source shows now", so once the source is gone it shows nothing and holding
+        the last one lets the next turn describe a screen that has been taken
+        down. Frames paired with an utterance are kept: those are evidence for a
+        specific thing somebody said, and remain true after the screen goes.
+        """
+        before = len(self._screenshot_buffer)
+        self._screenshot_buffer = [
+            entry
+            for entry in self._screenshot_buffer
+            if entry.source != source or entry.utterance
+        ]
+        return before - len(self._screenshot_buffer)
 
     async def _register_screenshots_background(
         self,
@@ -2210,6 +2232,7 @@ class ConversationManager(metaclass=SingletonABCMeta):
                 user_remote_control_active=self.user_remote_control_active,
                 google_meet_active=self.call_manager.has_active_google_meet,
                 teams_meet_active=self.call_manager.has_active_teams_meet,
+                meet_screen_share_active=self.meet_screen_share_active,
                 active_web_sessions=web_sessions,
                 managers_initialized=self.initialized,
                 vm_ready=self.vm_ready,
@@ -3843,6 +3866,7 @@ class ConversationManager(metaclass=SingletonABCMeta):
                 user_remote_control_active=self.user_remote_control_active,
                 google_meet_active=self.call_manager.has_active_google_meet,
                 teams_meet_active=self.call_manager.has_active_teams_meet,
+                meet_screen_share_active=self.meet_screen_share_active,
                 vm_ready=self.vm_ready,
                 file_sync_complete=self.file_sync_complete,
                 has_desktop=SESSION_DETAILS.assistant.has_managed_desktop,

--- a/unify/conversation_manager/domains/brain_action_tools.py
+++ b/unify/conversation_manager/domains/brain_action_tools.py
@@ -1118,6 +1118,45 @@ class ConversationManagerBrainActionTools:
             ),
         }
 
+    async def start_meet_screenshare(self) -> dict[str, Any]:
+        """Share my desktop with everyone in the meeting, so they can watch me work.
+
+        Use this when showing is genuinely better than telling -- walking someone
+        through where a setting lives, or letting them watch a task run. What
+        participants see is my own machine, at a few frames a second: fine for
+        reading a screen, not for anything that depends on smooth motion.
+
+        Say what I am about to show before calling this. A screen appearing with
+        no explanation makes people hunt for what changed.
+        """
+        ok = await self._cm.call_manager.start_meet_screenshare()
+        if ok:
+            return {
+                "status": "ok",
+                "message": "Sharing my desktop with the meeting.",
+            }
+        return {
+            "status": "error",
+            "message": (
+                "Could not start sharing my desktop. Describe what I would have "
+                "shown instead of saying a screen is up."
+            ),
+        }
+
+    async def stop_meet_screenshare(self) -> dict[str, Any]:
+        """Stop sharing my desktop with the meeting.
+
+        Worth doing as soon as the thing I was showing is done: a stale screen
+        left up reads as inattention, and participants keep watching it.
+        """
+        ok = await self._cm.call_manager.stop_meet_screenshare()
+        if ok:
+            return {"status": "ok", "message": "Stopped sharing my desktop."}
+        return {
+            "status": "error",
+            "message": "Could not stop sharing -- my desktop may already be down.",
+        }
+
     async def _leave_google_meet(self) -> dict[str, Any]:
         """Disconnect the assistant from the active Google Meet session.
 
@@ -2528,6 +2567,15 @@ class ConversationManagerBrainActionTools:
             or self._cm.call_manager.has_active_teams_meet
         ):
             tools["send_meet_chat"] = self.send_meet_chat
+            # Only a managed desktop is ever shared. A user's own linked machine
+            # is not the assistant's to put in front of a room, so the tool is
+            # absent rather than failing when asked -- an assistant with no
+            # desktop should not be offering to show one.
+            if SESSION_DETAILS.assistant.has_managed_desktop:
+                if self._cm.call_manager.is_presenting_to_meet:
+                    tools["stop_meet_screenshare"] = self.stop_meet_screenshare
+                else:
+                    tools["start_meet_screenshare"] = self.start_meet_screenshare
         if self._cm.assistant_number:
             tools["send_sms"] = (
                 self.send_sms_to_boss if is_coordinator else self.send_sms

--- a/unify/conversation_manager/domains/browser_meeting.py
+++ b/unify/conversation_manager/domains/browser_meeting.py
@@ -90,13 +90,13 @@ class MeetProvider(Protocol):
     async def state(self, *, channel: str, session_id: str) -> MeetState | None:
         """Current meeting state, or None when the session is unknown."""
 
-    async def present(self, *, channel: str, session_id: str, room_name: str) -> bool:
+    async def present(self, *, channel: str, session_id: str) -> bool:
         """Start sharing the assistant's desktop with the meeting.
 
-        The backend decides how a desktop reaches the meeting; the caller only
-        supplies the room it is being published into. Returns False when the
-        backend could not start, so the assistant can say so rather than claim to
-        be sharing a screen nobody can see.
+        How a desktop reaches the meeting is entirely the backend's business, so
+        nothing about the transport appears here. Returns False when it could not
+        start, so the assistant can say so rather than claim to be sharing a screen
+        nobody can see.
         """
 
     async def stop_present(self, *, channel: str, session_id: str) -> bool:

--- a/unify/conversation_manager/domains/browser_meeting.py
+++ b/unify/conversation_manager/domains/browser_meeting.py
@@ -90,6 +90,22 @@ class MeetProvider(Protocol):
     async def state(self, *, channel: str, session_id: str) -> MeetState | None:
         """Current meeting state, or None when the session is unknown."""
 
+    async def present(self, *, channel: str, session_id: str, room_name: str) -> bool:
+        """Start sharing the assistant's desktop with the meeting.
+
+        The backend decides how a desktop reaches the meeting; the caller only
+        supplies the room it is being published into. Returns False when the
+        backend could not start, so the assistant can say so rather than claim to
+        be sharing a screen nobody can see.
+        """
+
+    async def stop_present(self, *, channel: str, session_id: str) -> bool:
+        """Stop sharing, leaving the rest of the session untouched.
+
+        Must not disturb whatever carries audio: losing the assistant's voice
+        mid-meeting is worse than a share that lingers a moment.
+        """
+
     async def send_chat(
         self,
         *,

--- a/unify/conversation_manager/domains/call_manager.py
+++ b/unify/conversation_manager/domains/call_manager.py
@@ -1313,10 +1313,9 @@ class LivekitCallManager:
     async def start_meet_screenshare(self) -> bool:
         """Share the assistant's desktop with the active browser meeting.
 
-        Two systems have to agree, in this order: the pod starts publishing its
-        desktop into the room, *then* the bot is pointed at the page that renders
-        it. Reversed, the bot loads a page with no track yet and the meeting is
-        shown a placeholder before the desktop appears.
+        The desktop is the managed VM's own liveview, framed by a page the bot
+        renders, so putting it up is a single call to the meeting backend -- there
+        is nothing on this side to start or keep running.
         """
         session_id = self._meet_session_id
         channel = self._call_channel or ""
@@ -1329,26 +1328,15 @@ class LivekitCallManager:
         if self._meet_presenting:
             return True
 
-        await self._set_desktop_share(True)
         ok = await self.meet_provider.present(
             channel=channel,
             session_id=session_id,
-            room_name=self.room_name,
         )
-        if not ok:
-            # Nothing is being shown, so nothing should be published either.
-            await self._set_desktop_share(False)
-            return False
-        self._meet_presenting = True
-        return True
+        self._meet_presenting = ok
+        return ok
 
     async def stop_meet_screenshare(self) -> bool:
-        """Stop sharing the desktop, leaving the meeting and its audio intact.
-
-        The reverse order of starting: drop the surface first, then stop
-        publishing. Unpublishing first would leave the meeting looking at a frozen
-        or black share for as long as the API call takes.
-        """
+        """Stop sharing the desktop, leaving the meeting and its audio intact."""
         session_id = self._meet_session_id
         channel = self._call_channel or ""
         if not session_id or not self._meet_presenting:
@@ -1358,22 +1346,11 @@ class LivekitCallManager:
             channel=channel,
             session_id=session_id,
         )
-        await self._set_desktop_share(False)
+        # Cleared either way: a failed stop leaves the surface up, but claiming to
+        # still be presenting would hide the ``start`` tool behind an idempotence
+        # guard and make the state unrecoverable for the rest of the meeting.
         self._meet_presenting = False
         return ok
-
-    async def _set_desktop_share(self, active: bool) -> None:
-        """Tell the voice worker to start or stop publishing the desktop.
-
-        The tool runs here, but only the worker process is in the LiveKit room,
-        so the decision crosses over IPC.
-        """
-        if self._socket_server is None:
-            return
-        await self._socket_server.queue_for_clients(
-            "app:call:desktop_share",
-            json.dumps({"active": bool(active)}),
-        )
 
     async def _watch_meet_state(self, channel: str) -> None:
         """Track the meeting backend's own view of the session.
@@ -1472,6 +1449,11 @@ class LivekitCallManager:
         self._meet_session_id = None
         self._meet_joining = False
         self._meet_lobby_waiting = False
+        # Per-meeting, like the flags above. This manager outlives individual
+        # meetings, so leaving it set would make the next one start believing it
+        # is already presenting: the start tool would be replaced by the stop
+        # tool, and starting would return success without putting anything up.
+        self._meet_presenting = False
         if channel == "google_meet":
             self.google_meet_start_timestamp = None
             self.google_meet_exchange_id = UNASSIGNED

--- a/unify/conversation_manager/domains/call_manager.py
+++ b/unify/conversation_manager/domains/call_manager.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
 from unify.conversation_manager.medium_scripts.common import (
     _resolve_agent_service_url,
 )
+from unify.session_details import SESSION_DETAILS
 
 
 def make_room_name(assistant_id: str, medium: str) -> str:
@@ -185,6 +186,11 @@ class LivekitCallManager:
         # ``_watch_meet_state``.
         self._meet_state_task: asyncio.Task | None = None
         self._meet_joining: bool = False
+        # Whether the assistant's desktop is currently on the bot's screenshare
+        # surface. Guards both directions: presenting twice would re-point a
+        # surface that is already correct, and stopping when nothing is shared
+        # would DELETE a surface the meeting never saw.
+        self._meet_presenting: bool = False
         # True while the browser is admitted-pending: it has knocked on the
         # meeting (clicked "Ask to join") and is sitting in the waiting room
         # for the host to let it in. This is a *successful* join in progress,
@@ -1297,6 +1303,76 @@ class LivekitCallManager:
             session_id=session_id,
             text=text,
             to=to,
+        )
+
+    @property
+    def is_presenting_to_meet(self) -> bool:
+        """Whether the assistant's desktop is on the meeting's screenshare now."""
+        return self._meet_presenting
+
+    async def start_meet_screenshare(self) -> bool:
+        """Share the assistant's desktop with the active browser meeting.
+
+        Two systems have to agree, in this order: the pod starts publishing its
+        desktop into the room, *then* the bot is pointed at the page that renders
+        it. Reversed, the bot loads a page with no track yet and the meeting is
+        shown a placeholder before the desktop appears.
+        """
+        session_id = self._meet_session_id
+        channel = self._call_channel or ""
+        if not session_id or channel not in self._MEET_ROOM_SUFFIX:
+            return False
+        if not SESSION_DETAILS.assistant.has_managed_desktop:
+            # Only the managed desktop is ever shared. A user's own linked machine
+            # is not the assistant's to put in front of a room of people.
+            return False
+        if self._meet_presenting:
+            return True
+
+        await self._set_desktop_share(True)
+        ok = await self.meet_provider.present(
+            channel=channel,
+            session_id=session_id,
+            room_name=self.room_name,
+        )
+        if not ok:
+            # Nothing is being shown, so nothing should be published either.
+            await self._set_desktop_share(False)
+            return False
+        self._meet_presenting = True
+        return True
+
+    async def stop_meet_screenshare(self) -> bool:
+        """Stop sharing the desktop, leaving the meeting and its audio intact.
+
+        The reverse order of starting: drop the surface first, then stop
+        publishing. Unpublishing first would leave the meeting looking at a frozen
+        or black share for as long as the API call takes.
+        """
+        session_id = self._meet_session_id
+        channel = self._call_channel or ""
+        if not session_id or not self._meet_presenting:
+            return False
+
+        ok = await self.meet_provider.stop_present(
+            channel=channel,
+            session_id=session_id,
+        )
+        await self._set_desktop_share(False)
+        self._meet_presenting = False
+        return ok
+
+    async def _set_desktop_share(self, active: bool) -> None:
+        """Tell the voice worker to start or stop publishing the desktop.
+
+        The tool runs here, but only the worker process is in the LiveKit room,
+        so the decision crosses over IPC.
+        """
+        if self._socket_server is None:
+            return
+        await self._socket_server.queue_for_clients(
+            "app:call:desktop_share",
+            json.dumps({"active": bool(active)}),
         )
 
     async def _watch_meet_state(self, channel: str) -> None:

--- a/unify/conversation_manager/domains/console_script_result.py
+++ b/unify/conversation_manager/domains/console_script_result.py
@@ -1,0 +1,78 @@
+"""Reading back what the console did with the moves that were asked for."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from unify.conversation_manager.conversation_manager import ConversationManager
+    from unify.conversation_manager.events import ConsoleScriptResult
+
+# Outcomes meaning the move did not land. Anything here is worth interrupting
+# for, because the assistant may have just described it as done.
+_FAILED = {
+    "unknown": "is not something I can open",
+    "not-found": "was not there",
+    "not-interactive": "was there but not clickable",
+}
+
+# Outcomes meaning it correctly did not happen. Worth knowing, not worth
+# correcting: the user cut in, or told me not to navigate.
+_DID_NOT_RUN = {
+    "skipped": "did not happen -- I was interrupted before reaching it",
+    "blocked": "did not happen -- my boss has turned off letting me navigate",
+}
+
+
+def summarize_console_script(event: "ConsoleScriptResult") -> tuple[str, bool]:
+    """A line for the notifications bar, and whether the brain should wake.
+
+    Successes are stated too. Knowing a move landed is what lets the assistant
+    refer to where the user now is without checking, and it costs one line.
+    """
+    landed: list[str] = []
+    problems: list[str] = []
+    quiet: list[str] = []
+
+    for entry in event.outcomes:
+        if not isinstance(entry, dict):
+            continue
+        target = str(entry.get("target") or "")
+        outcome = str(entry.get("outcome") or "")
+        if not target:
+            continue
+        if outcome in ("done", "clicked"):
+            landed.append(target)
+        elif outcome in _FAILED:
+            problems.append(f"{target} {_FAILED[outcome]}")
+        elif outcome in _DID_NOT_RUN:
+            quiet.append(f"{target} {_DID_NOT_RUN[outcome]}")
+
+    parts: list[str] = []
+    if landed:
+        parts.append(f"Opened for my boss: {', '.join(landed)}.")
+    if problems:
+        parts.append(
+            "Did not work: " + "; ".join(problems) + ". I should not say otherwise.",
+        )
+    if quiet:
+        parts.append(" ".join(quiet) + ".")
+
+    return " ".join(parts), bool(problems)
+
+
+async def handle_console_script_result(
+    event: "ConsoleScriptResult",
+    cm: "ConversationManager",
+) -> bool:
+    """Record the outcome; report whether it needs the brain's attention.
+
+    A successful move is noted silently. Waking a run for every landed click
+    would be a turn per navigation, and there is nothing to decide -- the
+    assistant already said what it was doing and it happened.
+    """
+    summary, needs_attention = summarize_console_script(event)
+    if not summary:
+        return False
+    cm.notifications_bar.push_notif("Console", summary, event.timestamp)
+    return needs_attention

--- a/unify/conversation_manager/domains/event_handlers.py
+++ b/unify/conversation_manager/domains/event_handlers.py
@@ -44,6 +44,9 @@ from unify.conversation_manager.domains.task_execution import (
     _handle_task_trigger_requested_event,
     _surface_trigger_task_candidates,
 )
+from unify.conversation_manager.domains.console_script_result import (
+    handle_console_script_result,
+)
 from unify.conversation_manager.domains.whatsapp_history import (
     whatsapp_sent_history_content,
 )
@@ -3557,6 +3560,19 @@ async def _(
             "assistant_presence_observed",
             f"Assistant presence observed from {event.source or 'console'}.",
         )
+
+
+@EventHandler.register(ConsoleScriptResult)
+async def _(
+    event: ConsoleScriptResult,
+    cm: "ConversationManager",
+    *args,
+    **kwargs,
+):
+    # Only a move that failed is worth a turn. A landed one is recorded for the
+    # next one, because the assistant already said what it was doing.
+    if await handle_console_script_result(event, cm):
+        await cm.request_llm_run(delay=0)
 
 
 @EventHandler.register(CoordinatorDelegate)

--- a/unify/conversation_manager/domains/event_handlers.py
+++ b/unify/conversation_manager/domains/event_handlers.py
@@ -4038,6 +4038,8 @@ _MEET_LOG_TYPES: dict[type, str] = {
     AssistantScreenShareStopped: "screen_share_off",
     UserScreenShareStarted: "user_screen_share",
     UserScreenShareStopped: "user_screen_share_off",
+    MeetScreenShareStarted: "meet_screen_share_on",
+    MeetScreenShareStopped: "meet_screen_share_off",
     UserWebcamStarted: "webcam_on",
     UserWebcamStopped: "webcam_off",
     UserRemoteControlStarted: "remote_control",
@@ -4049,6 +4051,8 @@ _MEET_INTERACTION_NOTIFICATIONS: dict[type, str] = {
     AssistantScreenShareStopped: "The user disabled assistant screen sharing — they can no longer see your desktop.",
     UserScreenShareStarted: "The user started sharing their screen with you.",
     UserScreenShareStopped: "The user stopped sharing their screen.",
+    MeetScreenShareStarted: "Someone in the meeting started sharing their screen with you.",
+    MeetScreenShareStopped: "Nobody in the meeting is sharing a screen any more.",
     UserWebcamStarted: "The user enabled their webcam — you can now see them.",
     UserWebcamStopped: "The user disabled their webcam.",
     UserRemoteControlStarted: "The user took remote control of your desktop — they now have mouse and keyboard control.",
@@ -4076,6 +4080,16 @@ _MEET_FAST_BRAIN_GUIDANCE: dict[type, str] = {
         "details. Do NOT guess or fabricate what is on their screen."
     ),
     UserScreenShareStopped: ("The user stopped sharing their screen."),
+    MeetScreenShareStarted: (
+        "Someone in the meeting is sharing their screen. Snapshots of it are "
+        "arriving in the background. If they point at something on it, "
+        "acknowledge naturally and wait for the details. Do NOT guess what is "
+        "on it."
+    ),
+    MeetScreenShareStopped: (
+        "The shared screen is gone. Anything you saw on it is history now, not "
+        "something you can still look at."
+    ),
     UserWebcamStarted: (
         "The user enabled their webcam. Visual context is being captured "
         "in the background. If they reference their appearance or something "
@@ -4098,6 +4112,8 @@ _MEET_STATE_FLAGS: dict[type, tuple[str, bool]] = {
     AssistantScreenShareStopped: ("assistant_screen_share_active", False),
     UserScreenShareStarted: ("user_screen_share_active", True),
     UserScreenShareStopped: ("user_screen_share_active", False),
+    MeetScreenShareStarted: ("meet_screen_share_active", True),
+    MeetScreenShareStopped: ("meet_screen_share_active", False),
     UserWebcamStarted: ("user_webcam_active", True),
     UserWebcamStopped: ("user_webcam_active", False),
     UserRemoteControlStarted: ("user_remote_control_active", True),
@@ -4111,6 +4127,8 @@ _MEET_STATE_FLAGS: dict[type, tuple[str, bool]] = {
         AssistantScreenShareStopped,
         UserScreenShareStarted,
         UserScreenShareStopped,
+        MeetScreenShareStarted,
+        MeetScreenShareStopped,
         UserWebcamStarted,
         UserWebcamStopped,
         UserRemoteControlStarted,
@@ -4123,6 +4141,8 @@ async def _(
         | AssistantScreenShareStopped
         | UserScreenShareStarted
         | UserScreenShareStopped
+        | MeetScreenShareStarted
+        | MeetScreenShareStopped
         | UserWebcamStarted
         | UserWebcamStopped
         | UserRemoteControlStarted
@@ -4167,6 +4187,20 @@ async def _(
 
     # Update state flag on the CM.
     setattr(cm, attr, value)
+
+    if isinstance(event, MeetScreenShareStopped):
+        # The buffer is peeked non-destructively and only cleared after a
+        # successful turn, so without this the frame from a screen that has just
+        # been taken down survives into the next turn and gets described as
+        # current. Utterance-paired frames stay: those answer a question somebody
+        # actually asked.
+        for source in ("google_meet", "teams_meet"):
+            dropped = cm.drop_unpaired_screenshots(source)
+            if dropped:
+                cm._session_logger.debug(
+                    log_type,
+                    f"Dropped {dropped} stale {source} screenshot(s)",
+                )
 
     if (
         isinstance(event, (UserWebcamStarted, UserWebcamStopped))

--- a/unify/conversation_manager/domains/managers_utils.py
+++ b/unify/conversation_manager/domains/managers_utils.py
@@ -103,6 +103,10 @@ _MESSAGE_PRODUCING_EVENTS = {
     "OutboundGoogleMeetUtterance",
     "InboundTeamsMeetUtterance",
     "OutboundTeamsMeetUtterance",
+    "GoogleMeetChatMessage",
+    "TeamsMeetChatMessage",
+    "GoogleMeetChatSent",
+    "TeamsMeetChatSent",
     "AssistantTurnInjected",
     "FastBrainNotification",
     "PhoneCallReceived",
@@ -625,6 +629,44 @@ async def hydrate_global_thread(cm: "ConversationManager") -> None:
                     sender_name=sender_name,
                     thread_name=Medium.TEAMS_MEET,
                     message_content=cm_event.content,
+                    role="assistant",
+                    timestamp=ts,
+                )
+
+            # --- Browser-meet chat ---
+            # The `<meeting chat>` prefix is reproduced rather than inferred: the
+            # thread is flat text to the brain, so a rehydrated line without it
+            # reads as something the participant said out loud.
+            case "GoogleMeetChatMessage" | "TeamsMeetChatMessage":
+                entry = cm.contact_index.build_message(
+                    contact_id=contact_id,
+                    # The typist, not the call's contact. Anyone in the meeting
+                    # can type, and unlike every case above, the event carries
+                    # the real name -- resolving it from the contact would
+                    # attribute a third participant's message to whoever the
+                    # call is with.
+                    sender_name=cm_event.sender_name,
+                    thread_name=(
+                        Medium.GOOGLE_MEET
+                        if payload_cls == "GoogleMeetChatMessage"
+                        else Medium.TEAMS_MEET
+                    ),
+                    message_content=f"<meeting chat> {cm_event.content}",
+                    role="user",
+                    timestamp=ts,
+                )
+            case "GoogleMeetChatSent" | "TeamsMeetChatSent":
+                entry = cm.contact_index.build_message(
+                    contact_id=contact_id,
+                    # Ignored for an assistant role, which renders as "You" --
+                    # passed for symmetry with every other case here.
+                    sender_name=sender_name,
+                    thread_name=(
+                        Medium.GOOGLE_MEET
+                        if payload_cls == "GoogleMeetChatSent"
+                        else Medium.TEAMS_MEET
+                    ),
+                    message_content=f"<meeting chat> {cm_event.content}",
                     role="assistant",
                     timestamp=ts,
                 )

--- a/unify/conversation_manager/domains/recall/client.py
+++ b/unify/conversation_manager/domains/recall/client.py
@@ -202,6 +202,7 @@ class RecallClient:
         metadata: Mapping[str, Any] | None = None,
         as_screenshare: bool = False,
         capture_participant_video: bool = False,
+        may_screenshare: bool = False,
     ) -> RecallBotState:
         """Dispatch a bot to one meeting and return its initial state.
 
@@ -209,6 +210,11 @@ class RecallClient:
         screenshare when ``as_screenshare``) and supplies both directions of
         audio. It must already carry the LiveKit room token: the bot loads it
         verbatim and cannot be handed credentials any other way.
+
+        ``may_screenshare`` says this call *might* later put a second page on the
+        screenshare surface. It only affects the variant, and it has to be decided
+        here because the variant is fixed for the bot's whole life -- there is no
+        upgrading it at the moment somebody asks to share.
         """
 
         surface = "screenshare" if as_screenshare else "camera"
@@ -249,10 +255,20 @@ class RecallClient:
             # subscribing the event without declaring the artifact yields
             # nothing.
             payload["recording_config"]["video_separate_png"] = {}
-            # Recall's prose says separate participant video requires the
-            # four-core variant while their own PNG example omits it. Paying the
-            # surcharge (+$0.10/hr on plan) is the cheaper of the two mistakes:
-            # the other one is a meeting where the assistant is silently blind.
+        if capture_participant_video or may_screenshare:
+            # CPU headroom, wanted for either of two independent reasons, and the
+            # variant cannot be changed later so both are decided here.
+            #
+            # Participant video: Recall's prose says separate per-participant
+            # video requires the four-core variant while their own PNG example
+            # omits it. Paying the surcharge (+$0.10/hr on plan) is the cheaper of
+            # the two mistakes; the other is a meeting where the assistant is
+            # silently blind.
+            #
+            # Screensharing: a second rendered page competes with the bridge for
+            # the default variant's 250 millicores, which Recall names as the
+            # cause of choppy output. Kept separate from the flag above so turning
+            # participant video off does not quietly degrade sharing too.
             payload["variant"] = {
                 "google_meet": VARIANT_WEB_4_CORE,
                 "microsoft_teams": VARIANT_WEB_4_CORE,
@@ -321,6 +337,45 @@ class RecallClient:
         if to:
             payload["to"] = to
         await self._request("POST", f"/bot/{bot_id}/send_chat_message", json=payload)
+
+    async def start_screenshare(self, bot_id: str, page_url: str) -> None:
+        """Put ``page_url`` on the bot's screenshare surface, mid-call.
+
+        Sends the screenshare surface **only**. The camera is deliberately absent:
+        it is the page bridging audio, and this endpoint's merge-vs-replace
+        behaviour is undocumented, so naming the camera at all risks reloading or
+        replacing the page that carries the assistant's voice. Recall states the
+        camera cannot be turned off while output media is on, so there is nothing
+        to preserve by re-sending it either.
+
+        The previous implementation of this always re-sent the camera URL, and
+        losing audio mid-meeting is the failure that got it withdrawn.
+        """
+
+        await self._request(
+            "POST",
+            f"/bot/{bot_id}/output_media/",
+            json={
+                "screenshare": {
+                    "kind": "webpage",
+                    "config": {"url": page_url},
+                },
+            },
+        )
+
+    async def stop_screenshare(self, bot_id: str) -> None:
+        """Drop the screenshare surface, leaving the camera running.
+
+        ``DELETE`` with the surface named is the documented stop. Clearing it by
+        re-POSTing a camera-only body -- what the withdrawn implementation did --
+        is not, and depends on the same undocumented merge behaviour.
+        """
+
+        await self._request(
+            "DELETE",
+            f"/bot/{bot_id}/output_media/",
+            json={"screenshare": True},
+        )
 
     async def _request(
         self,

--- a/unify/conversation_manager/domains/recall/provider.py
+++ b/unify/conversation_manager/domains/recall/provider.py
@@ -30,6 +30,7 @@ from unify.conversation_manager.domains.recall.client import (
     RecallBotState,
     meet_bridge_base_url,
 )
+from unify.session_details import SESSION_DETAILS
 
 LOGGER = logging.getLogger(__name__)
 
@@ -40,6 +41,12 @@ LOGGER = logging.getLogger(__name__)
 _BRIDGE_TOKEN_TTL = timedelta(hours=4)
 
 _BRIDGE_IDENTITY_PREFIX = "recall-bridge"
+
+# Distinct from the bridge's, and that is the whole point: LiveKit evicts a
+# duplicate identity, so a desktop page joining under the bridge's name would
+# kick the page carrying audio and leave the assistant silent for the rest of the
+# meeting. Never derive one of these prefixes from the other.
+_DESKTOP_IDENTITY_PREFIX = "recall-screenshare"
 
 # Recall's own sub_codes are stable strings, but they are not phrased for a
 # person. Map the ones a user can act on; anything else passes through so an
@@ -120,6 +127,12 @@ class RecallMeetProvider:
                     "unify_assistant_id": self._assistant_id,
                 },
                 capture_participant_video=self._capture_participant_video,
+                # Decided here because the variant is fixed for the bot's whole
+                # life: an assistant with a managed desktop may be asked to share
+                # it at any point, and there is no upgrading the bot at that
+                # moment. An assistant with no desktop can never share, so it pays
+                # nothing.
+                may_screenshare=SESSION_DETAILS.assistant.has_managed_desktop,
             )
         except RecallError as exc:
             LOGGER.error("[recall] %s join failed: %s", channel, exc)
@@ -175,12 +188,77 @@ class RecallMeetProvider:
             LOGGER.warning("[recall] chat send failed for %s: %s", session_id, exc)
             return False
 
+    async def present(
+        self,
+        *,
+        channel: str = "",
+        session_id: str,
+        room_name: str,
+    ) -> bool:
+        """Put the assistant's desktop on the bot's screenshare surface.
+
+        The desktop itself arrives over LiveKit: the pod publishes it into
+        ``room_name`` and the page this points the bot at subscribes to it. Recall
+        only ever learns a URL carrying a subscribe-only token, so the VM stays
+        unreachable from the internet.
+        """
+        _ = channel
+        try:
+            page_url = self._desktop_page_url(room_name)
+        except RuntimeError as exc:
+            LOGGER.error("[recall] could not mint a desktop token: %s", exc)
+            return False
+        try:
+            await self._client.start_screenshare(session_id, page_url)
+            return True
+        except RecallError as exc:
+            LOGGER.warning("[recall] present failed for %s: %s", session_id, exc)
+            return False
+
+    async def stop_present(self, *, channel: str = "", session_id: str) -> bool:
+        """Drop the screenshare surface, leaving the audio bridge alone."""
+        _ = channel
+        try:
+            await self._client.stop_screenshare(session_id)
+            return True
+        except RecallError as exc:
+            LOGGER.warning("[recall] stop-present failed for %s: %s", session_id, exc)
+            return False
+
+    def _desktop_page_url(self, room_name: str) -> str:
+        """Tokenised URL for the desktop page, scoped to one room.
+
+        Narrower than the bridge's grant in every direction that matters: it may
+        subscribe and nothing else. A page that could publish would be able to put
+        audio or video into the call, and this one exists only to display.
+        """
+
+        server_url, api_key, api_secret = _livekit_credentials()
+        base = meet_bridge_base_url()
+        if not base:
+            raise RuntimeError("MEET_BRIDGE_PAGE_URL must be set")
+
+        token = (
+            AccessToken(api_key, api_secret)
+            .with_identity(f"{_DESKTOP_IDENTITY_PREFIX}-{room_name}")
+            .with_name("Unify desktop")
+            .with_grants(
+                VideoGrants(
+                    room_join=True,
+                    room=room_name,
+                    can_publish=False,
+                    can_subscribe=True,
+                    can_publish_data=False,
+                ),
+            )
+            .with_ttl(_BRIDGE_TOKEN_TTL)
+            .to_jwt()
+        )
+        query = urlencode({"url": server_url, "token": token})
+        return f"{base}/desktop?{query}"
+
     def _bridge_url(self, room_name: str, display_name: str) -> str:
-        server_url = (os.environ.get("LIVEKIT_URL") or "").strip()
-        api_key = (os.environ.get("LIVEKIT_API_KEY") or "").strip()
-        api_secret = (os.environ.get("LIVEKIT_API_SECRET") or "").strip()
-        if not server_url or not api_key or not api_secret:
-            raise RuntimeError("LIVEKIT_URL / _API_KEY / _API_SECRET must all be set")
+        server_url, api_key, api_secret = _livekit_credentials()
 
         token = (
             AccessToken(api_key, api_secret)
@@ -223,6 +301,17 @@ class RecallMeetProvider:
         query = urlencode({"room": room_name, "token": secret})
         separator = "&" if "?" in self._relay_url else "?"
         return f"{self._relay_url}{separator}{query}"
+
+
+def _livekit_credentials() -> tuple[str, str, str]:
+    """Server URL and signing key pair, or a hard failure naming what is missing."""
+
+    server_url = (os.environ.get("LIVEKIT_URL") or "").strip()
+    api_key = (os.environ.get("LIVEKIT_API_KEY") or "").strip()
+    api_secret = (os.environ.get("LIVEKIT_API_SECRET") or "").strip()
+    if not server_url or not api_key or not api_secret:
+        raise RuntimeError("LIVEKIT_URL / _API_KEY / _API_SECRET must all be set")
+    return server_url, api_key, api_secret
 
 
 def _participant_video_enabled() -> bool:

--- a/unify/conversation_manager/domains/recall/provider.py
+++ b/unify/conversation_manager/domains/recall/provider.py
@@ -30,6 +30,10 @@ from unify.conversation_manager.domains.recall.client import (
     RecallBotState,
     meet_bridge_base_url,
 )
+from unify.conversation_manager.domains.self_host_desktop import (
+    desktop_proxy_healthy,
+    resolve_desktop_urls,
+)
 from unify.session_details import SESSION_DETAILS
 
 LOGGER = logging.getLogger(__name__)
@@ -41,12 +45,6 @@ LOGGER = logging.getLogger(__name__)
 _BRIDGE_TOKEN_TTL = timedelta(hours=4)
 
 _BRIDGE_IDENTITY_PREFIX = "recall-bridge"
-
-# Distinct from the bridge's, and that is the whole point: LiveKit evicts a
-# duplicate identity, so a desktop page joining under the bridge's name would
-# kick the page carrying audio and leave the assistant silent for the rest of the
-# meeting. Never derive one of these prefixes from the other.
-_DESKTOP_IDENTITY_PREFIX = "recall-screenshare"
 
 # Recall's own sub_codes are stable strings, but they are not phrased for a
 # person. Map the ones a user can act on; anything else passes through so an
@@ -188,25 +186,32 @@ class RecallMeetProvider:
             LOGGER.warning("[recall] chat send failed for %s: %s", session_id, exc)
             return False
 
-    async def present(
-        self,
-        *,
-        channel: str = "",
-        session_id: str,
-        room_name: str,
-    ) -> bool:
-        """Put the assistant's desktop on the bot's screenshare surface.
+    async def present(self, *, channel: str = "", session_id: str) -> bool:
+        """Put the assistant's live desktop on the bot's screenshare surface.
 
-        The desktop itself arrives over LiveKit: the pod publishes it into
-        ``room_name`` and the page this points the bot at subscribes to it. Recall
-        only ever learns a URL carrying a subscribe-only token, so the VM stays
-        unreachable from the internet.
+        The bot renders a page of ours which frames the managed VM's own noVNC
+        liveview, so the meeting sees the real desktop at VNC's frame rate rather
+        than a reconstruction of it.
+
+        Health is checked first because entitlement is not liveness: an assistant
+        can be entitled to a desktop whose VM is down, and the failure mode there
+        is a noVNC error dialog on the meeting's main stage.
         """
         _ = channel
+        browser_url, api_url = resolve_desktop_urls()
+        if not browser_url:
+            LOGGER.error("[recall] no managed desktop URL; cannot present")
+            return False
+        if not await desktop_proxy_healthy(api_url):
+            LOGGER.warning(
+                "[recall] desktop proxy is not serving noVNC; not presenting",
+            )
+            return False
+
         try:
-            page_url = self._desktop_page_url(room_name)
+            page_url = self._desktop_page_url(browser_url)
         except RuntimeError as exc:
-            LOGGER.error("[recall] could not mint a desktop token: %s", exc)
+            LOGGER.error("[recall] could not build the desktop page URL: %s", exc)
             return False
         try:
             await self._client.start_screenshare(session_id, page_url)
@@ -225,36 +230,44 @@ class RecallMeetProvider:
             LOGGER.warning("[recall] stop-present failed for %s: %s", session_id, exc)
             return False
 
-    def _desktop_page_url(self, room_name: str) -> str:
-        """Tokenised URL for the desktop page, scoped to one room.
+    def _desktop_page_url(self, browser_desktop_url: str) -> str:
+        """URL of the page that frames the managed desktop's noVNC liveview.
 
-        Narrower than the bridge's grant in every direction that matters: it may
-        subscribe and nothing else. A page that could publish would be able to put
-        audio or video into the call, and this one exists only to display.
+        Wrapped in a page of ours rather than handing Recall the liveview
+        directly, so the framing decisions -- scaling the VM's resolution into the
+        bot's fixed viewport, hiding the VNC chrome, and swallowing noVNC's own
+        error dialogs -- are ours to make. All three would otherwise be visible on
+        the meeting's main stage.
         """
 
-        server_url, api_key, api_secret = _livekit_credentials()
         base = meet_bridge_base_url()
         if not base:
             raise RuntimeError("MEET_BRIDGE_PAGE_URL must be set")
 
-        token = (
-            AccessToken(api_key, api_secret)
-            .with_identity(f"{_DESKTOP_IDENTITY_PREFIX}-{room_name}")
-            .with_name("Unify desktop")
-            .with_grants(
-                VideoGrants(
-                    room_join=True,
-                    room=room_name,
-                    can_publish=False,
-                    can_subscribe=True,
-                    can_publish_data=False,
-                ),
-            )
-            .with_ttl(_BRIDGE_TOKEN_TTL)
-            .to_jwt()
+        secret = (os.environ.get("RECALL_RELAY_SECRET") or "").strip()
+        if not secret:
+            raise RuntimeError("RECALL_RELAY_SECRET must be set to sign the page URL")
+
+        liveview = f"{browser_desktop_url.rstrip('/')}/desktop/custom.html"
+        # The VNC password is the assistant's own API key, which is how Console
+        # reaches the same surface.
+        password = SESSION_DETAILS.unify_key
+        query = urlencode(
+            {
+                "liveview": liveview,
+                "password": password,
+                # The page is unauthenticated -- Recall's browser loads it with no
+                # credential of ours -- so without this it would frame any URL
+                # anyone handed it, on our own domain. Signing binds it to URLs
+                # this pod minted.
+                #
+                # MIRRORED: ``sign_liveview`` in unity-deploy's
+                # ``communication/meet_desktop_page.py``. Two repos, one
+                # construction; a mismatch is a 403 the assistant reports as "could
+                # not share".
+                "sig": _sign_liveview(liveview, password, secret),
+            },
         )
-        query = urlencode({"url": server_url, "token": token})
         return f"{base}/desktop?{query}"
 
     def _bridge_url(self, room_name: str, display_name: str) -> str:
@@ -301,6 +314,20 @@ class RecallMeetProvider:
         query = urlencode({"room": room_name, "token": secret})
         separator = "&" if "?" in self._relay_url else "?"
         return f"{self._relay_url}{separator}{query}"
+
+
+def _sign_liveview(liveview: str, password: str, secret: str) -> str:
+    """Signature the desktop page checks before framing a liveview URL.
+
+    MIRRORED: ``sign_liveview`` in unity-deploy's
+    ``communication/meet_desktop_page.py``. Change both together.
+    """
+
+    import hashlib
+    import hmac
+
+    payload = f"{liveview}\x00{password}".encode()
+    return hmac.new(secret.encode(), payload, hashlib.sha256).hexdigest()
 
 
 def _livekit_credentials() -> tuple[str, str, str]:

--- a/unify/conversation_manager/domains/renderer.py
+++ b/unify/conversation_manager/domains/renderer.py
@@ -607,6 +607,7 @@ class Renderer:
         user_remote_control_active: bool = False,
         google_meet_active: bool = False,
         teams_meet_active: bool = False,
+        meet_screen_share_active: bool = False,
         active_web_sessions: list | None = None,
         managers_initialized: bool = True,
         vm_ready: bool = True,
@@ -649,6 +650,7 @@ class Renderer:
             user_remote_control_active=user_remote_control_active,
             google_meet_active=google_meet_active,
             teams_meet_active=teams_meet_active,
+            meet_screen_share_active=meet_screen_share_active,
         )
         _meet_ms = _mark_step()
 

--- a/unify/conversation_manager/domains/renderer.py
+++ b/unify/conversation_manager/domains/renderer.py
@@ -824,12 +824,17 @@ class Renderer:
         user_remote_control_active: bool = False,
         google_meet_active: bool = False,
         teams_meet_active: bool = False,
+        meet_screen_share_active: bool = False,
     ) -> str:
         """Render active meet interaction states as top-level sections.
 
         Each active state gets its own prominent, self-contained XML section
         with clear context explaining what is happening and what it means.
         Inactive states produce no output — no clutter for text-only sessions.
+
+        The browser-meeting block is the exception that does render when
+        inactive: "nobody is sharing" is worth saying out loud, because silence
+        there was read as "the last screen I saw is still up".
         """
         parts: list[str] = []
 
@@ -874,35 +879,35 @@ class Renderer:
                 "</user_remote_control>",
             )
 
-        # These say what you can see *if* someone shares, not that anyone is:
-        # the flags mean a meeting is in progress. Whether a share is up right
-        # now is evident from the snapshots attached to this state, and claiming
-        # one unconditionally would have the assistant describing a screen that
-        # nobody put up.
-        if google_meet_active:
-            parts.append(
-                "<google_meet_visual status='active'>\n"
-                "You are in a Google Meet call. When a participant shares their "
-                "screen you receive periodic screenshots of it, labelled with "
-                "whose screen it is; those screenshots appear alongside this "
-                "state when a share is live. What you see is the sharer's own "
-                "machine -- not yours, and not the meeting's gallery view, so "
-                "you cannot see participants' faces or the meeting UI.\n"
-                "</google_meet_visual>",
-            )
-
-        if teams_meet_active:
-            parts.append(
-                "<teams_meet_visual status='active'>\n"
-                "You are in a Microsoft Teams meeting. When a participant "
-                "shares their screen you receive periodic screenshots of it, "
-                "labelled with whose screen it is; those screenshots appear "
-                "alongside this state when a share is live. What you see is the "
-                "sharer's own machine -- not yours, and not the meeting's "
-                "gallery view, so you cannot see participants' faces or the "
-                "meeting UI.\n"
-                "</teams_meet_visual>",
-            )
+        # Driven by whether a share is actually up, never by the meeting being in
+        # progress. The previous block was emitted for the whole meeting under the
+        # name ``google_meet_visual status='active'``, and a status attribute in a
+        # block named after a visual outvotes any amount of conditional prose
+        # inside it: the assistant went on describing the last screen it had seen
+        # long after the presenter stopped.
+        if google_meet_active or teams_meet_active:
+            platform = "Google Meet" if google_meet_active else "Microsoft Teams"
+            if meet_screen_share_active:
+                parts.append(
+                    "<meet_shared_screen status='live'>\n"
+                    f"Someone in the {platform} meeting is sharing their screen "
+                    "right now, and snapshots of it are attached to this state, "
+                    "labelled with whose screen it is. What you see is the "
+                    "sharer's own machine -- not yours, and not the meeting's "
+                    "gallery view, so you cannot see participants' faces or the "
+                    "meeting UI.\n"
+                    "</meet_shared_screen>",
+                )
+            else:
+                parts.append(
+                    "<meet_shared_screen status='none'>\n"
+                    f"Nobody in the {platform} meeting is sharing a screen. I "
+                    "cannot see anything. If a screen was shared earlier, what I "
+                    "saw is history -- I do not describe it as though it were "
+                    "still up, and I say plainly that nothing is being shared if "
+                    "asked.\n"
+                    "</meet_shared_screen>",
+                )
 
         return "\n\n".join(parts)
 

--- a/unify/conversation_manager/events.py
+++ b/unify/conversation_manager/events.py
@@ -2117,6 +2117,27 @@ class AssistantPresenceObserved(Event):
 
 
 @dataclass
+class ConsoleScriptResult(Event):
+    """What became of the console moves this assistant asked for.
+
+    Reported once per script, after it settles. Without it the runtime steers
+    blind: it says "and there it is" whether or not the control was there, which
+    is worse than never having offered to navigate.
+
+    ``outcomes`` is a list of ``{"target": str, "outcome": str}``. The outcomes
+    that mean a move did not happen are distinguished on purpose -- a control
+    that was missing, a user who switched the feature off, and speech that never
+    reached the move all call for the assistant to say something different.
+    """
+
+    topic: ClassVar[str | None] = "app:comms:console_script_result"
+    loggable: ClassVar[bool] = False
+
+    script_id: str = ""
+    outcomes: list = field(default_factory=list)
+
+
+@dataclass
 class CoordinatorDelegate(Event):
     """A Coordinator assigned asynchronous work to this colleague.
 

--- a/unify/conversation_manager/events.py
+++ b/unify/conversation_manager/events.py
@@ -2287,6 +2287,40 @@ class UserScreenShareStopped(Event):
 
 
 @dataclass
+class MeetScreenShareStarted(Event):
+    """Someone in a browser meeting started sharing their screen.
+
+    Distinct from ``UserScreenShareStarted``, which is the Console surface: that
+    one also gates the desktop fast path and web-session listing, which have no
+    business turning on because a stranger in a Google Meet shared a slide. This
+    one says only that a shared screen is now reaching the assistant.
+
+    Deliberately carries no sharer name: attribution rides the frame's own label,
+    which is where the model needs it, and at the moment this fires the first
+    frame has not arrived yet -- so any name here would be blank or the previous
+    presenter's.
+    """
+
+    topic: ClassVar[str | None] = "app:comms:meet_screen_share_started"
+
+    reason: str = ""
+
+
+@dataclass
+class MeetScreenShareStopped(Event):
+    """Nobody in the browser meeting is sharing a screen any more.
+
+    Without this the assistant keeps describing the last frame it saw: the state
+    block that says a share is live is otherwise driven by the meeting being in
+    progress, which stays true until hangup.
+    """
+
+    topic: ClassVar[str | None] = "app:comms:meet_screen_share_stopped"
+
+    reason: str = ""
+
+
+@dataclass
 class UserWebcamStarted(Event):
     """User enabled their webcam during a Unify Meet session.
 

--- a/unify/conversation_manager/medium_scripts/call.py
+++ b/unify/conversation_manager/medium_scripts/call.py
@@ -124,6 +124,49 @@ _log = FastBrainLogger()
 # but both are just as multi-party.
 MULTI_PARTY_CHANNELS = ("google_meet", "teams_meet", "unify_meet")
 
+# The assistant's desktop, published into the meeting room for the Recall bot's
+# screenshare page to render. 1280x720 because that is both the page's fixed
+# viewport and Recall's output ceiling on every variant -- sending more pixels
+# than that just costs conversion time to have them scaled back down.
+_DESKTOP_SHARE_WIDTH = 1280
+_DESKTOP_SHARE_HEIGHT = 720
+
+# A live desktop capture costs ~500ms on the agent-service, so this is close to
+# the practical ceiling anyway. A shared desktop is read, not watched: legibility
+# matters and motion smoothness does not.
+_DESKTOP_SHARE_FPS = 2.0
+
+
+def _desktop_frame(jpeg_b64: str) -> "rtc.VideoFrame | None":
+    """One base64 JPEG desktop capture as a LiveKit frame, or None if unreadable.
+
+    Pure and blocking, so callers run it off the event loop -- decoding a
+    full-resolution screenshot on the loop that also carries the assistant's audio
+    would stutter the voice to save a thread.
+    """
+    import base64
+    import io
+
+    from PIL import Image
+
+    try:
+        raw = base64.b64decode(jpeg_b64)
+        with Image.open(io.BytesIO(raw)) as img:
+            resized = img.convert("RGBA").resize(
+                (_DESKTOP_SHARE_WIDTH, _DESKTOP_SHARE_HEIGHT),
+                Image.LANCZOS,
+            )
+            data = resized.tobytes()
+    except (ValueError, TypeError, OSError):
+        return None
+    return rtc.VideoFrame(
+        width=_DESKTOP_SHARE_WIDTH,
+        height=_DESKTOP_SHARE_HEIGHT,
+        type=rtc.VideoBufferType.RGBA,
+        data=data,
+    )
+
+
 # How often to re-read the screen a meeting participant is sharing. Recall sends
 # frames at 2fps and the relay stores one a second, so polling faster only costs
 # round trips; polling much slower would leave the frame behind the conversation
@@ -1420,6 +1463,12 @@ async def entrypoint(ctx: agents.JobContext):
     _meet_last_pushed_frame: str | None = None
     _meet_last_push_at: float = 0.0
     _meet_fetch_misses: int = 0
+    # Outbound: the assistant's own desktop, published for the bot's screenshare
+    # page to render. Only alive between an explicit start and stop, so a meeting
+    # where nobody asks to see the desktop publishes nothing.
+    _desktop_share_task: asyncio.Task | None = None
+    _desktop_share_source: rtc.VideoSource | None = None
+    _desktop_share_sid: str = ""
     _meet_display_name: str = ""
     _meet_last_speaker_id: str | None = None
     _meet_speech_windows = MeetSpeakerWindows()
@@ -2228,6 +2277,7 @@ async def entrypoint(ctx: agents.JobContext):
             await utils.aio.cancel_and_wait(hang_up_gate_watcher_task)
         if _meet_screenshare_task is not None:
             await utils.aio.cancel_and_wait(_meet_screenshare_task)
+        await _stop_desktop_share()
         await screen_capture.close()
         await webcam_capture.close()
         # Unify Meet rooms belong to the call session, never to one agent:
@@ -2559,6 +2609,79 @@ async def entrypoint(ctx: agents.JobContext):
             # a stale snapshot in the fast brain's visual context outlives the
             # share and gets described as if it were still up.
             _clear_visual_context(source=channel)
+
+    async def _desktop_share_loop() -> None:
+        """Publish the assistant's desktop into the room until cancelled.
+
+        The bot's screenshare surface can only render a webpage, so the desktop
+        travels as an ordinary LiveKit video track that the hosted page subscribes
+        to. Going via the room rather than letting the page reach the VM is what
+        keeps the desktop off the public internet.
+        """
+        interval = 1.0 / _DESKTOP_SHARE_FPS
+        while True:
+            started = time.monotonic()
+            entry = await capture_assistant_screenshot(
+                utterance="",
+                cached=False,
+                fb_logger=_log,
+                agent_service_url=_agent_service_url,
+                http_session=_screenshot_http_session,
+            )
+            if entry is not None and _desktop_share_source is not None:
+                frame = await asyncio.to_thread(_desktop_frame, entry.b64)
+                if frame is not None:
+                    _desktop_share_source.capture_frame(frame)
+            # Pace on elapsed time: a capture that took 500ms should not also wait
+            # a full interval on top, or the meeting sees half the frame rate the
+            # assistant thinks it is sending.
+            await asyncio.sleep(max(0.0, interval - (time.monotonic() - started)))
+
+    async def _start_desktop_share() -> bool:
+        """Publish the desktop track. Idempotent; True once a track is live."""
+        nonlocal _desktop_share_task, _desktop_share_source, _desktop_share_sid
+
+        if _desktop_share_task is not None:
+            return True
+        source = rtc.VideoSource(_DESKTOP_SHARE_WIDTH, _DESKTOP_SHARE_HEIGHT)
+        track = rtc.LocalVideoTrack.create_video_track("assistant-desktop", source)
+        publication = await ctx.room.local_participant.publish_track(
+            track,
+            rtc.TrackPublishOptions(source=rtc.TrackSource.SOURCE_SCREENSHARE),
+        )
+        _desktop_share_source = source
+        _desktop_share_sid = publication.sid
+        _desktop_share_task = asyncio.create_task(_desktop_share_loop())
+        _log.screenshot("Desktop share: publishing to the meeting")
+        return True
+
+    async def _stop_desktop_share() -> None:
+        """Unpublish the desktop track and stop capturing. Idempotent."""
+        nonlocal _desktop_share_task, _desktop_share_source, _desktop_share_sid
+
+        if _desktop_share_task is not None:
+            await utils.aio.cancel_and_wait(_desktop_share_task)
+            _desktop_share_task = None
+        if _desktop_share_sid:
+            try:
+                await ctx.room.local_participant.unpublish_track(_desktop_share_sid)
+            except Exception as exc:  # noqa: BLE001 - teardown must reach its end
+                _log.screenshot(f"Desktop share: unpublish failed: {exc!r}")
+            _desktop_share_sid = ""
+        _desktop_share_source = None
+
+    def on_desktop_share(data: dict) -> None:
+        """Start or stop publishing the desktop, as the slow brain asks.
+
+        The tool runs in the CM, but only this process is in the LiveKit room, so
+        the decision arrives over IPC and the publishing happens here.
+        """
+        if bool(data.get("active")):
+            asyncio.create_task(_start_desktop_share())
+        else:
+            asyncio.create_task(_stop_desktop_share())
+
+    event_broker.register_callback("app:call:desktop_share", on_desktop_share)
 
     @session.on("conversation_item_added")
     def _on_chat_item_added(ev):

--- a/unify/conversation_manager/medium_scripts/call.py
+++ b/unify/conversation_manager/medium_scripts/call.py
@@ -2541,7 +2541,12 @@ async def entrypoint(ctx: agents.JobContext):
             await asyncio.sleep(_MEET_SCREENSHARE_POLL_INTERVAL_S)
 
     def _sync_meet_screenshare_poller() -> None:
-        """Start or stop the poller to match whether anyone is presenting."""
+        """Start or stop the poller to match whether anyone is presenting.
+
+        Also announces the transition to the slow brain, which otherwise has no
+        way to know: it sees only frames arriving, so the absence of a frame is
+        indistinguishable from a turn that happened not to include one.
+        """
         nonlocal _meet_screenshare_task
         nonlocal _meet_latest_screenshot, _meet_screenshare_sharer
 
@@ -2549,6 +2554,11 @@ async def entrypoint(ctx: agents.JobContext):
             _meet_screenshare_task = asyncio.create_task(
                 _meet_screenshare_poll_loop(),
             )
+            evt = MeetScreenShareStarted(
+                contact=contact,
+                reason="participant started sharing",
+            )
+            asyncio.create_task(event_broker.publish(evt.topic, evt.to_json()))
             return
         if not _meet_sharing and _meet_screenshare_task is not None:
             _meet_screenshare_task.cancel()
@@ -2559,6 +2569,11 @@ async def entrypoint(ctx: agents.JobContext):
             # a stale snapshot in the fast brain's visual context outlives the
             # share and gets described as if it were still up.
             _clear_visual_context(source=channel)
+            evt = MeetScreenShareStopped(
+                contact=contact,
+                reason="participant stopped sharing",
+            )
+            asyncio.create_task(event_broker.publish(evt.topic, evt.to_json()))
 
     @session.on("conversation_item_added")
     def _on_chat_item_added(ev):

--- a/unify/conversation_manager/medium_scripts/call.py
+++ b/unify/conversation_manager/medium_scripts/call.py
@@ -124,49 +124,6 @@ _log = FastBrainLogger()
 # but both are just as multi-party.
 MULTI_PARTY_CHANNELS = ("google_meet", "teams_meet", "unify_meet")
 
-# The assistant's desktop, published into the meeting room for the Recall bot's
-# screenshare page to render. 1280x720 because that is both the page's fixed
-# viewport and Recall's output ceiling on every variant -- sending more pixels
-# than that just costs conversion time to have them scaled back down.
-_DESKTOP_SHARE_WIDTH = 1280
-_DESKTOP_SHARE_HEIGHT = 720
-
-# A live desktop capture costs ~500ms on the agent-service, so this is close to
-# the practical ceiling anyway. A shared desktop is read, not watched: legibility
-# matters and motion smoothness does not.
-_DESKTOP_SHARE_FPS = 2.0
-
-
-def _desktop_frame(jpeg_b64: str) -> "rtc.VideoFrame | None":
-    """One base64 JPEG desktop capture as a LiveKit frame, or None if unreadable.
-
-    Pure and blocking, so callers run it off the event loop -- decoding a
-    full-resolution screenshot on the loop that also carries the assistant's audio
-    would stutter the voice to save a thread.
-    """
-    import base64
-    import io
-
-    from PIL import Image
-
-    try:
-        raw = base64.b64decode(jpeg_b64)
-        with Image.open(io.BytesIO(raw)) as img:
-            resized = img.convert("RGBA").resize(
-                (_DESKTOP_SHARE_WIDTH, _DESKTOP_SHARE_HEIGHT),
-                Image.LANCZOS,
-            )
-            data = resized.tobytes()
-    except (ValueError, TypeError, OSError):
-        return None
-    return rtc.VideoFrame(
-        width=_DESKTOP_SHARE_WIDTH,
-        height=_DESKTOP_SHARE_HEIGHT,
-        type=rtc.VideoBufferType.RGBA,
-        data=data,
-    )
-
-
 # How often to re-read the screen a meeting participant is sharing. Recall sends
 # frames at 2fps and the relay stores one a second, so polling faster only costs
 # round trips; polling much slower would leave the frame behind the conversation
@@ -1463,12 +1420,6 @@ async def entrypoint(ctx: agents.JobContext):
     _meet_last_pushed_frame: str | None = None
     _meet_last_push_at: float = 0.0
     _meet_fetch_misses: int = 0
-    # Outbound: the assistant's own desktop, published for the bot's screenshare
-    # page to render. Only alive between an explicit start and stop, so a meeting
-    # where nobody asks to see the desktop publishes nothing.
-    _desktop_share_task: asyncio.Task | None = None
-    _desktop_share_source: rtc.VideoSource | None = None
-    _desktop_share_sid: str = ""
     _meet_display_name: str = ""
     _meet_last_speaker_id: str | None = None
     _meet_speech_windows = MeetSpeakerWindows()
@@ -2277,7 +2228,6 @@ async def entrypoint(ctx: agents.JobContext):
             await utils.aio.cancel_and_wait(hang_up_gate_watcher_task)
         if _meet_screenshare_task is not None:
             await utils.aio.cancel_and_wait(_meet_screenshare_task)
-        await _stop_desktop_share()
         await screen_capture.close()
         await webcam_capture.close()
         # Unify Meet rooms belong to the call session, never to one agent:
@@ -2609,79 +2559,6 @@ async def entrypoint(ctx: agents.JobContext):
             # a stale snapshot in the fast brain's visual context outlives the
             # share and gets described as if it were still up.
             _clear_visual_context(source=channel)
-
-    async def _desktop_share_loop() -> None:
-        """Publish the assistant's desktop into the room until cancelled.
-
-        The bot's screenshare surface can only render a webpage, so the desktop
-        travels as an ordinary LiveKit video track that the hosted page subscribes
-        to. Going via the room rather than letting the page reach the VM is what
-        keeps the desktop off the public internet.
-        """
-        interval = 1.0 / _DESKTOP_SHARE_FPS
-        while True:
-            started = time.monotonic()
-            entry = await capture_assistant_screenshot(
-                utterance="",
-                cached=False,
-                fb_logger=_log,
-                agent_service_url=_agent_service_url,
-                http_session=_screenshot_http_session,
-            )
-            if entry is not None and _desktop_share_source is not None:
-                frame = await asyncio.to_thread(_desktop_frame, entry.b64)
-                if frame is not None:
-                    _desktop_share_source.capture_frame(frame)
-            # Pace on elapsed time: a capture that took 500ms should not also wait
-            # a full interval on top, or the meeting sees half the frame rate the
-            # assistant thinks it is sending.
-            await asyncio.sleep(max(0.0, interval - (time.monotonic() - started)))
-
-    async def _start_desktop_share() -> bool:
-        """Publish the desktop track. Idempotent; True once a track is live."""
-        nonlocal _desktop_share_task, _desktop_share_source, _desktop_share_sid
-
-        if _desktop_share_task is not None:
-            return True
-        source = rtc.VideoSource(_DESKTOP_SHARE_WIDTH, _DESKTOP_SHARE_HEIGHT)
-        track = rtc.LocalVideoTrack.create_video_track("assistant-desktop", source)
-        publication = await ctx.room.local_participant.publish_track(
-            track,
-            rtc.TrackPublishOptions(source=rtc.TrackSource.SOURCE_SCREENSHARE),
-        )
-        _desktop_share_source = source
-        _desktop_share_sid = publication.sid
-        _desktop_share_task = asyncio.create_task(_desktop_share_loop())
-        _log.screenshot("Desktop share: publishing to the meeting")
-        return True
-
-    async def _stop_desktop_share() -> None:
-        """Unpublish the desktop track and stop capturing. Idempotent."""
-        nonlocal _desktop_share_task, _desktop_share_source, _desktop_share_sid
-
-        if _desktop_share_task is not None:
-            await utils.aio.cancel_and_wait(_desktop_share_task)
-            _desktop_share_task = None
-        if _desktop_share_sid:
-            try:
-                await ctx.room.local_participant.unpublish_track(_desktop_share_sid)
-            except Exception as exc:  # noqa: BLE001 - teardown must reach its end
-                _log.screenshot(f"Desktop share: unpublish failed: {exc!r}")
-            _desktop_share_sid = ""
-        _desktop_share_source = None
-
-    def on_desktop_share(data: dict) -> None:
-        """Start or stop publishing the desktop, as the slow brain asks.
-
-        The tool runs in the CM, but only this process is in the LiveKit room, so
-        the decision arrives over IPC and the publishing happens here.
-        """
-        if bool(data.get("active")):
-            asyncio.create_task(_start_desktop_share())
-        else:
-            asyncio.create_task(_stop_desktop_share())
-
-    event_broker.register_callback("app:call:desktop_share", on_desktop_share)
 
     @session.on("conversation_item_added")
     def _on_chat_item_added(ev):

--- a/unify/workflow_manager/__init__.py
+++ b/unify/workflow_manager/__init__.py
@@ -1,0 +1,24 @@
+from .base import BaseWorkflowManager
+from .bundle import (
+    Surface,
+    SurfaceRegistry,
+    UnscopedSurfaceError,
+    WorkflowBundle,
+)
+from .surfaces import PENDING_SCOPING, SOURCE_SCOPED, register_default_surfaces
+from .types.workflow import WorkflowInstallation, WorkflowMode
+from .workflow_manager import WorkflowManager
+
+__all__ = [
+    "PENDING_SCOPING",
+    "SOURCE_SCOPED",
+    "BaseWorkflowManager",
+    "Surface",
+    "SurfaceRegistry",
+    "UnscopedSurfaceError",
+    "WorkflowBundle",
+    "WorkflowInstallation",
+    "WorkflowManager",
+    "WorkflowMode",
+    "register_default_surfaces",
+]

--- a/unify/workflow_manager/base.py
+++ b/unify/workflow_manager/base.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+from abc import abstractmethod
+from typing import Any, Dict, Optional
+
+from ..common.state_managers import BaseStateManager
+from ..manager_registry import SingletonABCMeta
+
+
+class BaseWorkflowManager(BaseStateManager, metaclass=SingletonABCMeta):
+    """
+    Public contract for a catalogue of installable workflows.
+
+    Overview
+    --------
+    A workflow is a bundle: one named, versioned package that plants
+    content across several surfaces at once — procedures, durable tasks,
+    typed claims, functions — so that a job the assistant does regularly
+    arrives set up rather than assembled by hand. "Draft my email replies
+    every morning" is a workflow: it is not one task but a mailbox pull, a
+    contact backfill, a set of procedures for tone and triage, and a
+    recurring task that depends on all of them.
+
+    Installing a workflow writes its content into the ordinary surfaces.
+    There is no separate place workflow content lives and no second
+    lookup path: procedures a workflow planted are found by the same
+    search as any other, and tasks it planted run like any other. What
+    installation adds is provenance — every planted row records which
+    workflow put it there — so a workflow can later be updated or removed
+    as a unit.
+
+    Modes
+    -----
+    Installation chooses how long the bundle keeps ownership:
+
+    - ``"seed"`` plants the content once and then lets go. Edits stick,
+      and later versions of the bundle leave the rows alone. Use this
+      when the workflow is a starting point the user is expected to
+      shape.
+    - ``"pinned"`` keeps reconciling. Edits to planted rows are
+      overwritten from the bundle on the next pass, and content dropped
+      from the bundle is removed. Use this when the workflow must stay
+      correct centrally and local drift is a defect.
+
+    Mode is about upkeep, not secrecy: under both modes the planted rows
+    are visible, readable, and attributed to the workflow.
+
+    Parameters
+    ----------
+    A bundle may declare install-time settings — which mailbox to read,
+    which calendar to write to. These are recorded on the installation
+    and read by the workflow's own tasks when they run. They are never
+    written into the planted rows: two people installing one workflow get
+    byte-identical content and differ only in their settings.
+
+    Data Model
+    ----------
+    Installations conform to
+    ``unify.workflow_manager.types.workflow.WorkflowInstallation``.
+    Implementations may return instances of this model or JSON-serialisable
+    dictionaries matching its schema.
+
+    Shared-Space Semantics
+    ----------------------
+    Reads cover personal installations plus every accessible shared team
+    installation. Writes default to personal. Installing to a team plants
+    the workflow's content for every member of that team, so it carries
+    wider consequences than a personal install.
+    """
+
+    _as_caller_description: str = "the WorkflowManager, managing installed workflows"
+
+    @abstractmethod
+    def list_workflows(
+        self,
+        *,
+        installed: Optional[bool] = None,
+        offset: int = 0,
+        limit: int = 100,
+    ) -> Dict[str, Any]:
+        """
+        List workflows, installed and available.
+
+        Use this before installing anything, both to check whether the
+        capability the user is asking for is already set up and to find
+        the exact ``slug`` to install.
+
+        Parameters
+        ----------
+        installed:
+            ``True`` for installed workflows only, ``False`` for available
+            but not installed, ``None`` (default) for both.
+        offset:
+            Number of entries to skip.
+        limit:
+            Maximum entries to return.
+
+        Returns
+        -------
+        A dict with ``workflows`` (a list of entries, each carrying at
+        least ``slug``, ``name``, ``description``, and ``installed``) and
+        ``total``.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def install_workflow(
+        self,
+        *,
+        slug: str,
+        mode: str = "seed",
+        params: Optional[Dict[str, Any]] = None,
+        destination: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """
+        Install a workflow, planting its content across the surfaces it covers.
+
+        This writes real content the user will see: new procedures, new
+        recurring tasks that will start firing on their schedule, new
+        typed claims. Confirm with the user before installing anything
+        they did not explicitly ask for, and tell them what it set up
+        afterwards — particularly any recurring task, since that will act
+        on its own later.
+
+        Installing a workflow that is already installed reconciles it to
+        the current bundle instead of duplicating it.
+
+        Parameters
+        ----------
+        slug:
+            Bundle identifier from ``list_workflows``.
+        mode:
+            ``"seed"`` (default) to plant once and leave the content
+            editable, or ``"pinned"`` to keep it reconciled to the bundle.
+            Prefer ``"seed"`` unless the user wants the workflow to stay
+            centrally managed: pinned content silently reverts local edits,
+            which surprises people who tuned a procedure and found it back
+            the way it started.
+        params:
+            Install-time settings declared by the bundle, e.g. which
+            mailbox to work from. Ask the user for any the bundle requires
+            rather than guessing.
+        destination:
+            ``None`` for personal, or ``team:<id>`` to install for a whole
+            team. A team install plants content for every member.
+
+        Returns
+        -------
+        A dict with the resulting installation and a ``planted`` summary
+        of what was written per surface.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def uninstall_workflow(
+        self,
+        *,
+        slug: str,
+        destination: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """
+        Remove a workflow and the content it planted.
+
+        This deletes the rows the workflow put in place, including any
+        recurring tasks it created, so those stop firing. Content the user
+        added themselves is untouched, and so is anything another workflow
+        planted. Confirm before calling: under ``"seed"`` mode the user may
+        have spent time editing the planted rows, and those edits go too.
+
+        Parameters
+        ----------
+        slug:
+            Bundle identifier of the installation to remove.
+        destination:
+            ``None`` for personal, or ``team:<id>``.
+
+        Returns
+        -------
+        A dict with a ``removed`` summary of what was deleted per surface.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_workflow(self, *, slug: str) -> Dict[str, Any]:
+        """
+        Read one workflow's full record: its description, whether it is
+        installed, at which version and mode, its current settings, and
+        which surfaces it covers.
+
+        Use this to answer questions about what a workflow does or what a
+        given installation is currently set to, and to read back the
+        settings before changing one.
+
+        Parameters
+        ----------
+        slug:
+            Bundle identifier.
+
+        Returns
+        -------
+        The workflow record, or a not-found result if no such bundle exists.
+        """
+        raise NotImplementedError

--- a/unify/workflow_manager/bundle.py
+++ b/unify/workflow_manager/bundle.py
@@ -1,0 +1,145 @@
+"""Workflow bundles and the surfaces they may write to.
+
+A bundle is content plus identity: a slug, a version, and one collected
+source dict per surface it plants into. The dicts are already in the
+shape the owning manager's ``sync_custom`` takes — ``{custom_key:
+{field: value, ...}}`` — so installing is a fan-out of ordinary custom
+syncs, not a second reconcile mechanism.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Mapping
+
+from unify.workflow_manager.types.workflow import WorkflowMode
+
+SurfaceSyncer = Callable[..., bool]
+"""A manager's ``sync_custom``, called with its source kwarg and ``source_id``."""
+
+
+class UnscopedSurfaceError(RuntimeError):
+    """A surface was registered before its adapter honours ``source_id``.
+
+    Registering an unscoped surface is not a degraded mode, it is data
+    loss: that manager's ``live_rows`` still selects every managed row in
+    the context, so the first workflow to sync there prunes the
+    deployment's rows, and the deployment's next pass prunes the
+    workflow's. The registry refuses rather than letting the fan-out
+    reach such a manager.
+    """
+
+    def __init__(self, surface: str) -> None:
+        self.surface = surface
+        super().__init__(
+            f"Surface {surface!r} is not source-scoped; registering it "
+            "would let workflows and the deployment prune each other's "
+            "rows. Thread source_id through that manager's adapter first.",
+        )
+
+
+@dataclass(frozen=True)
+class Surface:
+    """One manager's custom-sync entry point, as a workflow may drive it."""
+
+    name: str
+    """Bundle key, e.g. ``"guidance"``."""
+
+    syncer: SurfaceSyncer
+    """The manager's ``sync_custom``."""
+
+    source_kwarg: str
+    """Keyword its collected source arrives on, e.g. ``"source_guidance"``."""
+
+    def sync(self, source: Mapping[str, Dict[str, Any]], *, source_id: str) -> bool:
+        return self.syncer(**{self.source_kwarg: dict(source)}, source_id=source_id)
+
+
+@dataclass
+class WorkflowBundle:
+    """A workflow's identity and its per-surface content."""
+
+    slug: str
+    name: str
+    version: str = ""
+    description: str = ""
+    mode: WorkflowMode = WorkflowMode.seed
+    surfaces: Dict[str, Dict[str, Dict[str, Any]]] = field(default_factory=dict)
+    """Surface name -> collected source, keyed by ``custom_key``."""
+
+    params_schema: Dict[str, Any] = field(default_factory=dict)
+    """Declared install-time settings. Values are supplied per install and
+    read at run time; they never enter the collected sources above."""
+
+    def __post_init__(self) -> None:
+        if not self.slug:
+            raise ValueError("A workflow bundle needs a slug.")
+        if self.slug == "deployment":
+            raise ValueError(
+                "'deployment' is the reserved source_id for the assistant's "
+                "own sources; a bundle may not claim it.",
+            )
+
+    def content_hash(self) -> str:
+        """Fingerprint of everything this bundle would plant.
+
+        Covers the collected sources and the version, so a bundle whose
+        content is unchanged short-circuits its whole fan-out. Params are
+        excluded by construction: they are not part of what gets planted,
+        and folding them in would give two installations of one bundle
+        different hashes for identical rows.
+        """
+
+        payload = json.dumps(
+            {"version": self.version, "surfaces": self.surfaces},
+            sort_keys=True,
+            default=str,
+        )
+        return hashlib.sha256(payload.encode()).hexdigest()
+
+    def surface_names(self) -> list[str]:
+        return sorted(self.surfaces)
+
+
+class SurfaceRegistry:
+    """The surfaces a workflow install is allowed to fan out to.
+
+    Deliberately explicit. A manager appears here only once its adapter
+    scopes ``live_rows`` and its collision probe to ``source_id``; until
+    then :class:`UnscopedSurfaceError` keeps workflows away from it.
+    """
+
+    def __init__(self) -> None:
+        self._surfaces: Dict[str, Surface] = {}
+
+    def register(
+        self,
+        name: str,
+        syncer: SurfaceSyncer,
+        *,
+        source_kwarg: str,
+        source_scoped: bool,
+    ) -> None:
+        if not source_scoped:
+            raise UnscopedSurfaceError(name)
+        self._surfaces[name] = Surface(
+            name=name,
+            syncer=syncer,
+            source_kwarg=source_kwarg,
+        )
+
+    def get(self, name: str) -> Surface:
+        if name not in self._surfaces:
+            raise KeyError(
+                f"No surface {name!r} is registered; workflows may write to "
+                f"{sorted(self._surfaces) or 'nothing'}.",
+            )
+        return self._surfaces[name]
+
+    def names(self) -> list[str]:
+        return sorted(self._surfaces)
+
+    def __contains__(self, name: object) -> bool:
+        return name in self._surfaces

--- a/unify/workflow_manager/surfaces.py
+++ b/unify/workflow_manager/surfaces.py
@@ -1,0 +1,76 @@
+"""Which managers a workflow may plant into.
+
+The list is short on purpose. A surface belongs here only once its
+custom-sync adapter scopes ``live_rows`` and its collision probe to
+``source_id``; until then the reconcile loop's prune step cannot tell one
+source's rows from another's, and the first workflow to sync would delete
+the deployment's content. :data:`SOURCE_SCOPED` is the record of which
+managers have crossed that line.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Mapping
+
+from .bundle import SurfaceRegistry
+
+if TYPE_CHECKING:  # pragma: no cover
+    from ..guidance_manager.guidance_manager import GuidanceManager
+    from ..knowledge_manager.knowledge_manager import KnowledgeManager
+    from ..task_scheduler.task_scheduler import TaskScheduler
+
+
+SOURCE_SCOPED: Mapping[str, str] = {
+    "guidance": "source_guidance",
+    "knowledge": "source_claims",
+    "tasks": "source_tasks",
+}
+"""Surface name -> the kwarg its manager's ``sync_custom`` takes.
+
+Adding an entry here is a claim that the manager's adapter is scoped.
+Make the adapter change first; this mapping is the consequence, not the
+mechanism.
+"""
+
+PENDING_SCOPING: tuple[str, ...] = (
+    "contacts",
+    "secrets",
+    "blacklist",
+    "data",
+    "dashboards",
+    "functions",
+    "venvs",
+    "integration_registry",
+)
+"""Surfaces workflows cannot reach yet, listed so the gap is visible
+rather than merely absent."""
+
+
+def register_default_surfaces(
+    registry: SurfaceRegistry,
+    *,
+    guidance_manager: "GuidanceManager | None" = None,
+    knowledge_manager: "KnowledgeManager | None" = None,
+    task_scheduler: "TaskScheduler | None" = None,
+) -> SurfaceRegistry:
+    """Wire every source-scoped manager that was supplied.
+
+    Managers passed as ``None`` are skipped, so a caller holding only some
+    of them gets a registry covering exactly those.
+    """
+
+    managers: dict[str, Any] = {
+        "guidance": guidance_manager,
+        "knowledge": knowledge_manager,
+        "tasks": task_scheduler,
+    }
+    for name, manager in managers.items():
+        if manager is None:
+            continue
+        registry.register(
+            name,
+            manager.sync_custom,
+            source_kwarg=SOURCE_SCOPED[name],
+            source_scoped=True,
+        )
+    return registry

--- a/unify/workflow_manager/types/__init__.py
+++ b/unify/workflow_manager/types/__init__.py
@@ -1,0 +1,9 @@
+from .meta import WorkflowMeta
+from .workflow import UNASSIGNED, WorkflowInstallation, WorkflowMode
+
+__all__ = [
+    "UNASSIGNED",
+    "WorkflowInstallation",
+    "WorkflowMeta",
+    "WorkflowMode",
+]

--- a/unify/workflow_manager/types/meta.py
+++ b/unify/workflow_manager/types/meta.py
@@ -1,0 +1,18 @@
+"""Pydantic model for the ``Workflows/Meta`` context."""
+
+from pydantic import Field
+
+from unify.common.authorship import AuthoredRow
+
+
+class WorkflowMeta(AuthoredRow):
+    """Metadata record for source-defined workflow catalogue sync state."""
+
+    meta_id: int = Field(
+        1,
+        description="Fixed ID for the single metadata row.",
+    )
+    custom_workflow_hash: str = Field(
+        "",
+        description="Hash of all source-defined workflow installations.",
+    )

--- a/unify/workflow_manager/types/workflow.py
+++ b/unify/workflow_manager/types/workflow.py
@@ -1,0 +1,138 @@
+"""Pydantic model for the ``Workflows`` context."""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import ClassVar
+
+from pydantic import Field, model_validator
+
+from unify.common.authorship import AuthoredRow
+
+UNASSIGNED = -1
+
+
+class WorkflowMode(str, Enum):
+    """How long a workflow keeps ownership of the rows it planted.
+
+    The mode is policy, not provenance. Every row a workflow writes
+    carries its ``source_id`` under either mode, so "what did this
+    workflow plant?" always has an answer. What the mode decides is
+    whether the bundle keeps reconciling those rows.
+    """
+
+    pinned = "pinned"
+    """Reconciled on every pass. Source supremacy applies: local edits to
+    a planted row are overwritten from the bundle, and a row whose key
+    left the bundle is pruned. Use for content the workflow must be able
+    to fix or evolve centrally."""
+
+    seed = "seed"
+    """Reconciled exactly once, at install. The rows are then left alone
+    forever — later passes skip the bundle entirely, so edits survive and
+    a key leaving the bundle prunes nothing. Use for a starting point the
+    user is meant to grow past."""
+
+
+class WorkflowInstallation(AuthoredRow):
+    """One installed workflow bundle.
+
+    The row is the installation, not the bundle: it records which bundle
+    was installed, at which version, under which mode, and which surfaces
+    it wrote to. The bundle's *content* lives in the surfaces themselves
+    (guidance rows, task rows, ...), each stamped with this row's
+    :attr:`slug` as its ``source_id``.
+    """
+
+    SHORTHAND_MAP: ClassVar[dict[str, str]] = {
+        "workflow_id": "wid",
+        "slug": "s",
+        "name": "n",
+        "version": "v",
+        "mode": "m",
+        "status": "st",
+        "params": "p",
+        "surfaces": "sf",
+        "destination": "dst",
+    }
+
+    workflow_id: int = Field(
+        default=UNASSIGNED,
+        description="Unique identifier for the installation.",
+        ge=UNASSIGNED,
+    )
+    slug: str = Field(
+        description=(
+            "Stable bundle identifier, e.g. 'draft_email_replies'. Doubles "
+            "as the custom-sync source_id stamped onto every row this "
+            "workflow plants, so it must not change across versions."
+        ),
+    )
+    name: str = Field(
+        description="Human-readable workflow name.",
+        json_schema_extra={"ui_editable": True},
+    )
+    version: str = Field(
+        default="",
+        description="Bundle version last reconciled into the surfaces.",
+    )
+    description: str = Field(
+        default="",
+        description="What the workflow does, shown when listing workflows.",
+    )
+    mode: WorkflowMode = Field(
+        default=WorkflowMode.seed,
+        description=(
+            "'pinned' to keep reconciling the planted rows from the "
+            "bundle, 'seed' to plant once and leave them to the user."
+        ),
+    )
+    status: str = Field(
+        default="installed",
+        description=(
+            "'installed' when the last reconcile completed, 'partial' when "
+            "some entries failed and the next pass will retry them."
+        ),
+    )
+    params: str = Field(
+        default="{}",
+        description=(
+            "JSON object of install-time settings, read at run time by the "
+            "workflow's own tasks and functions. Never baked into the "
+            "planted rows: doing so would make their content hashes differ "
+            "per installation."
+        ),
+    )
+    surfaces: str = Field(
+        default="[]",
+        description=(
+            "JSON array of surface names this workflow wrote to, e.g. "
+            '["guidance", "tasks"]. Recorded so uninstall can find the '
+            "planted rows without the bundle still being on disk."
+        ),
+    )
+    destination: str = Field(
+        default="personal",
+        description="Root that owns this installation, personal or team:<id>.",
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _inject_sentinel(cls, data: dict) -> dict:
+        data.setdefault("workflow_id", UNASSIGNED)
+        return data
+
+    def to_post_json(self) -> dict:
+        """Dump for POST; omit the sentinel id when unassigned."""
+        exclude = {"destination"}
+        if self.workflow_id == UNASSIGNED:
+            exclude.add("workflow_id")
+        return self.model_dump(mode="json", exclude=exclude)
+
+    @classmethod
+    def shorthand_map(cls) -> dict[str, str]:
+        return dict(cls.SHORTHAND_MAP)
+
+    @classmethod
+    def shorthand_inverse_map(cls) -> dict[str, str]:
+        return {v: k for k, v in cls.SHORTHAND_MAP.items()}

--- a/unify/workflow_manager/workflow_manager.py
+++ b/unify/workflow_manager/workflow_manager.py
@@ -1,0 +1,488 @@
+"""Installable workflow bundles.
+
+Installing a workflow is a fan-out of ordinary custom syncs, one per
+surface the bundle covers, each stamped with the bundle's slug as its
+``source_id``. That is the whole mechanism: there is no second reconcile
+loop, no parallel store for workflow content, and no lookup path that
+knows about workflows. What the slug buys is provenance — the ability to
+ask a surface "which rows did this bundle plant?" and get an exact
+answer, which is what makes update and uninstall possible at all.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+from typing import Any, Dict, List, Mapping, Optional
+
+import unisdk
+
+from ..common.authorship import strip_authoring_assistant_id
+from ..common.context_registry import ContextRegistry, TableContext
+from ..common.custom_sync import CustomSyncPartialFailure
+from ..common.embed_utils import list_private_fields
+from ..common.log_utils import create_logs as unity_create_logs
+from ..common.model_to_fields import model_to_fields
+from ..common.sync_lease import exclusive_sync_lease
+from ..common.tool_outcome import ToolErrorException
+from .base import BaseWorkflowManager
+from .bundle import SurfaceRegistry, WorkflowBundle
+from .types.meta import WorkflowMeta
+from .types.workflow import UNASSIGNED, WorkflowInstallation, WorkflowMode
+
+logger = logging.getLogger(__name__)
+
+WORKFLOW_TABLE = "Workflows"
+WORKFLOW_META_TABLE = "Workflows/Meta"
+
+
+class WorkflowManager(BaseWorkflowManager):
+    """Catalogue of available workflow bundles and their installations."""
+
+    class Config:
+        required_contexts = [
+            TableContext(
+                name=WORKFLOW_TABLE,
+                description="Installed workflow bundles and their settings.",
+                fields=model_to_fields(WorkflowInstallation),
+                unique_keys={"workflow_id": "int"},
+                auto_counting={"workflow_id": None},
+            ),
+            TableContext(
+                name=WORKFLOW_META_TABLE,
+                description="Metadata for workflow catalogue sync state.",
+                fields=model_to_fields(WorkflowMeta),
+                unique_keys={"meta_id": "int"},
+            ),
+        ]
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._ctx = ContextRegistry.get_context(self, WORKFLOW_TABLE)
+        self._meta_ctx = ContextRegistry.get_context(self, WORKFLOW_META_TABLE)
+        self._surfaces = SurfaceRegistry()
+        self._catalogue: Dict[str, WorkflowBundle] = {}
+        self._lock = threading.RLock()
+
+    # ------------------------------------------------------------------ #
+    # Wiring                                                             #
+    # ------------------------------------------------------------------ #
+    @property
+    def surfaces(self) -> SurfaceRegistry:
+        return self._surfaces
+
+    def register_bundle(self, bundle: WorkflowBundle) -> None:
+        """Add a bundle to the catalogue of installable workflows.
+
+        Raises if the bundle covers a surface no manager has registered,
+        so a bundle referencing an unscoped or absent surface fails at
+        registration rather than half-planting itself at install.
+        """
+
+        unknown = [s for s in bundle.surface_names() if s not in self._surfaces]
+        if unknown:
+            raise KeyError(
+                f"Bundle {bundle.slug!r} covers unregistered surfaces "
+                f"{unknown}; registered surfaces are {self._surfaces.names()}.",
+            )
+        with self._lock:
+            self._catalogue[bundle.slug] = bundle
+
+    def available_bundles(self) -> List[WorkflowBundle]:
+        with self._lock:
+            return [self._catalogue[s] for s in sorted(self._catalogue)]
+
+    # ------------------------------------------------------------------ #
+    # Destination resolution                                             #
+    # ------------------------------------------------------------------ #
+    def _workflow_context_for_destination(self, destination: str | None) -> str:
+        root = ContextRegistry.write_root(
+            self,
+            WORKFLOW_TABLE,
+            destination=destination,
+        )
+        return f"{root.strip('/')}/{WORKFLOW_TABLE}"
+
+    def _meta_context_for_destination(self, destination: str | None) -> str:
+        root = ContextRegistry.write_root(
+            self,
+            WORKFLOW_META_TABLE,
+            destination=destination,
+        )
+        return f"{root.strip('/')}/{WORKFLOW_META_TABLE}"
+
+    def _read_contexts(self) -> List[str]:
+        roots = ContextRegistry.read_roots(self, WORKFLOW_TABLE)
+        contexts = [f"{root.strip('/')}/{WORKFLOW_TABLE}" for root in roots]
+        return list(dict.fromkeys(contexts))
+
+    # ------------------------------------------------------------------ #
+    # Installation rows                                                  #
+    # ------------------------------------------------------------------ #
+    def _read_installation(
+        self,
+        slug: str,
+        *,
+        context: str,
+    ) -> Optional[Dict[str, Any]]:
+        logs = unisdk.get_logs(
+            context=context,
+            filter=f"slug == '{slug}'",
+            exclude_fields=list_private_fields(context),
+            limit=1,
+        )
+        if not logs:
+            return None
+        return dict(logs[0].entries or {})
+
+    def _installations(self) -> List[Dict[str, Any]]:
+        rows: List[Dict[str, Any]] = []
+        for context in self._read_contexts():
+            logs = unisdk.get_logs(
+                context=context,
+                exclude_fields=list_private_fields(context),
+            )
+            rows.extend(dict(lg.entries or {}) for lg in logs)
+        return rows
+
+    def _write_installation(
+        self,
+        record: WorkflowInstallation,
+        *,
+        context: str,
+        existing: Optional[Dict[str, Any]],
+    ) -> None:
+        payload = strip_authoring_assistant_id(record.to_post_json())
+        if existing:
+            logs = unisdk.get_logs(
+                context=context,
+                filter=f"slug == '{record.slug}'",
+                limit=1,
+            )
+            if logs:
+                payload.pop("workflow_id", None)
+                unisdk.update_logs(
+                    context=context,
+                    logs=[logs[0].id],
+                    entries=payload,
+                    overwrite=True,
+                )
+                return
+        unity_create_logs(
+            context=context,
+            entries=[payload],
+            stamp_authoring=True,
+        )
+
+    def _delete_installation(self, slug: str, *, context: str) -> bool:
+        logs = unisdk.get_logs(
+            context=context,
+            filter=f"slug == '{slug}'",
+            limit=1,
+        )
+        if not logs:
+            return False
+        unisdk.delete_logs(context=context, logs=[logs[0].id])
+        return True
+
+    # ------------------------------------------------------------------ #
+    # Fan-out                                                            #
+    # ------------------------------------------------------------------ #
+    def _plant(
+        self,
+        bundle: WorkflowBundle,
+        *,
+        surface_names: Optional[List[str]] = None,
+        empty: bool = False,
+    ) -> tuple[Dict[str, Any], Dict[str, BaseException]]:
+        """Sync each covered surface under the bundle's slug.
+
+        With ``empty=True`` every surface receives an empty source, which
+        prunes exactly the rows carrying this slug and leaves every other
+        source's rows — the deployment's, another workflow's, the user's
+        own — untouched. That is uninstall, and it is the same code path
+        as install precisely because the scoping is what does the work.
+        """
+
+        planted: Dict[str, Any] = {}
+        failures: Dict[str, BaseException] = {}
+        names = surface_names if surface_names is not None else bundle.surface_names()
+
+        for name in names:
+            source = {} if empty else bundle.surfaces.get(name, {})
+            try:
+                surface = self._surfaces.get(name)
+                changed = surface.sync(source, source_id=bundle.slug)
+                planted[name] = {"entries": len(source), "changed": bool(changed)}
+            except CustomSyncPartialFailure as exc:
+                failures[name] = exc
+                planted[name] = {
+                    "entries": len(source),
+                    "changed": True,
+                    "failed_keys": sorted(exc.failures),
+                }
+            except Exception as exc:
+                failures[name] = exc
+                planted[name] = {"entries": len(source), "error": str(exc)}
+
+        return planted, failures
+
+    @staticmethod
+    def _validate_params(
+        bundle: WorkflowBundle,
+        params: Mapping[str, Any],
+    ) -> Dict[str, Any]:
+        required = {
+            name
+            for name, spec in bundle.params_schema.items()
+            if isinstance(spec, Mapping) and spec.get("required")
+        }
+        missing = sorted(required - set(params))
+        if missing:
+            raise ToolErrorException(
+                {
+                    "error": "missing_params",
+                    "slug": bundle.slug,
+                    "missing": missing,
+                    "message": (
+                        f"Workflow {bundle.slug!r} needs {missing} before it "
+                        "can be installed."
+                    ),
+                },
+            )
+        return dict(params)
+
+    # ------------------------------------------------------------------ #
+    # Public API                                                         #
+    # ------------------------------------------------------------------ #
+    def list_workflows(
+        self,
+        *,
+        installed: Optional[bool] = None,
+        offset: int = 0,
+        limit: int = 100,
+    ) -> Dict[str, Any]:
+        by_slug = {row.get("slug"): row for row in self._installations()}
+        entries: List[Dict[str, Any]] = []
+
+        for bundle in self.available_bundles():
+            row = by_slug.get(bundle.slug)
+            is_installed = row is not None
+            if installed is True and not is_installed:
+                continue
+            if installed is False and is_installed:
+                continue
+            entry = {
+                "slug": bundle.slug,
+                "name": bundle.name,
+                "description": bundle.description,
+                "version": bundle.version,
+                "surfaces": bundle.surface_names(),
+                "installed": is_installed,
+            }
+            if row:
+                entry.update(
+                    {
+                        "installed_version": row.get("version", ""),
+                        "mode": row.get("mode"),
+                        "status": row.get("status"),
+                        "params": json.loads(row.get("params") or "{}"),
+                    },
+                )
+            entries.append(entry)
+
+        # Installations whose bundle has left the catalogue still exist and
+        # still own rows; hiding them would make their content unremovable.
+        for slug, row in by_slug.items():
+            if any(e["slug"] == slug for e in entries):
+                continue
+            if installed is False:
+                continue
+            entries.append(
+                {
+                    "slug": slug,
+                    "name": row.get("name", slug),
+                    "description": row.get("description", ""),
+                    "installed": True,
+                    "orphaned": True,
+                    "installed_version": row.get("version", ""),
+                    "mode": row.get("mode"),
+                    "surfaces": json.loads(row.get("surfaces") or "[]"),
+                },
+            )
+
+        entries.sort(key=lambda e: e["slug"])
+        return {
+            "workflows": entries[offset : offset + limit],
+            "total": len(entries),
+        }
+
+    def install_workflow(
+        self,
+        *,
+        slug: str,
+        mode: str = "seed",
+        params: Optional[Dict[str, Any]] = None,
+        destination: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        with self._lock:
+            bundle = self._catalogue.get(slug)
+        if bundle is None:
+            raise ToolErrorException(
+                {
+                    "error": "unknown_workflow",
+                    "slug": slug,
+                    "available": [b.slug for b in self.available_bundles()],
+                },
+            )
+
+        try:
+            resolved_mode = WorkflowMode(mode)
+        except ValueError:
+            raise ToolErrorException(
+                {
+                    "error": "invalid_mode",
+                    "mode": mode,
+                    "expected": [m.value for m in WorkflowMode],
+                },
+            )
+
+        resolved_params = self._validate_params(bundle, params or {})
+        context = self._workflow_context_for_destination(destination)
+        meta_context = self._meta_context_for_destination(destination)
+
+        with exclusive_sync_lease(f"{meta_context}:workflow_install"):
+            existing = self._read_installation(slug, context=context)
+
+            # Seed plants once. A repeat install refreshes the settings and
+            # leaves the content alone, because the whole point of seed mode
+            # is that what the user did to those rows since is theirs.
+            already_seeded = (
+                existing is not None
+                and existing.get("mode") == WorkflowMode.seed.value
+                and resolved_mode is WorkflowMode.seed
+                and existing.get("status") == "installed"
+            )
+
+            if already_seeded:
+                planted: Dict[str, Any] = {}
+                failures: Dict[str, BaseException] = {}
+            else:
+                planted, failures = self._plant(bundle)
+
+            record = WorkflowInstallation(
+                workflow_id=(
+                    existing.get("workflow_id", UNASSIGNED) if existing else UNASSIGNED
+                ),
+                slug=bundle.slug,
+                name=bundle.name,
+                version=bundle.version,
+                description=bundle.description,
+                mode=resolved_mode,
+                status="partial" if failures else "installed",
+                params=json.dumps(resolved_params, sort_keys=True),
+                surfaces=json.dumps(bundle.surface_names()),
+                destination=destination or "personal",
+            )
+            self._write_installation(record, context=context, existing=existing)
+
+        result: Dict[str, Any] = {
+            "installed": record.model_dump(mode="json"),
+            "planted": planted,
+            "content_unchanged": already_seeded,
+        }
+        if failures:
+            result["failures"] = {n: str(e) for n, e in failures.items()}
+            logger.warning(
+                "Workflow %r installed with failures on surfaces: %s",
+                slug,
+                sorted(failures),
+            )
+        return result
+
+    def uninstall_workflow(
+        self,
+        *,
+        slug: str,
+        destination: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        context = self._workflow_context_for_destination(destination)
+        meta_context = self._meta_context_for_destination(destination)
+
+        with exclusive_sync_lease(f"{meta_context}:workflow_install"):
+            existing = self._read_installation(slug, context=context)
+            if existing is None:
+                raise ToolErrorException(
+                    {
+                        "error": "not_installed",
+                        "slug": slug,
+                    },
+                )
+
+            # Prefer the recorded surfaces over the bundle's: the bundle may
+            # have been dropped from the catalogue, or may cover a different
+            # set now than when it planted.
+            recorded = json.loads(existing.get("surfaces") or "[]")
+            bundle = self._catalogue.get(slug) or WorkflowBundle(
+                slug=slug,
+                name=existing.get("name", slug),
+            )
+
+            removed, failures = self._plant(
+                bundle,
+                surface_names=recorded,
+                empty=True,
+            )
+            if not failures:
+                self._delete_installation(slug, context=context)
+
+        result: Dict[str, Any] = {"slug": slug, "removed": removed}
+        if failures:
+            result["failures"] = {n: str(e) for n, e in failures.items()}
+            result["retained"] = True
+            logger.warning(
+                "Workflow %r left installed; surfaces failed to clear: %s",
+                slug,
+                sorted(failures),
+            )
+        return result
+
+    def get_workflow(self, *, slug: str) -> Dict[str, Any]:
+        bundle = self._catalogue.get(slug)
+        row = next(
+            (r for r in self._installations() if r.get("slug") == slug),
+            None,
+        )
+        if bundle is None and row is None:
+            return {"found": False, "slug": slug}
+
+        entry: Dict[str, Any] = {"found": True, "slug": slug}
+        if bundle:
+            entry.update(
+                {
+                    "name": bundle.name,
+                    "description": bundle.description,
+                    "version": bundle.version,
+                    "surfaces": bundle.surface_names(),
+                    "params_schema": bundle.params_schema,
+                    "entries_per_surface": {
+                        name: len(source) for name, source in bundle.surfaces.items()
+                    },
+                },
+            )
+        entry["installed"] = row is not None
+        if row:
+            entry.update(
+                {
+                    "installed_version": row.get("version", ""),
+                    "mode": row.get("mode"),
+                    "status": row.get("status"),
+                    "params": json.loads(row.get("params") or "{}"),
+                    "installed_surfaces": json.loads(row.get("surfaces") or "[]"),
+                    "destination": row.get("destination", "personal"),
+                },
+            )
+            if bundle is None:
+                entry["orphaned"] = True
+        return entry


### PR DESCRIPTION
Release PR from staging to main.

Carries the LLM cache work: unify now follows unillm's approach rather than the
GCS backing that was briefly on staging (reverted here).

- The shared store is published as an `llm-cache-ndjson` artifact. Artifacts are
  repo-scoped where the Actions cache is branch-scoped, which is the gap that
  bit us: a promotion PR into main runs with `base=main` and cannot restore an
  entry saved on staging, so every refresh this repo has dispatched -- all on
  staging until yesterday -- was unreadable from the PRs that needed it.
- Hydration is gated on an Actions-cache miss rather than unconditional as in
  unillm, because our store is gigabytes and the matrix fans out.
- A monthly keepalive rolls the artifact into a fresh retention window with no
  provider calls, so 90-day retention cannot quietly become the moment the
  store dies.

Also included: the publish guard and uv cache changes already on main, plus the
flows conftest fix that depends on `unillm.set_cache_dir` (merged to unillm main
in unifyai/unillm#107, so unillm@main has it before this lands).