### PR TITLE
Release: staging → main

### DIFF
--- a/.github/scripts/consolidate_cache.py
+++ b/.github/scripts/consolidate_cache.py
@@ -1,6 +1,7 @@
 import argparse
+import hashlib
 from pathlib import Path
-from typing import List
+from typing import Iterator, List
 
 CACHE_READ_FILE_NAME = ".cache_write.ndjson"
 CACHE_WRITE_FILE_NAME = ".cache.ndjson"
@@ -14,30 +15,17 @@ def find_cache_files(artifacts_dir: Path) -> List[Path]:
     return sorted(files)
 
 
-def _read_nonempty_lines(path: Path) -> List[str]:
+def _read_nonempty_lines(path: Path) -> Iterator[str]:
     if not path.exists() or not path.is_file():
-        return []
+        return
     with path.open("r", encoding="utf-8") as f:
-        lines = []
-        for line in f.readlines():
+        for line in f:
             if line.strip():
                 # Ensure each line ends with newline to prevent concatenation
                 # when merging files (last line of a file may lack trailing \n)
                 if not line.endswith("\n"):
                     line = line + "\n"
-                lines.append(line)
-        return lines
-
-
-def _merge_unique_preserve_order(*sequences: List[str]) -> List[str]:
-    seen = set()
-    merged: List[str] = []
-    for seq in sequences:
-        for line in seq:
-            if line not in seen:
-                seen.add(line)
-                merged.append(line)
-    return merged
+                yield line
 
 
 def concatenate_files(
@@ -47,22 +35,39 @@ def concatenate_files(
 ) -> int:
     output_file.parent.mkdir(parents=True, exist_ok=True)
 
-    # 1) Start from the previously consolidated global cache (if any)
-    base_lines = _read_nonempty_lines(existing_cache_file)
+    # Streamed rather than read into lists. Inputs here include the whole
+    # upstream store as well as the base, and a cache entry is large -- the
+    # median is around 100 KB -- so holding two full copies in memory would
+    # scale with the store instead of with its entry count. Dedupe on a digest
+    # per line: 32 bytes each, so the only resident structure stays in the
+    # megabytes however far the store grows.
+    seen: set[bytes] = set()
+    written = 0
 
-    # 2) Read all diff files
-    diff_lines: List[str] = []
-    for input_path in input_files:
-        non_empty_lines = _read_nonempty_lines(input_path)
-        diff_lines.extend(non_empty_lines)
-        print(f"Found {len(non_empty_lines)} diff lines in {input_path}")
+    # Written to a sibling first so a crash mid-merge cannot leave a truncated
+    # store behind: the output is usually the base being read.
+    staging = output_file.with_name(output_file.name + ".merging")
+    with staging.open("w", encoding="utf-8") as out_f:
+        # Base first, then the diffs, so first-seen order is preserved.
+        for line in _read_nonempty_lines(existing_cache_file):
+            digest = hashlib.sha256(line.encode("utf-8")).digest()
+            if digest not in seen:
+                seen.add(digest)
+                out_f.write(line)
+                written += 1
 
-    # 3) Merge uniquely while preserving first-seen order: base first, then new diffs
-    merged_lines = _merge_unique_preserve_order(base_lines, diff_lines)
+        for input_path in input_files:
+            found = 0
+            for line in _read_nonempty_lines(input_path):
+                found += 1
+                digest = hashlib.sha256(line.encode("utf-8")).digest()
+                if digest not in seen:
+                    seen.add(digest)
+                    out_f.write(line)
+                    written += 1
+            print(f"Found {found} diff lines in {input_path}")
 
-    # 4) Write once
-    with output_file.open("w", encoding="utf-8") as out_f:
-        out_f.writelines(merged_lines)
+    staging.replace(output_file)
 
     # Indexed backends rebuild from fingerprint; drop any stale sidecar so
     # the next process does not serve offsets against the replaced file.
@@ -75,7 +80,7 @@ def concatenate_files(
             sidecar.unlink()
             print(f"Removed stale index sidecar: {sidecar}")
 
-    return len(merged_lines)
+    return written
 
 
 def main() -> int:

--- a/.github/workflows/flow-smoke.yml
+++ b/.github/workflows/flow-smoke.yml
@@ -427,19 +427,13 @@ jobs:
         path: .cache.ndjson
         key: cache-ndjson-${{ runner.os }}-${{ github.run_id }}-${{ github.run_attempt }}
 
-    # The Actions copy above is branch-scoped and evictable, so the completions
-    # this gate paid for only outlive the branch as an artifact. Retention is
-    # the ceiling on how long the store survives without a refresh.
-    - name: Publish the cross-branch LLM cache artifact
-      if: always() && steps.consolidate.outputs.publish == 'true'
-      uses: actions/upload-artifact@v4
-      with:
-        name: llm-cache-ndjson
-        path: .cache.ndjson
-        if-no-files-found: error
-        include-hidden-files: true
-        compression-level: 0
-        retention-days: 90
+    # This job deliberately does not publish llm-cache-ndjson. Readers resolve
+    # that name to the most recently created one, so a publisher whose store is
+    # not a superset of the current artifact shadows it -- and this job's store
+    # is whatever its own branch happened to restore. Only the refresh merges
+    # the upstream artifact back in, so only the refresh can publish safely.
+    # What this gate buys still reaches the Actions cache above, and the next
+    # refresh folds it onward from there.
 
     - name: Stop local orchestra
       if: always()

--- a/.github/workflows/llm-cache-refresh.yml
+++ b/.github/workflows/llm-cache-refresh.yml
@@ -544,11 +544,18 @@ jobs:
     # is what stops a refresh from *shrinking* the store. On 29 July one
     # restored nothing, merged its own 52 entries, and published that over a
     # 9586-entry history.
-    - name: Hydrate .cache.ndjson from the cross-branch artifact
-      if: steps.cache-read.outputs.cache-matched-key == ''
+    # Staged as a diff and merged, not restored on a miss. The artifact is a
+    # separate lineage from the branch-scoped Actions cache, and this job
+    # republishes it: restoring 52 entries from a branch and uploading those as
+    # the newest artifact would shadow a far larger one, which is the same
+    # most-recently-created trap the Actions cache has. Merging makes what this
+    # job publishes a superset of both, so the upload is always safe to make.
+    - name: Stage the cross-branch artifact for consolidation
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: .github/scripts/hydrate_llm_cache.sh
+      run: |
+        mkdir -p cache-artifacts/upstream
+        .github/scripts/hydrate_llm_cache.sh cache-artifacts/upstream/.cache_write.ndjson
 
     - name: Download cache diffs from matrix shards
       uses: actions/download-artifact@v4
@@ -567,15 +574,19 @@ jobs:
         # all when the file is missing, so neither case may abort the step.
         entries() { local n; n=$(grep -c . "$1" 2>/dev/null || true); echo "${n:-0}"; }
         restored=$(entries .cache.ndjson)
-        # Decided here rather than in the step condition so that dying before
-        # the comparison leaves the answer at "do not publish".
+        # Decided here rather than in the step conditions so that dying before
+        # the comparison leaves both answers at "do not publish".
         echo "publish=false" >> "$GITHUB_OUTPUT"
+        echo "has_entries=false" >> "$GITHUB_OUTPUT"
         python3 .github/scripts/consolidate_cache.py --artifacts-dir cache-artifacts
         # actions/cache/save fails if the path is absent.
         touch .cache.ndjson
         merged=$(entries .cache.ndjson)
         if (( merged > restored )); then
           echo "publish=true" >> "$GITHUB_OUTPUT"
+        fi
+        if (( merged > 0 )); then
+          echo "has_entries=true" >> "$GITHUB_OUTPUT"
         fi
         echo "Consolidated entry count: $merged (restored $restored)"
         ls -lh .cache.ndjson
@@ -594,8 +605,14 @@ jobs:
     # is branch-scoped, so a promotion PR into main cannot restore it. Retention
     # is also the ceiling on how long the store survives with no refresh, since
     # nothing else outlives eviction.
+    #
+    # Gated on having entries rather than on growth, unlike the Actions save.
+    # The upstream artifact was merged in above, so this store is a superset of
+    # the newest one and cannot shadow it -- and requiring growth would mean a
+    # repo with no artifact yet never published a first one, because a refresh
+    # that hits every key grows nothing.
     - name: Publish the cross-branch LLM cache artifact
-      if: steps.consolidate.outputs.publish == 'true'
+      if: steps.consolidate.outputs.has_entries == 'true'
       uses: actions/upload-artifact@v4
       with:
         name: llm-cache-ndjson


### PR DESCRIPTION
Release PR from staging to main.

Follow-up to #118, closing a gap in the artifact layer it introduced.

The publish guard compared against the Actions cache, but the artifact is a
separate lineage, so the most-recently-created trap applied to it untouched: a
job restoring a small store from its own branch could upload it as the newest
artifact and shadow a much larger one. Growth was also the wrong condition for
the artifact — with none published yet, a refresh that hits every key grows
nothing and so would never publish a first one.

- The refresh merges the upstream artifact in before consolidating, making what
  it publishes a superset of both lineages; the upload is gated on having
  entries rather than on growth.
- Flow smoke no longer publishes the artifact at all. Its store is whatever its
  branch restored, so it can only shadow. What it buys still reaches the Actions
  cache and the next refresh folds it onward.
- `consolidate_cache.py` streams and dedupes on a digest instead of reading
  every input into memory, since the upstream store is now one of the inputs.
  Output verified byte-identical to the previous implementation.