### PR TITLE
Release: staging → main

### DIFF
--- a/.agents/plans/out-of-process-steering.md
+++ b/.agents/plans/out-of-process-steering.md
@@ -1,27 +1,31 @@
 # Plan: steering out-of-process execution
 
-**Status:** planned, not started. In-process steering is shipped and tested.
+**Status:** Phase 1 built and tested — venv (one-shot and pooled) and shell.
+Phase 2 (instrumented child source) not started, deliberately. Non-local
+surfaces turned out not to share the RPC transport at all (see below) and are
+out of scope for this mechanism.
 
-Live steering — correcting a block of code while it is still running — works for
-every in-process Python path. This plan extends it to the three paths that run
-somewhere else: venv-backed functions, shell scripts, and non-local execution
-surfaces.
+Live steering — correcting a block of code while it is still running — works
+for every in-process Python path and, at the dispatch boundary, for code
+running in venv subprocesses and shell scripts. This document records how, and
+what was learned closing the plan's open questions.
 
-Read `unify/function_manager/steering.py` first. This plan assumes its four
-parts (probes, idempotency cache, retry via source splice, bounded lifetime)
-and reuses them rather than replacing them.
+Read `unify/function_manager/steering.py` first. Its four parts (probes,
+idempotency cache, retry via source splice, bounded lifetime) are reused
+out-of-process rather than replaced; the out-of-process entry point is
+`dispatch_with_steering` in the same module.
 
-## Read this before deciding how much to build
+## Read this before deciding how much more to build
 
-The work splits into two phases with very different costs, and **Phase 1 is
-worth doing on its own**. It is not groundwork for Phase 2; it is the whole
+The work split into two phases with very different costs, and **Phase 1 is
+worth having on its own**. It is not groundwork for Phase 2; it is the whole
 feature for most cases.
 
 Phase 1 makes out-of-process execution correctable at every side effect that
 goes through primitives, and that is the case the mechanism exists for — the
 reason to steer is to stop a side effect before it happens, and side effects
-are overwhelmingly primitive dispatches. It needs no changes inside the child
-process and it covers venv, shell and remote at once.
+are overwhelmingly primitive dispatches. It needed no changes to how the child
+executes code, and it covers venv and shell at once.
 
 Phase 2 closes one specific remaining gap: a loop in the child that does no
 primitive call, and so is invisible to the parent. It is venv-only, it is the
@@ -34,128 +38,102 @@ If Phase 2 never happens, this feature is not half-finished.
 
 ## Where things stand
 
-**Covered today.** Every in-process Python path, whichever sandbox it runs in:
+**Covered.** Every in-process Python path (statement-level, via AST probes):
 
 - `PythonExecutionSession.execute` — all state modes, including the `stateless`
   default that `execute_code` uses
 - `FunctionManager._execute_in_default_env` — the route that skips the sandbox
   entirely and runs a stored function directly
 
-Within those: loops, `if` and `try` arms at any depth; awaits nested inside
-expressions (comprehensions, `gather`); nested primitive namespaces such as
-`primitives.integrations.slack.send_message`; stored function bodies, because
-`execute_function` synthesises the implementation as a preamble.
+And every out-of-process path that round-trips primitives over JSON-RPC
+(dispatch-boundary, no instrumentation):
 
-**Not covered.** Three paths, all of which run the user's code in another
-process or on another machine:
+- One-shot venv subprocesses — `FunctionManager.execute_in_venv`
+- Pooled persistent venv sessions — `_VenvConnection.execute`
+- Shell scripts using the `unity-primitive` bridge —
+  `FunctionManager.execute_shell_script` (cache and pause only; see the
+  boundaries section for why interrupts cannot fire on shell)
 
-| Path | Entry | Runs where |
-|---|---|---|
-| Venv-backed Python | `venv_id` set on `execute_code` / a venv-backed stored function | subprocess via `VenvPool` |
-| Shell | `language` in `bash`/`zsh`/`sh`/`powershell` | subprocess via `ShellPool` |
-| Non-local surface | `surface != "local"` on `execute_code` | assistant desktop or user desktop, via `unify/actor/execution/targets` |
+**Not covered.** Non-local surfaces (`surface != "local"`), and any child-side
+work between dispatches (Phase 2).
 
 ---
 
-## The key finding: the channel already exists
+## The key finding: the channel already existed
 
-The obvious reading of this problem is "we need a bidirectional event stream to
-and from the child process". We already have one.
+The obvious reading of this problem was "we need a bidirectional event stream
+to and from the child process". We already had one.
 
 `unify/function_manager/venv_runner.py` documents the protocol in its module
 docstring:
 
 ```
-{"type": "rpc_call",   "id": str, "path": str, "kwargs": dict}   # child → parent
-{"type": "rpc_result", "id": str, "result": Any}                 # parent → child
-{"type": "rpc_error",  "id": str, "error": str}                  # parent → child
+{"type": "rpc_call",      "id": str, "path": str, "kwargs": dict}   # child → parent
+{"type": "rpc_result",    "id": str, "result": Any}                 # parent → child
+{"type": "rpc_error",     "id": str, "error": str}                  # parent → child
+{"type": "rpc_interrupt", "id": str, "reason": str}                 # parent → child
 ```
 
 Every `primitives.*` call made inside a venv or shell child round-trips to the
-parent and **blocks the child until the parent replies**. `shell_runner.py`
-speaks the same shape.
+parent and **blocks the child until the parent replies**. Two things follow,
+and they are the whole reason this was tractable:
 
-Two things follow, and they are the whole reason this is tractable:
+1. **The parent sees `path` and `kwargs` for every dispatch.** Those are
+   exactly the inputs to the cache key `(tool, serialized_args, occurrence)` —
+   and `path` is the same string in-process memoisation records, so entries
+   mean the same thing on both sides of the process boundary.
+2. **The child is suspended at every dispatch.** A checkpoint that fires at
+   side effects needed no new mechanism — just a new thing the parent is
+   allowed to say in reply (`rpc_interrupt`, the one message type added).
 
-1. **The parent already sees `path` and `kwargs` for every dispatch.** Those are
-   exactly the inputs to the cache key `(tool, serialized_args, occurrence)`.
-   The cache needs no new information and no child cooperation.
-2. **The child is already suspended at every dispatch.** A checkpoint that only
-   needs to fire at side effects therefore needs no new mechanism — just a new
-   thing the parent is allowed to say in reply.
+So the work was not building a channel. It was widening a reply.
 
-So the work is not building a channel. It is widening a reply, and moving the
-existing parent-side session to sit across it.
+### How Phase 1 is wired
 
-### Two handlers, not one
+One checkpoint, one convergence point, three loops that translate:
 
-There are **two** implementations of `_handle_rpc_call`, and both need the
-change:
+- `dispatch_with_steering` (`steering.py`) is the parent-side checkpoint: it
+  honours pause, collects interjections, raises `ControlledInterruption` when
+  a pending correction targets the running block, replays memoised dispatches,
+  and memoises fresh ones.
+- `FunctionManager._handle_rpc_call` routes **every** RPC through that
+  checkpoint before resolving the path (`_dispatch_rpc_path`). The plan's
+  "two handlers, not one" risk — the pooled `_VenvConnection._handle_rpc_call`
+  looking wired while doing nothing — was resolved structurally: it now
+  delegates to `FunctionManager._handle_rpc_call` instead of duplicating it,
+  so the pooled path cannot drift.
+- The two venv execute loops (one-shot `execute_in_venv`, pooled
+  `_VenvConnection.execute`) catch `ControlledInterruption` at the rpc_call
+  site, reply `rpc_interrupt` so the blocked child unwinds, discard the
+  child's completion, and re-raise into `run_with_steering` — which splices
+  the patch and re-sends `execute` with the new source. A one-shot retry is a
+  fresh subprocess; a pooled retry reuses the connection. Both replay the
+  completed prefix from the parent's cache.
+- The child (`venv_runner.py`) raises its own standalone
+  `ControlledInterruption` at the blocked call site when the reply is an
+  `rpc_interrupt`. That is the entire child-side change; the runner script is
+  re-synced into venvs by `prepare_venv` on every call, so parent and child
+  protocol versions cannot drift apart.
+- The interrupt-targeting question ("is the child inside the patched
+  function?") cannot be answered from the parent, so the nearest sound
+  reading is used: fire when a patch names any function the shipped source
+  defines (`_targets_running_block`). Firing early costs one replay-backed
+  retry; not firing would drop the correction.
 
-- `FunctionManager._handle_rpc_call` — used by `execute_in_venv` and
-  `execute_shell_script`
-- `_VenvConnection._handle_rpc_call` — used by the pooled persistent-venv path
-  (`_VenvConnection.execute` → nested `handle_rpc_loop`)
-
-Missing the second would leave pooled venv sessions silently unsteerable, which
-is the same class of bug as binding the session to the wrong sandbox object was
-in-process: it looks wired and does nothing.
-
----
-
-## Phase 1 — parent-side cache and interrupt (worth doing alone)
-
-One change, no child changes, and it benefits venv, shell and remote at once
-because all three converge on the RPC handler.
-
-**Cache.** In `_handle_rpc_call`, derive the key from `(path, kwargs)` and the
-active `SteeringSession`. On a hit, return the memoised result without
-dispatching. On a miss, dispatch and memoise. Replay then works out-of-process
-with no child involvement.
-
-**Interrupt.** Add one message type:
-
-```
-{"type": "rpc_interrupt", "id": str, "reason": str}   # parent → child
-```
-
-The child raises `ControlledInterruption` at that call site instead of returning
-a result. Since the child is already blocked on the reply, this is the `_int`
-probe realised without instrumentation.
-
-**Pause.** The parent delays the reply. Nothing to build.
-
-**Retry.** The parent splices the patch and re-sends `execute` with the new
-source. The re-run's `rpc_call`s hit the parent cache and return memoised
-results without re-dispatching. This is *cleaner* than in-process, where the
-cache and the code live on the same side and the ownership has to be reasoned
-about; here the parent unambiguously owns it.
-
-### What Phase 1 gets you
-
-Correction at every side effect that goes through primitives, plus replay, on
-all three out-of-process paths. That is most of what matters, because the reason
-to steer is to stop a side effect and side effects are overwhelmingly dispatches.
-
-### What Phase 1 does not get you
-
-A loop in the child that does no primitive call is invisible to the parent. Two
-sub-cases, and they are not equally important:
-
-- **Pure computation** — nothing to correct. Not a real loss.
-- **A direct third-party call**, e.g. `requests.post` inside the venv. A real
-  side effect the parent never sees. In-process, statement and loop probes catch
-  this; here nothing does.
+Tests: `tests/function_manager/python/test_venv_steering.py` (boundary units,
+one-shot flow, pooled flow — including that a pooled connection outlives the
+session that steered it) and `tests/function_manager/shell/test_shell_steering.py`.
 
 ---
 
-## Phase 2 — instrumented child source (venv only, optional)
+## Phase 2 — instrumented child source (venv only, not started)
 
-Full parity, and the only part with a performance question.
+Full parity inside non-dispatching loops, and the only part with a performance
+question.
 
-The parent holds the source before it ships it, so the existing AST pass can run
-parent-side and the child receives already-instrumented code. `_cp`, `_int` and
-`_around_cp` become shims in the child that consult the parent.
+The parent holds the source before it ships it, so the existing AST pass can
+run parent-side and the child receives already-instrumented code. `_cp`,
+`_int` and `_around_cp` become shims in the child that consult the parent.
 
 **The cost is the problem.** In-process a checkpoint is ~10 µs (measured). A
 round trip over a pipe is 0.1–1 ms. A per-iteration checkpoint on a
@@ -169,8 +147,10 @@ reads **non-blockingly** at each checkpoint:
 - idle cost ≈ a non-blocking pipe read, on the order of microseconds
 - a pending correction is a byte on that channel; the child then raises
 
-This is what makes per-iteration probes affordable out-of-process, and it is the
-piece to design carefully rather than the AST work, which is already written.
+This is what makes per-iteration probes affordable out-of-process, and it is
+the piece to design carefully rather than the AST work, which is already
+written. Build it when a real workload needs correction inside a
+non-dispatching loop.
 
 ---
 
@@ -178,55 +158,46 @@ piece to design carefully rather than the AST work, which is already written.
 
 State these as boundaries rather than as work items:
 
-**Shell** has no AST and no Python, so statement-level probes are not possible
-by any design. It tops out at dispatch-boundary steering (Phase 1), which it
-gets for free.
+**Non-local surfaces do not share the transport.** This was the plan's
+load-bearing open question, and the answer is no: `surface != "local"` routes
+through `unify/actor/execution/targets`, whose `AgentServiceExecClient` POSTs
+the whole command to the desktop agent-service `/api/exec` and blocks for a
+single JSON response — python is shipped as a base64'd `python3 -c` one-liner.
+There is no primitives round-trip, no mid-run message of any kind, and so no
+dispatch boundary to steer at. Steering a remote surface means changing the
+agent-service protocol itself (a streaming or bidirectional exec endpoint),
+which is a separate piece of work, not a third integration point on this
+mechanism.
 
-**Non-local surfaces** are dispatch-boundary in practice regardless of design:
-at 10–100 ms per network hop, per-iteration checkpoints are not viable. Phase 1
-applies; Phase 2 does not.
+**Shell interrupts cannot fire.** Shell has no AST and no Python, so there is
+no function a patch can name: `_targets_running_block` finds nothing in shell
+source, and the patch author (`steering_patcher.LLMPatchAuthor`) already
+declines to author patches when the source defines no functions. Shell
+therefore gets dispatch memoisation and pause from the shared checkpoint, and
+nothing else. An interjection against a running shell script is recorded and
+reported, not acted on. Making shell stoppable would need its own decision
+path (e.g. "any interjection terminates the script"), which is a product
+question before it is a mechanism.
 
-**Synchronous blocking code** remains opaque, exactly as in-process. A blocking
-call holds the loop for its duration, and during that window a correction cannot
-arrive. Out-of-process this is arguably *better*, since the parent is a separate
-process and stays responsive — but the child still cannot observe anything until
-it yields.
+**Child-local state across a retry** (was open question 2). One-shot venv
+retries run in a fresh subprocess — a genuinely clean slate, stronger than
+in-process. Pooled venv retries re-send `execute` on the same connection, so
+the persistent namespace still holds residue from the abandoned attempt —
+exactly the property in-process stateful sessions have. Accepted, not fixed.
 
-**Retraction** is still impossible. Replay records that a side effect happened;
-it cannot undo one. A patch redirects work that has not happened yet. This is
-unchanged by anything in this plan and should not be presented as a gap it
-closes.
+**Where the session lives for a pooled venv** (was open question 3). Resolved
+by the same contextvar that fixed this in-process: `active_session()` is read
+per `execute` call, inside the connection lock, so the session follows the
+call and a long-lived `_VenvConnection` never holds one. There is a test
+pinning that a later call on the same connection runs unsteered.
 
----
+**Synchronous blocking code** remains opaque, exactly as in-process. A
+blocking call holds the child between dispatches, and during that window a
+correction cannot land. (One extra wrinkle out-of-process: the child's RPC
+wait has a 300 s timeout, so a pause held longer than that fails the blocked
+call rather than extending it.)
 
-## Open questions to resolve before starting
-
-1. **Does `surface != "local"` use this RPC shape at all?** `_execute_on_surface`
-   routes through `unify/actor/execution/targets` and `ExecutionSurface`, which
-   has not been traced. If it uses a different transport, Phase 1 needs a third
-   integration point rather than riding on `_handle_rpc_call`.
-2. **Child-local state across a retry.** For `stateful` venv sessions, attempt 2
-   runs in a namespace still holding residue from attempt 1. In-process has the
-   same property, so this is not new — but out-of-process it is worth deciding
-   explicitly whether the retry reuses the child or replaces it.
-3. **Where the session lives for a pooled venv.** In-process the session travels
-   by contextvar and whichever sandbox runs binds it. The pooled-venv equivalent
-   needs the same "follows the call, not the connection" property, or a
-   long-lived `_VenvConnection` will outlive the session that bound it.
-
----
-
-## Suggested order
-
-1. Trace open question 1, so the scope of Phase 1 is known.
-2. Phase 1 in `FunctionManager._handle_rpc_call`, with tests on the venv path.
-3. Phase 1 in `_VenvConnection._handle_rpc_call`, with a test that specifically
-   covers a *pooled* session, since that is the one that silently no-ops if
-   missed.
-4. Shell coverage — same parent change, so mostly a test exercise confirming a
-   shell script's primitive calls are cached and interruptible.
-5. Phase 2 only if a real workload needs correction inside a non-dispatching
-   loop. Design the control channel first; the AST pass already exists.
-
-Steps 1-4 are the feature. Step 5 is a response to evidence, not a
-commitment made in advance — see the framing at the top of this document.
+**Retraction** is still impossible. Replay records that a side effect
+happened; it cannot undo one. A patch redirects work that has not happened
+yet. This is unchanged by anything here and should not be presented as a gap
+this closes.

--- a/.env.advanced.example
+++ b/.env.advanced.example
@@ -8,10 +8,12 @@
 # Your Unify API key (https://unify.ai)
 UNIFY_KEY=
 
-# At least one LLM provider key is required
-OPENAI_API_KEY=
+# At least one LLM provider key is required. OpenAI chat models are reached
+# through OpenRouter, so OPENROUTER_API_KEY covers them.
 ANTHROPIC_API_KEY=
 OPENROUTER_API_KEY=
+# Speech-to-text and realtime voice only; not an LLM provider key.
+OPENAI_API_KEY=
 # Together AI key for OpenRouter BYOK (Together-pinned open-weight models).
 TOGETHER_API_KEY=
 

--- a/.env.example
+++ b/.env.example
@@ -10,11 +10,13 @@ UNIFY_KEY=
 # The hosted assistant this local runtime drives (from https://console.unify.ai).
 ASSISTANT_ID=
 
-# At least one provider key is required.
-OPENAI_API_KEY=
+# At least one LLM provider key is required. OpenAI chat models are reached
+# through OpenRouter, so OPENROUTER_API_KEY covers them.
 ANTHROPIC_API_KEY=
 DEEPSEEK_API_KEY=
 OPENROUTER_API_KEY=
+# Speech-to-text and realtime voice only; not an LLM provider key.
+OPENAI_API_KEY=
 # Together AI key for OpenRouter BYOK (Together-pinned open-weight models).
 TOGETHER_API_KEY=
 

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1963,30 +1963,30 @@
       {
         "type": "Secret Keyword",
         "filename": "tests/common/test_production_settings.py",
+        "hashed_secret": "fd9a45bc0b07706d849cf85021ecf9123fa83d82",
+        "is_verified": false,
+        "line_number": 43
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/common/test_production_settings.py",
         "hashed_secret": "e9a5f12a8ecbb3eb46eca5096b5c52aa5e7c9fdd",
         "is_verified": false,
-        "line_number": 42
+        "line_number": 53
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/common/test_production_settings.py",
         "hashed_secret": "6b8f36db289d14c3c7ba1bb21147b7a4fa7e7536",
         "is_verified": false,
-        "line_number": 56
+        "line_number": 68
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/common/test_production_settings.py",
         "hashed_secret": "ffc7b27c5ee452d6f8eb9d91972a62df55b48c3d",
         "is_verified": false,
-        "line_number": 75
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/common/test_production_settings.py",
-        "hashed_secret": "fd9a45bc0b07706d849cf85021ecf9123fa83d82",
-        "is_verified": false,
-        "line_number": 76
+        "line_number": 87
       }
     ],
     "tests/conversation_manager/actions/integration/conftest.py": [
@@ -2380,5 +2380,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-03T09:49:28Z"
+  "generated_at": "2026-08-03T17:37:37Z"
 }

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -21,15 +21,18 @@ COPY scripts/install-canvas-toolchain.sh /tmp/install-canvas-toolchain.sh
 
 # CANVAS_BRANDING_SHA busts this layer when branding moves; without it a stale
 # kit would be baked in indefinitely. Branch logic mirrors the dependency clones
-# below: main→main, everything else→staging.
+# below: main→main, everything else→staging. The second insteadOf covers the
+# packages/iso submodule, whose .gitmodules URL is SSH-form; without it the
+# submodule init cannot authenticate and the kit build loses @unity/iso.
 RUN echo "canvas_branding_sha=${CANVAS_BRANDING_SHA}" && \
     git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/" && \
+    git config --global --add url."https://${GITHUB_TOKEN}@github.com/".insteadOf "git@github.com:" && \
     chmod +x /tmp/install-canvas-toolchain.sh && \
     /tmp/install-canvas-toolchain.sh \
         --branch "$([ "$BRANCH" = "main" ] && echo main || echo staging)" \
         --toolchain /opt/canvas-toolchain \
         --host /opt/canvas-host && \
-    git config --global --unset url."https://${GITHUB_TOKEN}@github.com/".insteadOf
+    git config --global --unset-all url."https://${GITHUB_TOKEN}@github.com/".insteadOf
 
 
 # Use Python 3.12 slim image as base

--- a/logs/README.md
+++ b/logs/README.md
@@ -603,7 +603,7 @@ Each `.jsonl` file contains one JSON object per line, representing a span:
 
 ```json
 {"service": "unity", "trace_id": "099b207f...", "span_id": "a1b2c3d4", "parent_span_id": null, "name": "ContactManager.ask", "start_time": "2026-01-01T14:30:22.123Z", "end_time": "2026-01-01T14:30:25.456Z", "duration_ms": 3333, "attributes": {...}}
-{"service": "unillm", "trace_id": "099b207f...", "span_id": "e5f6g7h8", "parent_span_id": "a1b2c3d4", "name": "LLM gpt-5.2@openai", "start_time": "...", ...}
+{"service": "unillm", "trace_id": "099b207f...", "span_id": "e5f6g7h8", "parent_span_id": "a1b2c3d4", "name": "LLM openai/gpt-5.2@openrouter", "start_time": "...", ...}
 {"service": "unify", "trace_id": "099b207f...", "span_id": "i9j0k1l2", "parent_span_id": "e5f6g7h8", "name": "POST /v0/chat/completions", "start_time": "...", ...}
 {"service": "orchestra", "trace_id": "099b207f...", "span_id": "m3n4o5p6", "parent_span_id": "i9j0k1l2", "name": "POST /v0/chat/completions", "start_time": "...", ...}
 ```

--- a/scripts/install-canvas-toolchain.sh
+++ b/scripts/install-canvas-toolchain.sh
@@ -79,6 +79,11 @@ if [[ -z "$BRANDING_PATH" ]]; then
     echo ">> cloning branding@${BRANCH}"
     git clone --depth 1 --branch "$BRANCH" \
         https://github.com/unifyai/branding.git "$CLONED_DIR"
+    # packages/iso is a submodule, so a plain clone leaves it as an empty
+    # directory and npm then resolves @unity/iso from the public registry (404)
+    # instead of the workspace. Only this one is initialised; the repo's other
+    # submodule is editor tooling the build does not need.
+    git -C "$CLONED_DIR" submodule update --init --depth 1 packages/iso
     BRANDING_PATH="$CLONED_DIR"
 fi
 
@@ -116,8 +121,11 @@ BUILD_DIR="$(mktemp -d)/branding-build"
 mkdir -p "$BUILD_DIR/packages" "$BUILD_DIR/apps"
 cp "$BRANDING_PATH/package.json" "$BUILD_DIR/package.json"
 for workspace in packages/iso packages/brand packages/canvas-kit apps/canvas-host; do
-    if [[ ! -d "$BRANDING_PATH/$workspace" ]]; then
-        echo "missing workspace $workspace in $BRANDING_PATH" >&2
+    # package.json, not just the directory: an uninitialised submodule is an
+    # empty directory that passes -d and then fails npm resolution far away.
+    if [[ ! -f "$BRANDING_PATH/$workspace/package.json" ]]; then
+        echo "workspace $workspace in $BRANDING_PATH is missing or empty" \
+             "(uninitialised submodule?)" >&2
         cleanup_build
         exit 1
     fi

--- a/tests/actor/code_act/test_act_llm_profiles.py
+++ b/tests/actor/code_act/test_act_llm_profiles.py
@@ -165,7 +165,7 @@ async def test_act_llm_profile_overrides_main_actor_client(monkeypatch):
         await actor.close()
 
     assert (None, {}) in calls
-    assert ("gpt-5.5@openai", {"reasoning_effort": "high"}) in calls
+    assert ("openai/gpt-5.5@openrouter", {"reasoning_effort": "high"}) in calls
     assert "default" in active_profiles_at_loop_start
     assert "gpt_5_5_high" in active_profiles_at_loop_start
     assert CURRENT_ACT_LLM_PROFILE.get().name == "default"

--- a/tests/actor/code_act/test_ask_computer_progress.py
+++ b/tests/actor/code_act/test_ask_computer_progress.py
@@ -11,7 +11,7 @@ pytestmark = pytest.mark.llm_call
 
 
 class _DummyLoopClient:
-    endpoint = "gpt-4o-mini@openai"
+    endpoint = "openai/gpt-4o-mini@openrouter"
 
     def __init__(self) -> None:
         self.messages = [

--- a/tests/async_tool_loop/test_context_compression.py
+++ b/tests/async_tool_loop/test_context_compression.py
@@ -97,7 +97,7 @@ class TestEvalTransformation:
 
 
 class TestMakeUpdateTool:
-    _ENDPOINT = "gpt-4o@openai"
+    _ENDPOINT = "openai/gpt-4o@openrouter"
 
     def test_overwrite_entry(self):
         entries = {
@@ -310,7 +310,7 @@ class TestCompressAndRebuild:
         result = await compress_and_rebuild(
             state,
             messages,
-            "gpt-4o@openai",
+            "openai/gpt-4o@openrouter",
             original_tools,
         )
 
@@ -349,7 +349,12 @@ class TestCompressAndRebuild:
             {"role": "user", "content": "first"},
             {"role": "assistant", "content": "response"},
         ]
-        await compress_and_rebuild(state, pass1_messages, "gpt-4o@openai", {})
+        await compress_and_rebuild(
+            state,
+            pass1_messages,
+            "openai/gpt-4o@openrouter",
+            {},
+        )
 
         assert state.count == 1
         assert len(state.entries) == 2
@@ -364,7 +369,12 @@ class TestCompressAndRebuild:
             {"role": "user", "content": "follow-up"},
             {"role": "assistant", "content": "answer"},
         ]
-        await compress_and_rebuild(state, pass2_messages, "gpt-4o@openai", {})
+        await compress_and_rebuild(
+            state,
+            pass2_messages,
+            "openai/gpt-4o@openrouter",
+            {},
+        )
 
         assert state.count == 2
         mock_received = call_log["messages"]
@@ -415,7 +425,12 @@ class TestCompressAndRebuild:
             {"role": "user", "content": "hello"},
             {"role": "assistant", "content": "hi there"},
         ]
-        result = await compress_and_rebuild(state, messages, "gpt-4o@openai", {})
+        result = await compress_and_rebuild(
+            state,
+            messages,
+            "openai/gpt-4o@openrouter",
+            {},
+        )
 
         non_compressed_sys = [
             m for m in result.system_msgs if not m.get("_compressed_message")
@@ -447,7 +462,12 @@ class TestCompressAndRebuild:
             },
             {"role": "assistant", "content": "I see a red pixel."},
         ]
-        result1 = await compress_and_rebuild(state, pass1_messages, "gpt-4o@openai", {})
+        result1 = await compress_and_rebuild(
+            state,
+            pass1_messages,
+            "openai/gpt-4o@openrouter",
+            {},
+        )
 
         assert 0 in state.image_registry
         assert 0 in state.live_image_ids
@@ -484,7 +504,12 @@ class TestCompressAndRebuild:
             )
 
         monkeypatch.setattr(_cc_mod, "compress_messages", _pass2_mock)
-        await compress_and_rebuild(state, pass2_messages, "gpt-4o@openai", {})
+        await compress_and_rebuild(
+            state,
+            pass2_messages,
+            "openai/gpt-4o@openrouter",
+            {},
+        )
 
         assert state.next_image_id == 2
         assert 0 in state.image_registry and 1 in state.image_registry
@@ -500,7 +525,12 @@ class TestCompressAndRebuild:
             {"role": "assistant", "content": "msg-one"},
             {"role": "user", "content": "msg-two"},
         ]
-        result = await compress_and_rebuild(state, messages, "gpt-4o@openai", {})
+        result = await compress_and_rebuild(
+            state,
+            messages,
+            "openai/gpt-4o@openrouter",
+            {},
+        )
 
         unpack = result.tools["unpack_messages"]
         single = json.loads(unpack(0))
@@ -733,7 +763,7 @@ class TestMultiPassCompression:
             result = loop.run_until_complete(
                 compress_messages(
                     new_messages,
-                    "gpt-4o@openai",
+                    "openai/gpt-4o@openrouter",
                     prior_entries=prior,
                     raw_archives=archives,
                     new_indices=[2],
@@ -754,7 +784,7 @@ class TestMultiPassCompression:
             asyncio.get_event_loop().run_until_complete(
                 compress_messages(
                     [{"role": "user", "content": "a"}],
-                    "gpt-4o@openai",
+                    "openai/gpt-4o@openrouter",
                     new_indices=[0, 1],
                 ),
             )

--- a/tests/async_tool_loop/test_context_compression_integration.py
+++ b/tests/async_tool_loop/test_context_compression_integration.py
@@ -891,7 +891,7 @@ async def test_compression_restart_omits_parent_chat_context(monkeypatch):
     )
     handle._client = MagicMock()
     handle._client.messages = [{"role": "user", "content": "loop"}]
-    handle._client.endpoint = "gpt-4o@openai"
+    handle._client.endpoint = "openai/gpt-4o@openrouter"
     handle._loop_config = {
         "loop_id": "test-loop",
         "parent_lineage": [],

--- a/tests/async_tool_loop/test_otel.py
+++ b/tests/async_tool_loop/test_otel.py
@@ -282,7 +282,9 @@ class TestUnityToUnillmHierarchy:
             unity_ctx = unity_span.get_span_context()
 
             # Simulate what unillm.logger.llm_span does
-            with unillm_tracer.start_as_current_span("LLM gpt-4@openai") as llm_span:
+            with unillm_tracer.start_as_current_span(
+                "LLM openai/gpt-4o@openrouter",
+            ) as llm_span:
                 llm_ctx = llm_span.get_span_context()
 
                 # Same trace
@@ -364,7 +366,9 @@ class TestFullStackHierarchy:
 
         # Unity -> Unillm -> Unify
         with logger.unity_span("Actor.act") as unity_span:
-            with unillm_tracer.start_as_current_span("LLM gpt-4@openai") as llm_span:
+            with unillm_tracer.start_as_current_span(
+                "LLM openai/gpt-4o@openrouter",
+            ) as llm_span:
                 with unify_tracer.start_as_current_span("GET projects") as http_span:
                     pass
 

--- a/tests/common/test_custom_sync.py
+++ b/tests/common/test_custom_sync.py
@@ -139,6 +139,30 @@ def test_adoption_wins_over_collision_and_insert():
     assert result.adopted == 1
 
 
+def test_derived_stale_forces_update_despite_matching_hash():
+    class _DerivedAdapter(_RecordingAdapter):
+        def derived_stale(self, key, live_row, fields):
+            return live_row.get("entrypoint") != fields.get("resolved_entrypoint")
+
+    adapter = _DerivedAdapter(
+        live=[
+            _row("dangling", "s", entrypoint=1),
+            _row("aligned", "s", entrypoint=2),
+        ],
+    )
+    result = reconcile_custom_rows(
+        source={
+            "dangling": _row("dangling", "s", resolved_entrypoint=29),
+            "aligned": _row("aligned", "s", resolved_entrypoint=2),
+        },
+        adapter=adapter,
+    )
+    assert ("update", "dangling") in adapter.calls
+    assert ("update", "aligned") not in adapter.calls
+    assert result.updated == 1
+    assert result.unchanged == 1
+
+
 def test_no_prune_keeps_removed_rows():
     adapter = _RecordingAdapter(live=[_row("stale", "x")])
     adapter.prune = False

--- a/tests/common/test_llm_helper_images.py
+++ b/tests/common/test_llm_helper_images.py
@@ -1,0 +1,60 @@
+"""Image promotion out of tool payloads is gated on real base64 image data.
+
+Payloads use "image" keys for plenty of non-image strings (asset URNs, URLs,
+schema fragments). Promoting those into image_url content blocks ships
+garbage that providers reject with a 400, killing the whole tool loop, so
+only strings whose decoded head carries a PNG/JPEG magic may be collected —
+everything else stays in the textual payload.
+"""
+
+from __future__ import annotations
+
+import base64
+
+from unify.common.llm_helpers import (
+    _collect_images,
+    _is_b64_image,
+    _strip_image_keys,
+)
+
+PNG_B64 = base64.b64encode(
+    b"\x89PNG\r\n\x1a\n" + b"\x00" * 64,
+).decode()
+JPEG_B64 = base64.b64encode(b"\xff\xd8\xff\xe0" + b"\x00" * 64).decode()
+
+
+def test_is_b64_image_accepts_png_and_jpeg():
+    assert _is_b64_image(PNG_B64)
+    assert _is_b64_image(JPEG_B64)
+
+
+def test_is_b64_image_rejects_non_image_strings():
+    assert not _is_b64_image("urn:li:image:C4D00AAAAbBCDEFGhiJ")
+    assert not _is_b64_image("https://example.com/picture.png")
+    assert not _is_b64_image(f"data:image/png;base64,{PNG_B64}")
+    assert not _is_b64_image(base64.b64encode(b"just some text bytes").decode())
+    assert not _is_b64_image("")
+
+
+def test_collect_images_skips_non_image_values():
+    acc: list[str] = []
+    _collect_images(
+        {
+            "examples": [{"image": "urn:li:image:C4D00AAAAbBCDEFGhiJ"}],
+            "nested": {"image": PNG_B64},
+            "schema": {"image": {"type": "string"}},
+        },
+        acc,
+    )
+    assert acc == [PNG_B64]
+
+
+def test_strip_image_keys_only_removes_real_images():
+    stripped = _strip_image_keys(
+        {
+            "examples": [{"image": "urn:li:image:C4D00AAAAbBCDEFGhiJ"}],
+            "shot": {"image": PNG_B64},
+        },
+    )
+    assert stripped["examples"][0]["image"] == "urn:li:image:C4D00AAAAbBCDEFGhiJ"
+    assert "image" not in stripped["shot"]

--- a/tests/common/test_production_settings.py
+++ b/tests/common/test_production_settings.py
@@ -39,12 +39,24 @@ class TestLLMProviderValidation:
         """Validation succeeds when at least one credential is set."""
         settings = ProductionSettings(
             UNITY_VALIDATE_LLM_PROVIDERS=True,
+            OPENAI_API_KEY="",
+            ANTHROPIC_API_KEY="sk-ant-test",
+            DEEPSEEK_API_KEY="",
+            OPENROUTER_API_KEY="",
+        )
+        settings.validate_llm_providers()
+
+    def test_validation_rejects_openai_only_credentials(self):
+        """OpenAI chat models route via OpenRouter, so its key grants no access."""
+        settings = ProductionSettings(
+            UNITY_VALIDATE_LLM_PROVIDERS=True,
             OPENAI_API_KEY="sk-test",
             ANTHROPIC_API_KEY="",
             DEEPSEEK_API_KEY="",
             OPENROUTER_API_KEY="",
         )
-        settings.validate_llm_providers()
+        with pytest.raises(RuntimeError):
+            settings.validate_llm_providers()
 
     def test_validation_passes_when_openrouter_credential_provided(self):
         """Validation accepts OpenRouter for *@openrouter platform defaults."""

--- a/tests/common/test_reasoning.py
+++ b/tests/common/test_reasoning.py
@@ -141,7 +141,7 @@ def test_llm_query_prompt_context_includes_model_selection_guidance():
     assert "ARC Prize leaderboard: https://arcprize.org/leaderboard" in context
     assert "Use `list_llms()` to inspect" in context
     assert "Supported UniLLM endpoints currently registered" not in context
-    assert "gpt-5.5@openai, gpt-5.5" not in context
+    assert "openai/gpt-5.5@openrouter, gpt-5.5" not in context
     assert "Do not put benchmark browsing or" in context
     assert (
         "Pass screenshots, photos, or image paths through ``images=[...]``" in context
@@ -151,13 +151,19 @@ def test_llm_query_prompt_context_includes_model_selection_guidance():
 def test_list_llms_returns_registered_endpoint_strings():
     endpoints = reasoning.list_llms()
 
-    assert "gpt-4.1-nano@openai" in endpoints
-    assert "gpt-5.5@openai" in endpoints
+    assert "openai/gpt-5.5@openrouter" in endpoints
+    assert "claude-opus-5@anthropic" in endpoints
     assert all("@" in endpoint for endpoint in endpoints)
 
 
 def test_list_llms_filters_by_provider():
-    endpoints = reasoning.list_llms("openai")
+    endpoints = reasoning.list_llms("openrouter")
 
-    assert "gpt-5.5@openai" in endpoints
-    assert all(endpoint.endswith("@openai") for endpoint in endpoints)
+    assert "openai/gpt-5.5@openrouter" in endpoints
+    assert all(endpoint.endswith("@openrouter") for endpoint in endpoints)
+
+
+def test_list_llms_has_no_native_openai_provider():
+    """OpenAI models are reached through OpenRouter, so @openai is not listed."""
+    assert reasoning.list_llms("openai") == []
+    assert not any(endpoint.endswith("@openai") for endpoint in reasoning.list_llms())

--- a/tests/conversation_manager/actions/integration/test_outbound_attachment.py
+++ b/tests/conversation_manager/actions/integration/test_outbound_attachment.py
@@ -165,7 +165,7 @@ async def test_generate_image_and_send_as_attachment(initialized_cm_codeact):
     b64 = base64.b64encode(image_bytes).decode()
     data_url = f"data:image/png;base64,{b64}"
 
-    client = new_llm_client("gpt-4o-mini@openai")
+    client = new_llm_client("openai/gpt-4o-mini@openrouter")
     judge_text = await client.generate(
         messages=[
             {

--- a/tests/docs/grid-search.md
+++ b/tests/docs/grid-search.md
@@ -10,10 +10,10 @@ Run tests across all combinations of settings values. This is useful for:
 
 ```bash
 # Grid search across models
-grid_search.sh --env UNIFY_MODEL="gpt-4o@openai|claude-sonnet-4-20250514@anthropic" tests/contact_manager/
+grid_search.sh --env UNIFY_MODEL="openai/gpt-4o@openrouter|claude-sonnet-4-20250514@anthropic" tests/contact_manager/
 
 # Grid search across models AND cache settings (2×2 = 4 combinations)
-grid_search.sh --env UNIFY_MODEL="gpt-4o@openai|claude-sonnet-4-20250514@anthropic" --env UNILLM_CACHE="true|false" tests/
+grid_search.sh --env UNIFY_MODEL="openai/gpt-4o@openrouter|claude-sonnet-4-20250514@anthropic" --env UNILLM_CACHE="true|false" tests/
 ```
 
 ---
@@ -102,7 +102,7 @@ Generates 2 runs:
 
 ```bash
 grid_search.sh \
-  --env UNIFY_MODEL="gpt-4o@openai|claude-sonnet-4-20250514@anthropic|gemini-2.5-pro@google" \
+  --env UNIFY_MODEL="openai/gpt-4o@openrouter|claude-sonnet-4-20250514@anthropic|google/gemini-2.5-pro@openrouter" \
   --env UNILLM_CACHE="false" \
   --eval-only \
   tests/contact_manager/
@@ -125,7 +125,7 @@ This generates 4 runs (2×2 grid) testing all combinations of these two feature 
 
 ```bash
 grid_search.sh -n \
-  --env UNIFY_MODEL="gpt-4o@openai|claude-sonnet-4-20250514@anthropic" \
+  --env UNIFY_MODEL="openai/gpt-4o@openrouter|claude-sonnet-4-20250514@anthropic" \
   --env UNILLM_CACHE="true|false" \
   tests/
 ```
@@ -136,21 +136,21 @@ Output:
 Grid Search Configuration
 =========================
 Grid variables:
-  UNIFY_MODEL: gpt-4o@openai | claude-sonnet-4-20250514@anthropic
+  UNIFY_MODEL: openai/gpt-4o@openrouter | claude-sonnet-4-20250514@anthropic
   UNILLM_CACHE: true | false
 
 Total combinations: 4
 
 Generated runs:
-  [1/4] UNIFY_MODEL=gpt-4o@openai UNILLM_CACHE=true
-  [2/4] UNIFY_MODEL=gpt-4o@openai UNILLM_CACHE=false
+  [1/4] UNIFY_MODEL=openai/gpt-4o@openrouter UNILLM_CACHE=true
+  [2/4] UNIFY_MODEL=openai/gpt-4o@openrouter UNILLM_CACHE=false
   [3/4] UNIFY_MODEL=claude-sonnet-4-20250514@anthropic UNILLM_CACHE=true
   [4/4] UNIFY_MODEL=claude-sonnet-4-20250514@anthropic UNILLM_CACHE=false
 
 Dry run - commands that would be executed:
 
-  parallel_run --env UNIFY_MODEL=gpt-4o@openai --env UNILLM_CACHE=true --tags UNIFY_MODEL=gpt-4o@openai,UNILLM_CACHE=true tests/
-  parallel_run --env UNIFY_MODEL=gpt-4o@openai --env UNILLM_CACHE=false --tags UNIFY_MODEL=gpt-4o@openai,UNILLM_CACHE=false tests/
+  parallel_run --env UNIFY_MODEL=openai/gpt-4o@openrouter --env UNILLM_CACHE=true --tags UNIFY_MODEL=openai/gpt-4o@openrouter,UNILLM_CACHE=true tests/
+  parallel_run --env UNIFY_MODEL=openai/gpt-4o@openrouter --env UNILLM_CACHE=false --tags UNIFY_MODEL=openai/gpt-4o@openrouter,UNILLM_CACHE=false tests/
   ...
 ```
 
@@ -188,7 +188,7 @@ Grid search composes with all `parallel_run` features:
 ```bash
 # Grid + eval-only + repeat for statistical sampling
 grid_search.sh \
-  --env UNIFY_MODEL="gpt-4o@openai|claude-sonnet-4-20250514@anthropic" \
+  --env UNIFY_MODEL="openai/gpt-4o@openrouter|claude-sonnet-4-20250514@anthropic" \
   --env UNILLM_CACHE="false" \
   --eval-only \
   --repeat 5 \

--- a/tests/docs/parallel-cloud-run.md
+++ b/tests/docs/parallel-cloud-run.md
@@ -122,7 +122,7 @@ parallel_cloud_run.sh tests/actor tests/contact_manager
 parallel_cloud_run.sh tests/actor/code_act.py
 
 # Override settings
-parallel_cloud_run.sh --env UNIFY_MODEL=gpt-5.2@openai tests/contact_manager
+parallel_cloud_run.sh --env UNIFY_MODEL=openai/gpt-5.2@openrouter tests/contact_manager
 ```
 
 Do not use `parallel_cloud_run.sh` for full-suite, uncached, or repeated LLM evals. Use `llm-cache-refresh.yml` for intentional paid LLM runs.

--- a/tests/docs/parallel-runner.md
+++ b/tests/docs/parallel-runner.md
@@ -175,7 +175,7 @@ The `-e/--env KEY=VALUE` flag sets environment variables for all pytest sessions
 parallel_run --env UNILLM_CACHE=false tests/contact_manager/test_ask.py
 
 # Multiple overrides (flag can be repeated)
-parallel_run -e UNIFY_MODEL=gpt-5.2@openai -e UNIFY_DELETE_CONTEXT_ON_EXIT=true tests/contact_manager
+parallel_run -e UNIFY_MODEL=openai/gpt-5.2@openrouter -e UNIFY_DELETE_CONTEXT_ON_EXIT=true tests/contact_manager
 
 # Use isolated random projects (each session gets its own project)
 parallel_run --env UNIFY_TESTS_RAND_PROJ=true --env UNIFY_TESTS_DELETE_PROJ_ON_EXIT=true tests
@@ -193,7 +193,7 @@ Settings are organized in two classes with inheritance:
 
 | Variable | Type | Default | Description |
 |----------|------|---------|-------------|
-| `UNIFY_MODEL` | str | `gpt-5.2@openai` | LLM model to use |
+| `UNIFY_MODEL` | str | `openai/gpt-5.2@openrouter` | LLM model to use |
 | `UNILLM_CACHE` | bool/str | `true` | Enable/disable LLM response caching |
 | `LLM_IO_DEBUG` | bool | `true` | Log full LLM request/response payloads |
 | `UNITY_TERMINAL_LOG` | bool | `true` | Enable/disable terminal (console) logging |

--- a/tests/event_bus/test_llm_events.py
+++ b/tests/event_bus/test_llm_events.py
@@ -199,7 +199,7 @@ async def test_llm_call_publishes_event():
     install_llm_event_hook()
 
     async with capture_events("LLM") as captured:
-        client = unillm.AsyncUnify("gpt-4.1-nano@openai", cache=True)
+        client = unillm.AsyncUnify("openai/gpt-4.1-nano@openrouter", cache=True)
         await client.generate(
             messages=[
                 {"role": "user", "content": "Say 'test123' exactly [llm_events_test]"},
@@ -228,7 +228,7 @@ async def test_llm_call_captures_full_response():
     install_llm_event_hook()
 
     async with capture_events("LLM") as captured:
-        client = unillm.AsyncUnify("gpt-4.1-nano@openai", cache=True)
+        client = unillm.AsyncUnify("openai/gpt-4.1-nano@openrouter", cache=True)
         await client.generate(
             messages=[{"role": "user", "content": "Say 'hi' [full_response_test]"}],
         )
@@ -264,7 +264,7 @@ async def test_llm_call_with_tools():
     ]
 
     async with capture_events("LLM") as captured:
-        client = unillm.AsyncUnify("gpt-4.1-nano@openai", cache=True)
+        client = unillm.AsyncUnify("openai/gpt-4.1-nano@openrouter", cache=True)
         await client.generate(
             messages=[{"role": "user", "content": "What is 2+2? [tools_test]"}],
             tools=tools,
@@ -288,7 +288,7 @@ async def test_multiple_sequential_llm_calls():
     install_llm_event_hook()
 
     async with capture_events("LLM") as captured:
-        client = unillm.AsyncUnify("gpt-4.1-nano@openai", cache=True)
+        client = unillm.AsyncUnify("openai/gpt-4.1-nano@openrouter", cache=True)
 
         # Make three calls
         await client.generate(
@@ -315,7 +315,7 @@ async def test_llm_events_searchable_in_eventbus():
     """LLM events should be searchable after publishing."""
     install_llm_event_hook()
 
-    client = unillm.AsyncUnify("gpt-4.1-nano@openai", cache=True)
+    client = unillm.AsyncUnify("openai/gpt-4.1-nano@openrouter", cache=True)
     await client.generate(
         messages=[{"role": "user", "content": "Searchable test [search_test]"}],
     )
@@ -352,7 +352,7 @@ async def test_llm_event_includes_cost_fields():
     unique_id = str(uuid.uuid4())[:8]
 
     async with capture_events("LLM") as captured:
-        client = unillm.AsyncUnify("gpt-4.1-nano@openai", cache=True)
+        client = unillm.AsyncUnify("openai/gpt-4.1-nano@openrouter", cache=True)
         await client.generate(
             messages=[{"role": "user", "content": f"Say 'cost test' [{unique_id}]"}],
         )
@@ -467,7 +467,7 @@ async def test_hook_works_when_installed_from_different_thread():
 
     # Now make LLM call from main thread and verify event is captured
     async with capture_events("LLM") as captured:
-        client = unillm.AsyncUnify("gpt-4.1-nano@openai", cache=True)
+        client = unillm.AsyncUnify("openai/gpt-4.1-nano@openrouter", cache=True)
         await client.generate(
             messages=[{"role": "user", "content": "Cross-thread test [xthread]"}],
         )
@@ -513,7 +513,7 @@ async def test_hook_works_when_installed_via_asyncio_to_thread():
 
     # Make LLM call from main async context
     async with capture_events("LLM") as captured:
-        client = unillm.AsyncUnify("gpt-4.1-nano@openai", cache=True)
+        client = unillm.AsyncUnify("openai/gpt-4.1-nano@openrouter", cache=True)
         await client.generate(
             messages=[{"role": "user", "content": "asyncio.to_thread test [tothread]"}],
         )

--- a/tests/event_bus/test_spending.py
+++ b/tests/event_bus/test_spending.py
@@ -1404,7 +1404,7 @@ class E2ETestConfig:
     test_user_id: str = "test-user-001"
     test_assistant_first_name: str = "SpendingTest"
     test_assistant_surname: str = "Assistant"
-    model: str = "gpt-4o-mini@openai"
+    model: str = "openai/gpt-4o-mini@openrouter"
     test_agent_id: _Optional[str] = None
 
     @classmethod
@@ -1682,7 +1682,7 @@ class TestE2ESpendingLimits:
 
         request = LimitCheckRequest(
             model="gpt-4o-mini",
-            endpoint="gpt-4o-mini@openai",
+            endpoint="openai/gpt-4o-mini@openrouter",
         )
 
         response = await check_spending_limits_callback(request)

--- a/tests/file_manager/filesystem_adapters/test_local_adapter.py
+++ b/tests/file_manager/filesystem_adapters/test_local_adapter.py
@@ -102,3 +102,21 @@ async def test_delete(tmp_path):
     # Test deleting a non-existent file
     with pytest.raises(FileNotFoundError):
         ad.delete("non_existent_file.txt")
+
+
+def test_abspath_maps_managed_vm_paths_into_the_workspace(tmp_path):
+    """A VM-side ``/Unity/Local/...`` path addresses the pod's synced tree.
+
+    The two machines expose the same synced tree at different absolute roots, so
+    re-rooting a VM path verbatim yielded ``<root>/Unity/Local/...`` and failed
+    the send with "File not found" while the file sat in the workspace.
+    """
+    root = tmp_path / "root"
+    (root / "Outputs").mkdir(parents=True)
+    (root / "Outputs" / "shot.jpg").write_bytes(b"jpeg")
+    ad = LocalFileSystemAdapter(root.as_posix())
+
+    assert ad._abspath("/Unity/Local/Outputs/shot.jpg") == root / "Outputs" / "shot.jpg"
+    assert ad.get_file("/Unity/Local/Outputs/shot.jpg").name == "shot.jpg"
+    # Workspace identities from _relativize keep re-rooting as before.
+    assert ad._abspath("/Outputs/shot.jpg") == root / "Outputs" / "shot.jpg"

--- a/tests/function_manager/python/test_reason_helper.py
+++ b/tests/function_manager/python/test_reason_helper.py
@@ -79,9 +79,9 @@ def test_venv_runner_list_llms_routes_through_runtime_rpc(
 
     def fake_rpc_call(path: str, kwargs: dict[str, Any]) -> list[str]:
         calls.append((path, kwargs))
-        return ["gpt-5.5@openai"]
+        return ["openai/gpt-5.5@openrouter"]
 
     monkeypatch.setattr(venv_runner, "rpc_call_sync", fake_rpc_call)
 
-    assert venv_runner.list_llms("openai") == ["gpt-5.5@openai"]
+    assert venv_runner.list_llms("openai") == ["openai/gpt-5.5@openrouter"]
     assert calls == [("runtime.list_llms", {"provider": "openai"})]

--- a/tests/function_manager/python/test_venv_steering.py
+++ b/tests/function_manager/python/test_venv_steering.py
@@ -1,0 +1,375 @@
+"""Steering venv-backed execution from the parent side of the RPC channel.
+
+Out-of-process code needs no instrumentation to be steered: every
+``primitives.*`` call round-trips to the parent and blocks the child until the
+reply arrives, so the reply itself is the checkpoint. These tests assert that
+the parent memoises those dispatches for replay, interrupts the child at a
+dispatch when a correction lands, and re-runs the patched source — on both the
+one-shot subprocess path and the pooled persistent-connection path, since the
+pooled path is the one that would no-op silently if its handler were missed.
+
+The mechanism is asserted with the patch supplied directly; whether a real
+model writes a usable one is the eval question, covered on the in-process
+paths.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import shutil
+from typing import List
+
+import pytest
+
+from tests.helpers import _handle_project
+from unify.common.context_registry import ContextRegistry
+from unify.function_manager.function_manager import FunctionManager, VenvPool
+from unify.function_manager.steering import (
+    ControlledInterruption,
+    InterruptionRequest,
+    Patch,
+    SteeringSession,
+    use_session,
+)
+
+MINIMAL_VENV_CONTENT = """
+[project]
+name = "test-steering-venv"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = []
+""".strip()
+
+IMPLEMENTATION = (
+    "async def notify_vendors(vendors):\n"
+    "    sent = []\n"
+    "    for v in vendors:\n"
+    "        sent.append(await primitives.comms.send(to=v))\n"
+    "    return sent\n"
+)
+
+VENDORS = ["eu-alpha", "us-beta", "us-gamma", "eu-delta"]
+
+EU_ONLY_PATCH = (
+    "async def notify_vendors(vendors):\n"
+    "    sent = []\n"
+    "    for v in vendors:\n"
+    "        if v.startswith('eu-'):\n"
+    "            sent.append(await primitives.comms.send(to=v))\n"
+    "    return sent\n"
+)
+
+
+class _Comms:
+    def __init__(self) -> None:
+        self.sent: List[str] = []
+
+    async def send(self, to: str) -> str:
+        self.sent.append(to)
+        # Yield long enough for a watcher task to react between the dispatch
+        # and the reply reaching the child.
+        await asyncio.sleep(0.01)
+        return f"sent:{to}"
+
+
+class _Prims:
+    def __init__(self, comms: _Comms) -> None:
+        self.comms = comms
+
+
+def _bare_manager() -> FunctionManager:
+    """A FunctionManager without its constructor's I/O.
+
+    ``_handle_rpc_call`` reads nothing from the instance, so the RPC-boundary
+    unit tests can avoid the per-test context setup entirely.
+    """
+    return FunctionManager.__new__(FunctionManager)
+
+
+def _patch_after(comms: _Comms, count: int, queue: asyncio.Queue, text: str):
+    async def _run() -> None:
+        while len(comms.sent) < count:
+            await asyncio.sleep(0)
+        await queue.put(text)
+
+    return asyncio.create_task(_run())
+
+
+async def _author(*, interjections, session):
+    return InterruptionRequest(
+        reason=interjections[0],
+        patches=[Patch(function_name="notify_vendors", source=EU_ONLY_PATCH)],
+    )
+
+
+@pytest.fixture
+def function_manager_factory():
+    """Factory fixture that creates FunctionManager instances."""
+    managers = []
+
+    def _create():
+        ContextRegistry.forget(FunctionManager, "Functions/VirtualEnvs")
+        ContextRegistry.forget(FunctionManager, "Functions/Compositional")
+        ContextRegistry.forget(FunctionManager, "Functions/Primitives")
+        ContextRegistry.forget(FunctionManager, "Functions/Meta")
+        fm = FunctionManager()
+        managers.append(fm)
+        return fm
+
+    yield _create
+
+    for fm in managers:
+        try:
+            fm.clear()
+        except Exception:
+            pass
+
+
+def _cleanup_venv(fm: FunctionManager, venv_id: int) -> None:
+    venv_dir = fm._get_venv_dir(venv_id)
+    if venv_dir.exists():
+        shutil.rmtree(venv_dir, ignore_errors=True)
+
+
+# ── the RPC boundary itself, no subprocess ──────────────────────────────────
+@pytest.mark.asyncio
+async def test_rpc_dispatch_runs_without_a_session():
+    comms = _Comms()
+    result = await _bare_manager()._handle_rpc_call(
+        path="comms.send",
+        kwargs={"to": "eu-alpha"},
+        primitives=_Prims(comms),
+    )
+    assert result == "sent:eu-alpha"
+    assert comms.sent == ["eu-alpha"]
+
+
+@pytest.mark.asyncio
+async def test_identical_dispatches_within_one_attempt_both_run():
+    """Occurrence indexing: the second send(a) of a run is a new effect."""
+    comms = _Comms()
+    session = SteeringSession()
+    with use_session(session):
+        fm = _bare_manager()
+        await fm._handle_rpc_call(
+            path="comms.send",
+            kwargs={"to": "eu-alpha"},
+            primitives=_Prims(comms),
+        )
+        await fm._handle_rpc_call(
+            path="comms.send",
+            kwargs={"to": "eu-alpha"},
+            primitives=_Prims(comms),
+        )
+    assert comms.sent == ["eu-alpha", "eu-alpha"]
+
+
+@pytest.mark.asyncio
+async def test_dispatches_replay_across_a_position_reset():
+    """A retry resets position but keeps the cache, so the prefix replays."""
+    comms = _Comms()
+    session = SteeringSession()
+    fm = _bare_manager()
+    with use_session(session):
+        first = await fm._handle_rpc_call(
+            path="comms.send",
+            kwargs={"to": "eu-alpha"},
+            primitives=_Prims(comms),
+        )
+        session.runtime.reset_position()
+        second = await fm._handle_rpc_call(
+            path="comms.send",
+            kwargs={"to": "eu-alpha"},
+            primitives=_Prims(comms),
+        )
+    assert first == second == "sent:eu-alpha"
+    assert comms.sent == ["eu-alpha"], "the replay re-dispatched"
+    assert session.cache.hits == 1
+
+
+@pytest.mark.asyncio
+async def test_pending_correction_interrupts_at_the_dispatch_boundary():
+    comms = _Comms()
+    session = SteeringSession()
+    session.bind_source(IMPLEMENTATION)
+    session.interruption = InterruptionRequest(
+        reason="only the EU vendors",
+        patches=[Patch(function_name="notify_vendors", source=EU_ONLY_PATCH)],
+    )
+    with use_session(session):
+        with pytest.raises(ControlledInterruption):
+            await _bare_manager()._handle_rpc_call(
+                path="comms.send",
+                kwargs={"to": "us-gamma"},
+                primitives=_Prims(comms),
+            )
+    assert comms.sent == [], "the dispatch ran despite the pending correction"
+    assert session.interruption is not None, "the retry loop owns consuming it"
+
+
+@pytest.mark.asyncio
+async def test_correction_for_shell_source_does_not_fire():
+    """Shell source defines nothing a patch can name, so nothing interrupts."""
+    comms = _Comms()
+    session = SteeringSession()
+    session.bind_source("unity-primitive comms send --to eu-alpha\n")
+    session.interruption = InterruptionRequest(
+        reason="stop",
+        patches=[Patch(function_name="notify_vendors", source=EU_ONLY_PATCH)],
+    )
+    with use_session(session):
+        result = await _bare_manager()._handle_rpc_call(
+            path="comms.send",
+            kwargs={"to": "eu-alpha"},
+            primitives=_Prims(comms),
+        )
+    assert result == "sent:eu-alpha"
+
+
+# ── the full loop, one-shot subprocess ──────────────────────────────────────
+@_handle_project
+@pytest.mark.asyncio
+async def test_correction_reaches_a_one_shot_venv_run(function_manager_factory):
+    fm = function_manager_factory()
+    venv_id = fm.add_venv(venv=MINIMAL_VENV_CONTENT)
+
+    comms = _Comms()
+    queue: asyncio.Queue = asyncio.Queue()
+    session = SteeringSession(interject_q=queue, patch_author=_author)
+    steerer = _patch_after(comms, 2, queue, "only the EU vendors")
+
+    try:
+        with use_session(session):
+            out = await fm.execute_in_venv(
+                venv_id=venv_id,
+                implementation=IMPLEMENTATION,
+                call_kwargs={"vendors": list(VENDORS)},
+                is_async=True,
+                primitives=_Prims(comms),
+            )
+        await steerer
+
+        assert out["error"] is None, out["error"]
+        assert session.retries == 1
+        # The correction landed before this one.
+        assert "us-gamma" not in comms.sent
+        # Already contacted, so replayed rather than contacted again.
+        assert comms.sent.count("eu-alpha") == 1
+        assert "eu-delta" in comms.sent
+        assert session.cache.hits >= 1, "the retry redid the prefix"
+        # The patched run's own return value: the replayed send plus the one
+        # the patch let through.
+        assert out["result"] == ["sent:eu-alpha", "sent:eu-delta"]
+    finally:
+        _cleanup_venv(fm, venv_id)
+
+
+@_handle_project
+@pytest.mark.asyncio
+async def test_one_shot_venv_run_is_unchanged_without_a_session(
+    function_manager_factory,
+):
+    fm = function_manager_factory()
+    venv_id = fm.add_venv(venv=MINIMAL_VENV_CONTENT)
+
+    comms = _Comms()
+    try:
+        out = await fm.execute_in_venv(
+            venv_id=venv_id,
+            implementation=IMPLEMENTATION,
+            call_kwargs={"vendors": list(VENDORS)},
+            is_async=True,
+            primitives=_Prims(comms),
+        )
+        assert out["error"] is None, out["error"]
+        assert comms.sent == VENDORS
+    finally:
+        _cleanup_venv(fm, venv_id)
+
+
+# ── the full loop, pooled persistent connection ─────────────────────────────
+@_handle_project
+@pytest.mark.asyncio
+async def test_correction_reaches_a_pooled_venv_run(function_manager_factory):
+    """The pooled path has its own RPC loop; missing it looks wired and does
+    nothing, so it is exercised specifically."""
+    fm = function_manager_factory()
+    venv_id = fm.add_venv(venv=MINIMAL_VENV_CONTENT)
+    await fm.prepare_venv(venv_id=venv_id)
+    pool = VenvPool()
+
+    comms = _Comms()
+    queue: asyncio.Queue = asyncio.Queue()
+    session = SteeringSession(interject_q=queue, patch_author=_author)
+    steerer = _patch_after(comms, 2, queue, "only the EU vendors")
+
+    try:
+        with use_session(session):
+            out = await pool.execute_in_venv(
+                venv_id=venv_id,
+                implementation=IMPLEMENTATION,
+                call_kwargs={"vendors": list(VENDORS)},
+                is_async=True,
+                session_id=0,
+                primitives=_Prims(comms),
+                function_manager=fm,
+            )
+        await steerer
+
+        assert out["error"] is None, out["error"]
+        assert session.retries == 1
+        assert "us-gamma" not in comms.sent
+        assert comms.sent.count("eu-alpha") == 1
+        assert "eu-delta" in comms.sent
+        assert session.cache.hits >= 1, "the retry redid the prefix"
+        assert out["result"] == ["sent:eu-alpha", "sent:eu-delta"]
+    finally:
+        await pool.close()
+        _cleanup_venv(fm, venv_id)
+
+
+@_handle_project
+@pytest.mark.asyncio
+async def test_pooled_connection_outlives_the_session_that_steered_it(
+    function_manager_factory,
+):
+    """The session follows the call, not the connection: a later call on the
+    same pooled venv must run unsteered once the session is gone."""
+    fm = function_manager_factory()
+    venv_id = fm.add_venv(venv=MINIMAL_VENV_CONTENT)
+    await fm.prepare_venv(venv_id=venv_id)
+    pool = VenvPool()
+
+    comms = _Comms()
+    queue: asyncio.Queue = asyncio.Queue()
+    session = SteeringSession(interject_q=queue, patch_author=_author)
+    steerer = _patch_after(comms, 2, queue, "only the EU vendors")
+
+    try:
+        with use_session(session):
+            await pool.execute_in_venv(
+                venv_id=venv_id,
+                implementation=IMPLEMENTATION,
+                call_kwargs={"vendors": list(VENDORS)},
+                is_async=True,
+                session_id=0,
+                primitives=_Prims(comms),
+                function_manager=fm,
+            )
+        await steerer
+
+        later = _Comms()
+        out = await pool.execute_in_venv(
+            venv_id=venv_id,
+            implementation=IMPLEMENTATION,
+            call_kwargs={"vendors": list(VENDORS)},
+            is_async=True,
+            session_id=0,
+            primitives=_Prims(later),
+            function_manager=fm,
+        )
+        assert out["error"] is None, out["error"]
+        assert later.sent == VENDORS, "a dead session still steered this call"
+    finally:
+        await pool.close()
+        _cleanup_venv(fm, venv_id)

--- a/tests/function_manager/shell/test_shell_steering.py
+++ b/tests/function_manager/shell/test_shell_steering.py
@@ -1,0 +1,103 @@
+"""Steering at the shell RPC bridge.
+
+Shell scripts have no AST to patch and the patch author declines to author
+corrections for non-Python source, so shell tops out at dispatch-boundary
+steering: every ``unity-primitive`` call round-trips through the same RPC
+handler the venv paths use, where an in-flight session memoises it and pause
+holds the reply. These tests pin that the bridge actually flows through the
+session — and that a pending correction can never fire on shell source.
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+import pytest
+
+from tests.helpers import _handle_project
+from unify.common.context_registry import ContextRegistry
+from unify.function_manager.function_manager import FunctionManager
+from unify.function_manager.steering import SteeringSession, use_session
+
+SCRIPT_SENDS_TWICE = """#!/bin/bash
+unity-primitive comms send --to eu-alpha
+unity-primitive comms send --to us-beta
+"""
+
+
+class _Comms:
+    def __init__(self) -> None:
+        self.sent: List[str] = []
+
+    async def send(self, to: str) -> str:
+        self.sent.append(to)
+        return f"sent:{to}"
+
+
+class _Prims:
+    def __init__(self, comms: _Comms) -> None:
+        self.comms = comms
+
+
+@pytest.fixture
+def function_manager_factory():
+    """Factory fixture that creates FunctionManager instances."""
+    managers = []
+
+    def _create():
+        ContextRegistry.forget(FunctionManager, "Functions/VirtualEnvs")
+        ContextRegistry.forget(FunctionManager, "Functions/Compositional")
+        ContextRegistry.forget(FunctionManager, "Functions/Primitives")
+        ContextRegistry.forget(FunctionManager, "Functions/Meta")
+        fm = FunctionManager()
+        managers.append(fm)
+        return fm
+
+    yield _create
+
+    for fm in managers:
+        try:
+            fm.clear()
+        except Exception:
+            pass
+
+
+@_handle_project
+@pytest.mark.asyncio
+async def test_shell_dispatches_flow_through_the_session(function_manager_factory):
+    fm = function_manager_factory()
+    comms = _Comms()
+    session = SteeringSession()
+    session.bind_source(SCRIPT_SENDS_TWICE)
+
+    with use_session(session):
+        result = await fm.execute_shell_script(
+            implementation=SCRIPT_SENDS_TWICE,
+            language="bash",
+            primitives=_Prims(comms),
+        )
+
+    assert result["error"] is None, result["error"]
+    assert result["result"] == 0
+    assert comms.sent == ["eu-alpha", "us-beta"]
+    # Both dispatches were seen — and recorded — by the session on their way
+    # through the bridge.
+    assert session.cache.misses == 2
+    assert session.cache.completed_calls() == ["comms.send", "comms.send"]
+    assert "sent:eu-alpha" in result["stdout"]
+
+
+@_handle_project
+@pytest.mark.asyncio
+async def test_shell_runs_unchanged_without_a_session(function_manager_factory):
+    fm = function_manager_factory()
+    comms = _Comms()
+
+    result = await fm.execute_shell_script(
+        implementation=SCRIPT_SENDS_TWICE,
+        language="bash",
+        primitives=_Prims(comms),
+    )
+
+    assert result["error"] is None, result["error"]
+    assert comms.sent == ["eu-alpha", "us-beta"]

--- a/tests/function_manager/test_custom_function_sync_identity.py
+++ b/tests/function_manager/test_custom_function_sync_identity.py
@@ -1,0 +1,100 @@
+"""The function/venv reconcile must never renumber rows it re-syncs.
+
+Task entrypoints hold ``function_id`` and function rows hold ``venv_id``, so
+a delete-and-reinsert on reconcile orphans every reference. Two behaviors pin
+that: legacy rows whose ``custom_key`` column is null still land in the
+managed index (matched by name), and same-named rows outside the index are
+adopted in place rather than replaced.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, Dict, List
+
+import unify.function_manager.function_manager as fm_module
+from unify.function_manager.function_manager import (
+    _FunctionSyncAdapter,
+    _VenvSyncAdapter,
+)
+
+
+def _fake_log(entries: Dict[str, Any], log_id: int = 1) -> SimpleNamespace:
+    return SimpleNamespace(id=log_id, entries=entries)
+
+
+def _manager_stub() -> SimpleNamespace:
+    return SimpleNamespace(
+        _compositional_ctx="ctx/Functions/Compositional",
+        _venvs_ctx="ctx/Functions/VirtualEnvs",
+    )
+
+
+def test_live_rows_defaults_null_custom_key_to_name(monkeypatch):
+    rows = [
+        _fake_log(
+            {
+                "function_id": 1,
+                "name": "run_gtm_stargazer_enrich_tick",
+                "custom_key": None,
+                "custom_hash": "hash-enrich",
+            },
+        ),
+    ]
+    monkeypatch.setattr(
+        fm_module.unisdk,
+        "get_logs",
+        lambda **kwargs: rows,
+    )
+    monkeypatch.setattr(
+        fm_module,
+        "list_private_fields",
+        lambda ctx: [],
+    )
+    adapter = _FunctionSyncAdapter(_manager_stub(), venv_name_to_id={})
+    live = adapter.live_rows()
+    assert live[0]["custom_key"] == "run_gtm_stargazer_enrich_tick"
+
+
+def test_find_adoptable_claims_same_named_row(monkeypatch):
+    existing = _fake_log(
+        {"function_id": 29, "name": "run_gtm_stargazer_enrich_tick"},
+    )
+    captured: Dict[str, Any] = {}
+
+    def fake_get_logs(**kwargs: Any) -> List[SimpleNamespace]:
+        captured.update(kwargs)
+        return [existing]
+
+    monkeypatch.setattr(fm_module.unisdk, "get_logs", fake_get_logs)
+    adapter = _FunctionSyncAdapter(_manager_stub(), venv_name_to_id={})
+    row = adapter.find_adoptable(
+        "run_gtm_stargazer_enrich_tick",
+        {"name": "run_gtm_stargazer_enrich_tick"},
+    )
+    assert row["function_id"] == 29
+    assert "run_gtm_stargazer_enrich_tick" in captured["filter"]
+
+
+def test_adopt_updates_in_place_preserving_function_id():
+    updates: List[Dict[str, Any]] = []
+    manager = _manager_stub()
+    manager._update_custom_function = lambda *, function_id, data: updates.append(
+        {"function_id": function_id, **data},
+    )
+    adapter = _FunctionSyncAdapter(manager, venv_name_to_id={})
+    adapter.adopt(
+        "run_gtm_stargazer_enrich_tick",
+        {"function_id": 29, "name": "run_gtm_stargazer_enrich_tick"},
+        {"name": "run_gtm_stargazer_enrich_tick", "custom_hash": "h"},
+    )
+    assert updates[0]["function_id"] == 29
+    assert updates[0]["custom_hash"] == "h"
+
+
+def test_venv_adapter_adopts_same_named_row(monkeypatch):
+    existing = _fake_log({"venv_id": 7, "name": "scraping"})
+    monkeypatch.setattr(fm_module.unisdk, "get_logs", lambda **kwargs: [existing])
+    adapter = _VenvSyncAdapter(_manager_stub())
+    row = adapter.find_adoptable("scraping", {"name": "scraping"})
+    assert row["venv_id"] == 7

--- a/tests/gateway/channels/unillm/test_views.py
+++ b/tests/gateway/channels/unillm/test_views.py
@@ -220,7 +220,7 @@ class TestChatCompletions:
         resp = client.post(
             "/unillm/chat/completions",
             json={
-                "model": "gpt-4o@openai",
+                "model": "openai/gpt-4o@openrouter",
                 "messages": [{"role": "user", "content": "hi"}],
             },
         )
@@ -238,7 +238,7 @@ class TestChatCompletions:
             resp = client.post(
                 "/unillm/chat/completions",
                 json={
-                    "model": "gpt-4o@openai",
+                    "model": "openai/gpt-4o@openrouter",
                     "messages": [{"role": "user", "content": "hi"}],
                 },
                 headers={"Authorization": "Bearer sk-bad"},
@@ -272,7 +272,7 @@ class TestChatCompletions:
         fake_response.model_dump.return_value = {
             "id": "chatcmpl-1",
             "object": "chat.completion",
-            "model": "gpt-4o@openai",
+            "model": "openai/gpt-4o@openrouter",
             "choices": [
                 {"index": 0, "message": {"role": "assistant", "content": "ok"}},
             ],
@@ -293,7 +293,7 @@ class TestChatCompletions:
             resp = client.post(
                 "/unillm/chat/completions",
                 json={
-                    "model": "gpt-4o@openai",
+                    "model": "openai/gpt-4o@openrouter",
                     "messages": [{"role": "user", "content": "hi"}],
                 },
                 headers={"Authorization": "Bearer sk-test"},
@@ -305,7 +305,7 @@ class TestChatCompletions:
         kwargs = MockAsync.call_args.kwargs
         assert kwargs["api_key"] == "sk-test"
         # AsyncUnify was called as positional model + kwargs.
-        assert MockAsync.call_args.args[0] == "gpt-4o@openai"
+        assert MockAsync.call_args.args[0] == "openai/gpt-4o@openrouter"
 
     def test_stream_returns_sse_with_done_marker(
         self,
@@ -338,7 +338,7 @@ class TestChatCompletions:
             resp = client.post(
                 "/unillm/chat/completions",
                 json={
-                    "model": "gpt-4o@openai",
+                    "model": "openai/gpt-4o@openrouter",
                     "messages": [{"role": "user", "content": "hi"}],
                     "stream": True,
                 },
@@ -377,7 +377,7 @@ class TestChatCompletions:
             client.post(
                 "/unillm/chat/completions",
                 json={
-                    "model": "gpt-4o@openai",
+                    "model": "openai/gpt-4o@openrouter",
                     "messages": [{"role": "user", "content": "hi"}],
                     "max_tokens": 42,
                 },
@@ -500,7 +500,7 @@ class TestSpendingEnforcement:
             resp = client.post(
                 "/unillm/chat/completions",
                 json={
-                    "model": "gpt-4o@openai",
+                    "model": "openai/gpt-4o@openrouter",
                     "messages": [{"role": "user", "content": "hi"}],
                 },
                 headers={"Authorization": "Bearer sk-test"},
@@ -538,7 +538,7 @@ class TestSpendingEnforcement:
             resp = client.post(
                 "/unillm/chat/completions",
                 json={
-                    "model": "gpt-4o@openai",
+                    "model": "openai/gpt-4o@openrouter",
                     "messages": [{"role": "user", "content": "hi"}],
                     "stream": True,
                 },
@@ -605,7 +605,7 @@ class TestSpendingEnforcement:
             resp = client.post(
                 "/unillm/chat/completions",
                 json={
-                    "model": "gpt-4o@openai",
+                    "model": "openai/gpt-4o@openrouter",
                     "messages": [{"role": "user", "content": "hi"}],
                 },
                 headers={"Authorization": "Bearer sk-caller"},
@@ -679,7 +679,7 @@ class TestSpendingEnforcement:
             resp = client.post(
                 "/unillm/chat/completions",
                 json={
-                    "model": "gpt-4o@openai",
+                    "model": "openai/gpt-4o@openrouter",
                     "messages": [{"role": "user", "content": "hi"}],
                 },
                 headers={"Authorization": "Bearer sk-test"},
@@ -731,7 +731,7 @@ class TestSpendingEnforcement:
             resp = client.post(
                 "/unillm/chat/completions",
                 json={
-                    "model": "gpt-4o@openai",
+                    "model": "openai/gpt-4o@openrouter",
                     "messages": [{"role": "user", "content": "hi"}],
                 },
                 headers={"Authorization": "Bearer sk-test"},
@@ -756,7 +756,10 @@ class TestSpendingEnforcement:
             os.environ["UNIFY_KEY"] = "sk-runtime"
             with patch("unify.spending_limits._check_user_limit", _boom):
                 return await check_spending_limits_callback(
-                    LimitCheckRequest(model="gpt-4o@openai", endpoint="chat"),
+                    LimitCheckRequest(
+                        model="openai/gpt-4o@openrouter",
+                        endpoint="chat",
+                    ),
                 )
 
         assert asyncio.run(_run()).allowed is True
@@ -805,7 +808,7 @@ class TestSpendingEnforcement:
             resp = client.post(
                 "/unillm/chat/completions",
                 json={
-                    "model": "gpt-4o@openai",
+                    "model": "openai/gpt-4o@openrouter",
                     "messages": [{"role": "user", "content": "hi"}],
                 },
                 headers={"Authorization": "Bearer sk-test"},
@@ -850,7 +853,10 @@ class TestSpendingEnforcement:
             os.environ["UNIFY_KEY"] = "sk-runtime"
             with patch("unify.spending_limits._check_user_limit", _no_api_access):
                 return await check_spending_limits_callback(
-                    LimitCheckRequest(model="gpt-4o@openai", endpoint="chat"),
+                    LimitCheckRequest(
+                        model="openai/gpt-4o@openrouter",
+                        endpoint="chat",
+                    ),
                 )
 
         assert asyncio.run(_run()).allowed is True

--- a/tests/gateway/test_app.py
+++ b/tests/gateway/test_app.py
@@ -251,7 +251,7 @@ def test_unillm_route_mounted_without_admin_auth(
     resp = client_no_lifespan.post(
         "/unillm/chat/completions",
         json={
-            "model": "gpt-4o@openai",
+            "model": "openai/gpt-4o@openrouter",
             "messages": [{"role": "user", "content": "hi"}],
         },
     )

--- a/tests/task_scheduler/test_custom_tasks.py
+++ b/tests/task_scheduler/test_custom_tasks.py
@@ -287,3 +287,33 @@ async def test_sync_writes_tags_onto_the_row_and_clears_them_on_removal(
     scheduler.sync_custom_tasks(source_tasks=collect_custom_tasks(path=untagged_dir))
     rows = scheduler._filter_tasks(filter="custom_key == 'ops/daily-check'", limit=1)
     assert not rows[0].tags
+
+
+def test_task_adapter_derived_stale_detects_repointed_entrypoint():
+    """A stored entrypoint id must track the function it was resolved from.
+
+    The content hash covers ``entrypoint_function`` (the name), never the
+    resolved id, so a re-registered functions store leaves the row dangling
+    with a matching hash; ``derived_stale`` is what forces the re-point.
+    """
+    from types import SimpleNamespace
+
+    from unify.task_scheduler.task_scheduler import _TaskSyncAdapter
+
+    scheduler_stub = SimpleNamespace(_custom_task_sync_workers=lambda: 1)
+    adapter = _TaskSyncAdapter(
+        scheduler_stub,
+        function_name_to_id={"run_gtm_stargazer_enrich_tick": 29},
+    )
+    fields = {"entrypoint_function": "run_gtm_stargazer_enrich_tick"}
+
+    assert adapter.derived_stale("k", {"entrypoint": 1}, fields)
+    assert adapter.derived_stale("k", {"entrypoint": None}, fields)
+    assert not adapter.derived_stale("k", {"entrypoint": 29}, fields)
+    # Unresolvable names are the writer's warning to raise, not churn here.
+    assert not adapter.derived_stale(
+        "k",
+        {"entrypoint": 1},
+        {"entrypoint_function": "run_unknown"},
+    )
+    assert not adapter.derived_stale("k", {"entrypoint": 1}, {})

--- a/tests/task_scheduler/test_custom_tasks.py
+++ b/tests/task_scheduler/test_custom_tasks.py
@@ -317,3 +317,27 @@ def test_task_adapter_derived_stale_detects_repointed_entrypoint():
         {"entrypoint_function": "run_unknown"},
     )
     assert not adapter.derived_stale("k", {"entrypoint": 1}, {})
+
+
+def test_entrypoint_resolution_participates_in_the_sync_hash():
+    """A function renumbering must invalidate the stored aggregate hash,
+    or the reconcile short-circuits and dangling entrypoints never heal."""
+    tasks = {
+        "ops/daily-check": {
+            "custom_hash": "abc",
+            "entrypoint_function": "run_daily_check",
+        },
+    }
+    base = compute_custom_tasks_hash(
+        source_tasks=tasks,
+        entrypoint_resolution={"run_daily_check": 1},
+    )
+    renumbered = compute_custom_tasks_hash(
+        source_tasks=tasks,
+        entrypoint_resolution={"run_daily_check": 29},
+    )
+    assert base != renumbered
+    assert base == compute_custom_tasks_hash(
+        source_tasks=tasks,
+        entrypoint_resolution={"run_daily_check": 1},
+    )

--- a/unify/actor/code_act_actor.py
+++ b/unify/actor/code_act_actor.py
@@ -5353,18 +5353,29 @@ class CodeActActor(BaseCodeActActor):
                         if attempts_remaining <= 0:
                             raise
                         attempts_remaining -= 1
-                        await self._repair_symbolic_entrypoint(
-                            entrypoint_id=entrypoint_id,
-                            request=request,
-                            entrypoint_kwargs=kwargs_for_entrypoint,
-                            failure=exc,
-                            repair_context=(
-                                entrypoint_repair_context
-                                if isinstance(entrypoint_repair_context, dict)
-                                else None
-                            ),
-                            destination=destination,
-                        )
+                        try:
+                            await self._repair_symbolic_entrypoint(
+                                entrypoint_id=entrypoint_id,
+                                request=request,
+                                entrypoint_kwargs=kwargs_for_entrypoint,
+                                failure=exc,
+                                repair_context=(
+                                    entrypoint_repair_context
+                                    if isinstance(entrypoint_repair_context, dict)
+                                    else None
+                                ),
+                                destination=destination,
+                            )
+                        except Exception as repair_exc:
+                            # The entrypoint failure is the actionable
+                            # record; a broken or refused repair pass must
+                            # not displace it in the execution row.
+                            logger.warning(
+                                "Symbolic entrypoint repair for %s failed: %s",
+                                entrypoint_id,
+                                repair_exc,
+                            )
+                            raise exc from repair_exc
 
             delegate_token = current_task_execution_delegate.set(
                 task_execution_delegate,

--- a/unify/canvas_manager/ops/review_ops.py
+++ b/unify/canvas_manager/ops/review_ops.py
@@ -508,9 +508,14 @@ def _render_and_critique(**kwargs: Any) -> ReviewReport:
 
     Kept separate from ``_render`` so the mechanical half stays testable without a
     model, and so a critique failure cannot be confused with a render failure.
+
+    A report with no screenshots is returned as-is: those are the skip paths
+    (no browser), and letting the critique's default verdict overwrite theirs
+    once disguised a pod whose chromium could not launch as a canvas that had
+    genuinely rendered.
     """
     report = _render(**kwargs)
-    if not report.rendered:
+    if not report.rendered or not report.screenshots:
         return report
 
     verdict, issues = _critique(report.screenshots)

--- a/unify/common/custom_sync.py
+++ b/unify/common/custom_sync.py
@@ -236,6 +236,21 @@ class CustomSyncAdapter:
         next reconcile retries."""
         return True
 
+    def derived_stale(
+        self,
+        key: str,
+        live_row: Dict[str, Any],
+        fields: Dict[str, Any],
+    ) -> bool:
+        """Return True when a field the writer derives from another store
+        (e.g. a function name resolved to a numeric id) no longer matches
+        its referent, forcing an update despite an unchanged content hash.
+
+        The content hash fingerprints the authored source only, so it is
+        blind to the referenced store being rewritten underneath the row.
+        """
+        return False
+
     def find_adoptable(
         self,
         key: str,
@@ -298,8 +313,14 @@ def _upsert_one(
     if key in live:
         live_row = live[key]
         if live_row.get("custom_hash") == fields.get("custom_hash"):
-            logger.debug("Custom %s unchanged: %s", adapter.kind, key)
-            return "unchanged"
+            if not adapter.derived_stale(key, live_row, fields):
+                logger.debug("Custom %s unchanged: %s", adapter.kind, key)
+                return "unchanged"
+            logger.info(
+                "Custom %s source unchanged but derived fields stale; " "updating: %s",
+                adapter.kind,
+                key,
+            )
         if not adapter.should_update(key, live_row, fields):
             logger.warning(
                 "Skipping update for custom %s key=%s this pass",

--- a/unify/common/llm_helpers.py
+++ b/unify/common/llm_helpers.py
@@ -1,4 +1,6 @@
 from __future__ import annotations
+import base64
+import binascii
 import json
 import asyncio
 import inspect
@@ -37,10 +39,33 @@ DEFAULT_TOOL_SCHEMA_STRICT = False
 # ─────────────────────────────────────────────────────────────────────────────
 
 
-# Recursively collect *every* base-64 image that lives under "image" key
+def _is_b64_image(value: str) -> bool:
+    """True when *value* is base64 whose decoded head carries a PNG or JPEG magic.
+
+    Payloads use "image" keys for plenty of non-image strings (asset URNs,
+    URLs, schema fragments); promoting those into image_url content blocks
+    ships garbage that providers reject as invalid base64. Magic bytes are
+    the only reliable discriminator, so anything undecodable or unrecognized
+    stays in the textual payload instead.
+    """
+    head = value[:44]
+    if len(head) < 8:
+        return False
+    try:
+        raw = base64.b64decode(head, validate=True)
+    except (binascii.Error, ValueError):
+        return False
+    return raw[:2] == b"\xff\xd8" or raw[:8] == b"\x89PNG\r\n\x1a\n"
+
+
+# Recursively collect *every* base-64 image that lives under an "image" key
 def _collect_images(obj, acc: list[str]) -> None:
     if isinstance(obj, dict):
-        if "image" in obj and isinstance(obj["image"], str):
+        if (
+            "image" in obj
+            and isinstance(obj["image"], str)
+            and _is_b64_image(obj["image"])
+        ):
             acc.append(obj["image"])
         for v in obj.values():
             _collect_images(v, acc)
@@ -75,8 +100,14 @@ def _strip_image_keys(obj):
                 obj_copy["content"] = new_content
                 return obj_copy
 
-        # Standard recursive dictionary copy
-        return {k: _strip_image_keys(v) for k, v in obj.items() if k != "image"}
+        # Standard recursive dictionary copy; only actual base64 images are
+        # stripped — non-image "image" values stay in the textual view since
+        # _collect_images never promotes them to blocks.
+        return {
+            k: _strip_image_keys(v)
+            for k, v in obj.items()
+            if not (k == "image" and isinstance(v, str) and _is_b64_image(v))
+        }
     elif isinstance(obj, list):
         return [_strip_image_keys(v) for v in obj]
     else:

--- a/unify/common/reasoning.py
+++ b/unify/common/reasoning.py
@@ -100,12 +100,9 @@ def get_llm_model_selection_context() -> str:
         Pass model overrides as UniLLM endpoint strings, e.g.
         `model="openai/gpt-5.4-mini@openrouter"`.
 
-        Reach OpenAI models through `@openrouter`, never through `@openai`.
-        The two suffixes are different providers: `@openai` is a native OpenAI
-        endpoint, and that account is inactive, so those calls burn a minute of
-        retries against a billing error before failing. `list_llms()` reports
-        every endpoint the runtime knows about, including native `@openai`
-        ones — being listed is not the same as being routable.
+        Reach OpenAI models through `@openrouter`, as
+        `openai/<model-id>@openrouter`. There is no `@openai` provider; every
+        endpoint `list_llms()` reports is routable.
 
         For durable or recurring stored functions, choose `model=` deliberately.
         Do not silently inherit the default high-reasoning model for bounded,

--- a/unify/dashboard_manager/dashboard_manager.py
+++ b/unify/dashboard_manager/dashboard_manager.py
@@ -102,21 +102,11 @@ def _get_active_project() -> str:
 
 
 def _build_tile_url(token: str) -> str:
-    console_url = getattr(SETTINGS, "CONSOLE_URL", "https://console.unify.ai")
-    if isinstance(console_url, str):
-        console_url = console_url.rstrip("/")
-    else:
-        console_url = "https://console.unify.ai"
-    return f"{console_url}/tile/view/{token}"
+    return f"{SETTINGS.CONSOLE_URL.rstrip('/')}/tile/view/{token}"
 
 
 def _build_dashboard_url(token: str) -> str:
-    console_url = getattr(SETTINGS, "CONSOLE_URL", "https://console.unify.ai")
-    if isinstance(console_url, str):
-        console_url = console_url.rstrip("/")
-    else:
-        console_url = "https://console.unify.ai"
-    return f"{console_url}/dashboard/view/{token}"
+    return f"{SETTINGS.CONSOLE_URL.rstrip('/')}/dashboard/view/{token}"
 
 
 def _require_dashboard_context(context: Optional[str], suffix: str) -> str:

--- a/unify/file_manager/filesystem_adapters/local_adapter.py
+++ b/unify/file_manager/filesystem_adapters/local_adapter.py
@@ -139,7 +139,14 @@ class LocalFileSystemAdapter(BaseFileSystemAdapter):
         except ValueError:
             pass
         if not resolved.exists():
-            candidate = (self._root / str(p).lstrip("/")).resolve()
+            # The managed VM exposes this same synced tree at /Unity/Local, so a
+            # path captured VM-side must be re-rooted against that prefix rather
+            # than appended to it: appending produced <root>/Unity/Local/... and
+            # reported the file missing while it sat in the workspace all along.
+            text = str(p)
+            if text.startswith("/Unity/Local/"):
+                text = text[len("/Unity/Local/") :]
+            candidate = (self._root / text.lstrip("/")).resolve()
             try:
                 candidate.relative_to(self._root)
                 return candidate

--- a/unify/function_manager/function_manager.py
+++ b/unify/function_manager/function_manager.py
@@ -60,9 +60,11 @@ from ..common.tool_outcome import ToolErrorException
 from .execution_env import ENVIRONMENT_MODULES, create_base_globals
 from .steering import (
     DEFAULT_TOOL_NAMESPACES,
+    ControlledInterruption,
     MemoisedDispatch,
     active_session,
     bind_session,
+    dispatch_with_steering,
     instrument,
     restore_session,
     run_with_steering,
@@ -496,6 +498,12 @@ class _VenvConnection:
         """
         Execute a function in the persistent venv subprocess.
 
+        While a steering session is in flight, each RPC reply doubles as a
+        checkpoint and a correction re-sends the (patched) source over the
+        same connection, replaying already-completed dispatches from the
+        parent's cache. The session arrives by contextvar so it follows the
+        call rather than this long-lived connection.
+
         Args:
             implementation: The function source code.
             call_kwargs: Keyword arguments to pass to the function.
@@ -517,48 +525,70 @@ class _VenvConnection:
                     f"Venv {self._venv_id} subprocess has died (returncode={self._process.returncode})",
                 )
 
-            # Send execute request
-            await self._write_message(
-                {
-                    "type": "execute",
-                    "implementation": implementation,
-                    "call_kwargs": call_kwargs,
-                    "is_async": is_async,
-                    "env_overlay": env_overlay or {},
-                },
-            )
+            async def _attempt(source: str) -> dict:
+                """Send one execute request for *source* and relay its RPC."""
+                await self._write_message(
+                    {
+                        "type": "execute",
+                        "implementation": source,
+                        "call_kwargs": call_kwargs,
+                        "is_async": is_async,
+                        "env_overlay": env_overlay or {},
+                    },
+                )
 
-            # Handle bidirectional RPC until we get a complete message
-            async def handle_rpc_loop() -> dict:
+                # Set when a correction interrupted this attempt; the child's
+                # completion is then an unwind to discard, not a result.
+                interrupted: Optional[ControlledInterruption] = None
+
                 while True:
                     msg = await self._read_message()
                     msg_type = msg.get("type")
 
                     if msg_type == "complete":
+                        if interrupted is not None:
+                            raise interrupted
                         return msg
 
                     if msg_type == "rpc_call":
                         # Handle RPC call from subprocess
-                        rpc_result = await self._handle_rpc_call(
-                            msg,
-                            primitives=primitives,
-                            computer_primitives=computer_primitives,
-                        )
-                        await self._write_message(rpc_result)
+                        try:
+                            reply = await self._handle_rpc_call(
+                                msg,
+                                primitives=primitives,
+                                computer_primitives=computer_primitives,
+                            )
+                        except ControlledInterruption as interruption:
+                            # The child is blocked on this reply, so telling
+                            # it to unwind here is the interrupt probe
+                            # realised without instrumentation.
+                            interrupted = interruption
+                            reply = {
+                                "type": "rpc_interrupt",
+                                "id": msg.get("id"),
+                                "reason": str(interruption),
+                            }
+                        await self._write_message(reply)
                     else:
                         logger.warning(
                             f"Venv {self._venv_id}: unexpected message type '{msg_type}'",
                         )
 
-            if timeout is not None:
+            async def _run(source: str) -> dict:
+                if timeout is None:
+                    return await _attempt(source)
                 try:
-                    return await asyncio.wait_for(handle_rpc_loop(), timeout=timeout)
+                    return await asyncio.wait_for(_attempt(source), timeout=timeout)
                 except asyncio.TimeoutError:
                     # After a timeout, the subprocess is in an unknown state.
                     # Mark it as tainted so the pool recreates it on next use.
                     self._tainted = True
                     raise
-            return await handle_rpc_loop()
+
+            steering = active_session()
+            if steering is None:
+                return await _run(implementation)
+            return await run_with_steering(implementation, _run, session=steering)
 
     async def _handle_rpc_call(
         self,
@@ -566,62 +596,31 @@ class _VenvConnection:
         primitives: Optional[Any],
         computer_primitives: Optional[Any],
     ) -> dict:
-        """Handle an RPC call from the subprocess."""
+        """Answer one RPC message from the subprocess.
+
+        Dispatch, memoisation and interrupts are shared with the one-shot
+        path via :meth:`FunctionManager._handle_rpc_call`, so a pooled session
+        cannot drift into being silently unsteerable. A
+        :class:`ControlledInterruption` propagates to the execute loop, which
+        owns telling the child to unwind.
+        """
         request_id = msg.get("id")
-        path = msg.get("path", "")
-        kwargs = msg.get("kwargs", {})
-
         try:
-            parts = path.split(".")
-            if len(parts) == 2:
-                namespace, method = parts
-                if namespace == "runtime" and method == "query_llm":
-                    from unify.common.reasoning import query_llm
-
-                    result = await query_llm(**kwargs)
-                    return {
-                        "type": "rpc_result",
-                        "id": request_id,
-                        "result": self._function_manager._make_json_serializable(
-                            result,
-                        ),
-                    }
-                if namespace == "runtime" and method == "list_llms":
-                    from unify.common.reasoning import list_llms
-
-                    result = list_llms(provider=kwargs.get("provider"))
-                    return {"type": "rpc_result", "id": request_id, "result": result}
-                if namespace == "runtime" and method == "get_oauth_access_token":
-                    from unify.common.runtime_oauth import get_oauth_access_token
-
-                    provider = kwargs.get("provider")
-                    min_ttl_seconds = int(kwargs.get("min_ttl_seconds", 300))
-                    result = get_oauth_access_token(
-                        provider,
-                        min_ttl_seconds=min_ttl_seconds,
-                    )
-                    return {"type": "rpc_result", "id": request_id, "result": result}
-                if namespace == "computer" and computer_primitives is not None:
-                    fn = getattr(computer_primitives, method, None)
-                elif primitives is not None:
-                    manager = getattr(primitives, namespace, None)
-                    fn = getattr(manager, method, None) if manager else None
-                else:
-                    fn = None
-
-                if fn is not None and callable(fn):
-                    result = fn(**kwargs)
-                    if asyncio.iscoroutine(result):
-                        result = await result
-                    return {"type": "rpc_result", "id": request_id, "result": result}
-
-            return {
-                "type": "rpc_error",
-                "id": request_id,
-                "error": f"Unknown RPC path: {path}",
-            }
+            result = await self._function_manager._handle_rpc_call(
+                path=msg.get("path", ""),
+                kwargs=msg.get("kwargs", {}),
+                primitives=primitives,
+                computer_primitives=computer_primitives,
+            )
+        except ControlledInterruption:
+            raise
         except Exception as e:
             return {"type": "rpc_error", "id": request_id, "error": str(e)}
+        return {
+            "type": "rpc_result",
+            "id": request_id,
+            "result": self._function_manager._make_json_serializable(result),
+        }
 
     async def get_state(self, timeout: float = 30.0) -> Dict[str, Any]:
         """
@@ -6290,6 +6289,13 @@ class FunctionManager(BaseFunctionManager):
         """
         Handle an RPC call from a subprocess.
 
+        Every out-of-process execution path — one-shot venv, pooled venv, and
+        shell — converges here, so this is where a steering session sees a
+        subprocess's dispatches: while a call is in flight they are memoised
+        for replay, pause holds the reply, and a pending correction raises
+        :class:`ControlledInterruption` for the caller to translate into an
+        ``rpc_interrupt`` message.
+
         Args:
             path: The RPC path (e.g., "contacts.ask", "computer.click")
             kwargs: The keyword arguments for the call
@@ -6299,6 +6305,31 @@ class FunctionManager(BaseFunctionManager):
         Returns:
             The result of the RPC call
         """
+
+        async def _dispatch() -> Any:
+            return await self._dispatch_rpc_path(
+                path=path,
+                kwargs=kwargs,
+                primitives=primitives,
+                computer_primitives=computer_primitives,
+            )
+
+        return await dispatch_with_steering(
+            active_session(),
+            path,
+            kwargs,
+            _dispatch,
+        )
+
+    async def _dispatch_rpc_path(
+        self,
+        *,
+        path: str,
+        kwargs: Dict[str, Any],
+        primitives: Optional[Any],
+        computer_primitives: Optional[Any],
+    ) -> Any:
+        """Resolve one RPC path against the runtime and primitives and call it."""
         parts = path.split(".", 1)
         if len(parts) != 2:
             raise ValueError(f"Invalid RPC path: {path}")
@@ -6378,6 +6409,11 @@ class FunctionManager(BaseFunctionManager):
         3. Handles bidirectional RPC for primitives and computer_primitives
         4. Returns the result from the subprocess
 
+        While a steering session is in flight, each RPC reply doubles as a
+        checkpoint and a correction re-runs the (patched) source in a fresh
+        subprocess, replaying already-completed dispatches from the parent's
+        cache.
+
         Args:
             venv_id: The virtual environment to use.
             implementation: The function source code.
@@ -6401,18 +6437,7 @@ class FunctionManager(BaseFunctionManager):
         python_path = await self.prepare_venv(venv_id=venv_id)
         runner_path = self._get_venv_runner_path(venv_id)
 
-        # Prepare initial execution request
-        execute_payload: Dict[str, Any] = {
-            "type": "execute",
-            "implementation": implementation,
-            "call_kwargs": call_kwargs,
-            "is_async": is_async,
-            "env_overlay": env_overlay or self._get_runtime_oauth_env_overlay(),
-        }
-        if initial_state is not None:
-            execute_payload["initial_state"] = initial_state
-
-        execute_msg = json.dumps(execute_payload) + "\n"
+        env_overlay = env_overlay or self._get_runtime_oauth_env_overlay()
 
         # Execute in subprocess with bidirectional communication
         # Use start_new_session=True to create a new process group, allowing
@@ -6493,124 +6518,149 @@ class FunctionManager(BaseFunctionManager):
 
         from unify.provider_proxy.session import build_sandbox_env
 
-        process = await asyncio.create_subprocess_exec(
-            str(python_path),
-            str(runner_path),
-            stdin=asyncio.subprocess.PIPE,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            start_new_session=use_process_group,
-            env=build_sandbox_env(),
-        )
+        async def _attempt(source: str) -> Dict[str, Any]:
+            """Run one subprocess attempt at *source*, relaying its RPC."""
+            execute_payload: Dict[str, Any] = {
+                "type": "execute",
+                "implementation": source,
+                "call_kwargs": call_kwargs,
+                "is_async": is_async,
+                "env_overlay": env_overlay,
+            }
+            if initial_state is not None:
+                execute_payload["initial_state"] = initial_state
 
-        # Send initial execution request
-        process.stdin.write(execute_msg.encode())
-        await process.stdin.drain()
+            process = await asyncio.create_subprocess_exec(
+                str(python_path),
+                str(runner_path),
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                start_new_session=use_process_group,
+                env=build_sandbox_env(),
+            )
 
-        # Handle bidirectional communication
-        stderr_output = []
+            # Send initial execution request
+            process.stdin.write((json.dumps(execute_payload) + "\n").encode())
+            await process.stdin.drain()
 
-        async def read_stderr():
-            """Read stderr in background."""
-            while True:
-                line = await process.stderr.readline()
-                if not line:
-                    break
-                stderr_output.append(line.decode())
+            # Handle bidirectional communication
+            stderr_output = []
 
-        stderr_task = asyncio.create_task(read_stderr())
+            async def read_stderr():
+                """Read stderr in background."""
+                while True:
+                    line = await process.stderr.readline()
+                    if not line:
+                        break
+                    stderr_output.append(line.decode())
 
-        try:
-            while True:
-                # Read next message from subprocess
-                line = await process.stdout.readline()
-                if not line:
-                    # Process ended without sending complete message
-                    await stderr_task
-                    return {
-                        "result": None,
-                        "error": "Subprocess ended unexpectedly",
-                        "stdout": "",
-                        "stderr": "".join(stderr_output),
-                    }
+            stderr_task = asyncio.create_task(read_stderr())
+            # Set when a correction interrupted this attempt; the child's
+            # completion is then an unwind to discard, not a result.
+            interrupted: Optional[ControlledInterruption] = None
 
-                try:
-                    msg = json.loads(line.decode().strip())
-                except json.JSONDecodeError as e:
-                    continue  # Skip malformed lines
-
-                msg_type = msg.get("type")
-
-                if msg_type == "rpc_call":
-                    # Handle RPC call from subprocess
-                    request_id = msg.get("id")
-                    path = msg.get("path", "")
-                    rpc_kwargs = msg.get("kwargs", {})
+            try:
+                while True:
+                    # Read next message from subprocess
+                    line = await process.stdout.readline()
+                    if not line:
+                        # Process ended without sending complete message
+                        await stderr_task
+                        if interrupted is not None:
+                            raise interrupted
+                        return {
+                            "result": None,
+                            "error": "Subprocess ended unexpectedly",
+                            "stdout": "",
+                            "stderr": "".join(stderr_output),
+                        }
 
                     try:
-                        result = await self._handle_rpc_call(
-                            path=path,
-                            kwargs=rpc_kwargs,
-                            primitives=primitives,
-                            computer_primitives=computer_primitives,
-                        )
-                        response = (
-                            json.dumps(
-                                {
-                                    "type": "rpc_result",
-                                    "id": request_id,
-                                    "result": self._make_json_serializable(result),
-                                },
-                            )
-                            + "\n"
-                        )
-                    except Exception as e:
-                        response = (
-                            json.dumps(
-                                {
-                                    "type": "rpc_error",
-                                    "id": request_id,
-                                    "error": str(e),
-                                },
-                            )
-                            + "\n"
-                        )
+                        msg = json.loads(line.decode().strip())
+                    except json.JSONDecodeError:
+                        continue  # Skip malformed lines
 
-                    process.stdin.write(response.encode())
-                    await process.stdin.drain()
+                    msg_type = msg.get("type")
 
-                elif msg_type == "complete":
-                    # Subprocess finished
+                    if msg_type == "rpc_call":
+                        # Handle RPC call from subprocess
+                        request_id = msg.get("id")
+
+                        try:
+                            result = await self._handle_rpc_call(
+                                path=msg.get("path", ""),
+                                kwargs=msg.get("kwargs", {}),
+                                primitives=primitives,
+                                computer_primitives=computer_primitives,
+                            )
+                            response = {
+                                "type": "rpc_result",
+                                "id": request_id,
+                                "result": self._make_json_serializable(result),
+                            }
+                        except ControlledInterruption as interruption:
+                            # The child is blocked on this reply, so telling
+                            # it to unwind here is the interrupt probe
+                            # realised without instrumentation.
+                            interrupted = interruption
+                            response = {
+                                "type": "rpc_interrupt",
+                                "id": request_id,
+                                "reason": str(interruption),
+                            }
+                        except Exception as e:
+                            response = {
+                                "type": "rpc_error",
+                                "id": request_id,
+                                "error": str(e),
+                            }
+
+                        process.stdin.write((json.dumps(response) + "\n").encode())
+                        await process.stdin.drain()
+
+                    elif msg_type == "complete":
+                        # Subprocess finished
+                        await stderr_task
+                        if interrupted is not None:
+                            raise interrupted
+                        return {
+                            "result": msg.get("result"),
+                            "error": msg.get("error"),
+                            "stdout": msg.get("stdout", ""),
+                            "stderr": msg.get("stderr", "") + "".join(stderr_output),
+                        }
+
+            except (asyncio.CancelledError, ControlledInterruption):
+                # Cancellation unwinds to the caller and an interruption to
+                # the retry loop, both after cleanup in the finally block.
+                raise
+            except Exception as e:
+                return {
+                    "result": None,
+                    "error": f"RPC error: {e}",
+                    "stdout": "",
+                    "stderr": "".join(stderr_output),
+                }
+            finally:
+                # Cancel stderr reader task
+                stderr_task.cancel()
+                try:
                     await stderr_task
-                    return {
-                        "result": msg.get("result"),
-                        "error": msg.get("error"),
-                        "stdout": msg.get("stdout", ""),
-                        "stderr": msg.get("stderr", "") + "".join(stderr_output),
-                    }
+                except asyncio.CancelledError:
+                    pass
 
-        except asyncio.CancelledError:
-            # Task was cancelled (e.g., Actor.stop() was called)
-            # Re-raise after cleanup in finally block
-            raise
-        except Exception as e:
-            return {
-                "result": None,
-                "error": f"RPC error: {e}",
-                "stdout": "",
-                "stderr": "".join(stderr_output),
-            }
-        finally:
-            # Cancel stderr reader task
-            stderr_task.cancel()
-            try:
-                await stderr_task
-            except asyncio.CancelledError:
-                pass
+                # Ensure process and all its children are terminated
+                if process.returncode is None:
+                    await self._terminate_process_group(process, use_process_group)
 
-            # Ensure process and all its children are terminated
-            if process.returncode is None:
-                await self._terminate_process_group(process, use_process_group)
+        # One-shot subprocesses give a retry a clean slate: each attempt is a
+        # fresh child, and the parent-side cache is what carries the completed
+        # prefix across attempts.
+        steering = active_session()
+        if steering is None:
+            return await _attempt(implementation)
+        return await run_with_steering(implementation, _attempt, session=steering)
 
     async def _terminate_process_group(
         self,

--- a/unify/function_manager/function_manager.py
+++ b/unify/function_manager/function_manager.py
@@ -46,6 +46,7 @@ from ..common.embed_utils import ensure_vector_column, list_private_fields
 from ..common.custom_sync import (
     CustomSyncAdapter,
     CustomSyncPartialFailure,
+    managed_rows_filter,
     run_custom_sync,
 )
 from ..common.sync_lease import exclusive_sync_lease
@@ -8081,9 +8082,10 @@ for _method_name in (
 class _VenvSyncAdapter(CustomSyncAdapter):
     """Storage mechanics for the custom venvs reconcile.
 
-    Venv identity is the name (``custom_key == name``). Rows written
-    before the ``custom_key`` column existed are matched by name and
-    stamped on their next content change.
+    Venv identity is the name (``custom_key == name``). Legacy rows with
+    a null ``custom_key`` are matched by name, and same-named rows outside
+    the managed index are adopted in place so their ``venv_id`` survives:
+    function rows hold that id.
     """
 
     kind = "venvs"
@@ -8094,13 +8096,16 @@ class _VenvSyncAdapter(CustomSyncAdapter):
     def live_rows(self) -> List[Dict[str, Any]]:
         logs = unisdk.get_logs(
             context=self._manager._venvs_ctx,
-            filter="custom_hash != None",
+            filter=managed_rows_filter(self.source_id),
             exclude_fields=list_private_fields(self._manager._venvs_ctx),
         )
         rows: List[Dict[str, Any]] = []
         for lg in logs:
             entries = dict(lg.entries or {})
-            entries.setdefault("custom_key", entries.get("name"))
+            # A null custom_key would survive setdefault and drop the row
+            # from the managed index — see _FunctionSyncAdapter.live_rows.
+            if not entries.get("custom_key"):
+                entries["custom_key"] = entries.get("name")
             rows.append(entries)
         return rows
 
@@ -8121,11 +8126,13 @@ class _VenvSyncAdapter(CustomSyncAdapter):
     def delete(self, key: str, live_row: Dict[str, Any]) -> None:
         self._manager._delete_custom_venv_by_name(str(live_row["name"]))
 
-    def find_collision(
+    def find_adoptable(
         self,
         key: str,
         fields: Dict[str, Any],
     ) -> Optional[Dict[str, Any]]:
+        """Claim any same-named row rather than reinserting, preserving
+        the ``venv_id`` that function rows reference."""
         existing = unisdk.get_logs(
             context=self._manager._venvs_ctx,
             filter=f"name == '{fields['name']}'",
@@ -8133,13 +8140,7 @@ class _VenvSyncAdapter(CustomSyncAdapter):
         )
         if not existing:
             return None
-        return {"_log_id": existing[0].id, **dict(existing[0].entries or {})}
-
-    def remove_collision(self, key: str, live_row: Dict[str, Any]) -> None:
-        unisdk.delete_logs(
-            context=self._manager._venvs_ctx,
-            logs=[live_row["_log_id"]],
-        )
+        return dict(existing[0].entries or {})
 
 
 class _FunctionSyncAdapter(CustomSyncAdapter):
@@ -8147,8 +8148,10 @@ class _FunctionSyncAdapter(CustomSyncAdapter):
 
     Function identity is the name (``custom_key == name``) — the
     call-site contract — so a rename is a delete-and-create by design.
-    Legacy rows without the ``custom_key`` column are matched by name
-    and stamped on their next content change.
+    Legacy rows carrying a null ``custom_key`` are matched by name, and
+    same-named rows outside the managed index are adopted in place so
+    their ``function_id`` survives: task entrypoints hold that id, and a
+    delete-and-reinsert would orphan every one of them.
     """
 
     kind = "functions"
@@ -8165,13 +8168,17 @@ class _FunctionSyncAdapter(CustomSyncAdapter):
     def live_rows(self) -> List[Dict[str, Any]]:
         logs = unisdk.get_logs(
             context=self._manager._compositional_ctx,
-            filter="custom_hash != None",
+            filter=managed_rows_filter(self.source_id),
             exclude_fields=list_private_fields(self._manager._compositional_ctx),
         )
         rows: List[Dict[str, Any]] = []
         for lg in logs:
             entries = dict(lg.entries or {})
-            entries.setdefault("custom_key", entries.get("name"))
+            # The column may exist with a null value on legacy rows, which
+            # setdefault would keep — and a null key drops the row from the
+            # managed index, sending every entry down the reinsert path.
+            if not entries.get("custom_key"):
+                entries["custom_key"] = entries.get("name")
             rows.append(entries)
         return rows
 
@@ -8199,11 +8206,17 @@ class _FunctionSyncAdapter(CustomSyncAdapter):
     def delete(self, key: str, live_row: Dict[str, Any]) -> None:
         self._manager._delete_custom_function_by_name(str(live_row["name"]))
 
-    def find_collision(
+    def find_adoptable(
         self,
         key: str,
         fields: Dict[str, Any],
     ) -> Optional[Dict[str, Any]]:
+        """Claim any same-named row rather than reinserting.
+
+        Adoption updates in place via ``function_id``, so references held
+        by task entrypoints stay valid; the update stamps
+        ``custom_key``/``custom_hash``/``source_id`` alongside the body.
+        """
         existing = unisdk.get_logs(
             context=self._manager._compositional_ctx,
             filter=f"name == '{fields['name']}'",
@@ -8211,10 +8224,4 @@ class _FunctionSyncAdapter(CustomSyncAdapter):
         )
         if not existing:
             return None
-        return {"_log_id": existing[0].id, **dict(existing[0].entries or {})}
-
-    def remove_collision(self, key: str, live_row: Dict[str, Any]) -> None:
-        unisdk.delete_logs(
-            context=self._manager._compositional_ctx,
-            logs=[live_row["_log_id"]],
-        )
+        return dict(existing[0].entries or {})

--- a/unify/function_manager/primitives/registry.py
+++ b/unify/function_manager/primitives/registry.py
@@ -166,7 +166,17 @@ _MANAGER_SPECS: tuple[ManagerSpec, ...] = (
             "and set ``destructive=True`` with ``confirm`` text for anything "
             "irreversible -- Console shows that outside the frame with the real "
             "arguments. Prefer ``update_view`` over creating a second canvas: the "
-            "URL is stable, so anywhere it was shared keeps working."
+            "URL is stable, so anywhere it was shared keeps working. "
+            "VERIFY WITH YOUR EYES: ``result.review.screenshots`` holds light and "
+            "dark captures of what was actually published -- ``display()`` them "
+            "and judge the result against what the user asked for before "
+            "declaring the work done; a canvas that compiles can still be empty, "
+            "clipped or unreadable. ``review.verdict`` and ``review.issues`` are "
+            "advisory; a verdict starting 'skipped' means nothing was rendered, "
+            "so say so rather than claiming it was reviewed. "
+            "SHARE THE URL: include ``result.url`` in your user-facing reply -- "
+            "pasting it into chat is what embeds the live canvas there, and it "
+            "is the link the user opens and returns to."
         ),
     ),
     ManagerSpec(

--- a/unify/function_manager/steering.py
+++ b/unify/function_manager/steering.py
@@ -29,6 +29,13 @@ call begins and discarded when it returns. Nothing survives into the next call,
 which is what keeps the positional cache key sound: the surrounding code cannot
 have changed underneath it, because the block is still the one that is running.
 
+Code that runs in another process — a venv subprocess, a shell script — is
+steered without instrumentation, because its JSON-RPC protocol already blocks
+the child at every primitive dispatch until the parent replies. The parent
+treats each reply as a checkpoint (:func:`dispatch_with_steering`) and re-sends
+patched source on retry; only dispatches are visible, so a loop that makes no
+primitive call cannot be paused or corrected out-of-process.
+
 What this deliberately does not do
 ----------------------------------
 Replay records that a side effect happened; it cannot undo one. A patch
@@ -827,6 +834,76 @@ class MemoisedDispatch:
             self._session,
             name,
         )
+
+
+# ---------------------------------------------------------------------------
+# Out-of-process dispatch
+# ---------------------------------------------------------------------------
+def _targets_running_block(request: InterruptionRequest, source: str) -> bool:
+    """Whether a correction is aimed at the block running out-of-process.
+
+    In-process, ``_int(name)`` fires only inside the function a patch names.
+    The parent cannot see which function a child process is inside, so the
+    nearest sound reading is "the patch names a function this block defines":
+    firing early costs one replay-backed retry, whereas not firing would let
+    the remaining dispatches run under a correction that asked them not to.
+
+    Source that is not Python — a shell script — defines nothing a patch can
+    name, so nothing fires; the patch author likewise refuses to author
+    patches for it. Shell tops out at pause and replay.
+    """
+    if not request.patches:
+        return False
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return False
+    defined = {
+        node.name
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+    return any(patch.function_name in defined for patch in request.patches)
+
+
+async def dispatch_with_steering(
+    session: Optional[SteeringSession],
+    tool: str,
+    kwargs: dict,
+    dispatch: typing.Callable[[], typing.Awaitable[Any]],
+) -> Any:
+    """One out-of-process dispatch, steered from the parent side.
+
+    A child process making a ``primitives.*`` call is blocked until the
+    parent replies, which makes the reply the checkpoint: pause holds here,
+    a pending correction interrupts here, and a dispatch the previous attempt
+    already made replays from the cache instead of running again. The child
+    needs no instrumentation for any of this — the suspension is a property
+    of the RPC protocol itself.
+
+    ``tool`` is the RPC path (``contacts.ask``), which is the same string the
+    in-process :class:`MemoisedDispatch` records, so cache entries mean the
+    same thing whichever side of the process boundary made them.
+
+    Raises :class:`ControlledInterruption` when a pending correction targets
+    the running block. The caller owns translating that into an
+    ``rpc_interrupt`` reply so the child unwinds, and re-raising it into the
+    retry loop; the request itself stays pending, because consuming it is
+    :func:`run_with_steering`'s job.
+    """
+    if session is None:
+        return await dispatch()
+    await session.cp(f"RPC: {tool}")
+    request = session.interruption
+    if request is not None and _targets_running_block(request, session.source):
+        raise ControlledInterruption(request.reason or "steered")
+    key = make_cache_key(session, tool, (), kwargs)
+    hit = session.cache.get(key)
+    if hit is not None:
+        return hit["result"]
+    result = await dispatch()
+    session.cache.put(key, result, tool=tool)
+    return result
 
 
 # ---------------------------------------------------------------------------

--- a/unify/function_manager/venv_runner.py
+++ b/unify/function_manager/venv_runner.py
@@ -16,6 +16,7 @@ During execution, subprocess can send RPC requests:
 Main process responds with:
     {"type": "rpc_result", "id": str, "result": Any}
     {"type": "rpc_error", "id": str, "error": str}
+    {"type": "rpc_interrupt", "id": str, "reason": str}
 
 Final response from subprocess:
     {"type": "complete", "result": Any, "error": str|null, "stdout": str, "stderr": str}
@@ -101,6 +102,16 @@ _stdin_lock = threading.Lock()
 _stdout_lock = threading.Lock()
 
 
+class ControlledInterruption(Exception):
+    """Raised at a blocked RPC call site when the parent interrupts the run.
+
+    The parent holds a correction for this block and wants the attempt to
+    unwind so it can re-send patched source. Calls the attempt already
+    completed replay from the parent's cache on the re-run, so unwinding here
+    does not repeat their effects.
+    """
+
+
 def send_message(msg: dict) -> None:
     """Send a JSON message to stdout (to main process)."""
     with _stdout_lock:
@@ -141,6 +152,8 @@ def rpc_call_sync(path: str, kwargs: dict) -> Any:
         # Wait for response
         response = response_queue.get(timeout=300)  # 5 minute timeout
 
+        if response.get("type") == "rpc_interrupt":
+            raise ControlledInterruption(response.get("reason") or "interrupted")
         if response.get("type") == "rpc_error":
             raise RuntimeError(f"RPC error: {response.get('error')}")
 
@@ -901,7 +914,7 @@ def run_with_rpc_loop(
                 line = sys.__stdin__.readline()
                 if line:
                     msg = json.loads(line.strip())
-                    if msg.get("type") in ("rpc_result", "rpc_error"):
+                    if msg.get("type") in ("rpc_result", "rpc_error", "rpc_interrupt"):
                         dispatch_rpc_response(msg)
         except Exception:
             # On Windows or if select fails, just do blocking read with thread check
@@ -1037,7 +1050,7 @@ def run_server_with_rpc_loop(
                 line = sys.__stdin__.readline()
                 if line:
                     msg = json.loads(line.strip())
-                    if msg.get("type") in ("rpc_result", "rpc_error"):
+                    if msg.get("type") in ("rpc_result", "rpc_error", "rpc_interrupt"):
                         dispatch_rpc_response(msg)
         except Exception:
             pass

--- a/unify/gateway/channels/unillm/views.py
+++ b/unify/gateway/channels/unillm/views.py
@@ -126,7 +126,8 @@ async def chat_completions(
     forwarding to UniLLM.
 
     The model should be specified in UniLLM format: ``model@provider``
-    (e.g. ``claude-sonnet-4-20250514@anthropic``, ``gpt-4o@openai``).
+    (e.g. ``claude-sonnet-4-20250514@anthropic``,
+    ``openai/gpt-4o@openrouter``).
     """
     api_key = _extract_api_key(request)
     user_info = await _authenticate_user_api_key(api_key)

--- a/unify/gateway/local_setup.py
+++ b/unify/gateway/local_setup.py
@@ -346,11 +346,6 @@ CHANNEL_SETUPS: tuple[ChannelSetup, ...] = (
                 required=False,
             ),
             CredentialSpec(
-                "OPENAI_API_KEY",
-                "OpenAI API key for native *@openai model calls",
-                required=False,
-            ),
-            CredentialSpec(
                 "ANTHROPIC_API_KEY",
                 "Anthropic API key for local model calls",
                 required=False,

--- a/unify/settings.py
+++ b/unify/settings.py
@@ -103,6 +103,10 @@ class ProductionSettings(BaseSettings):
     # Infrastructure URLs
     # ─────────────────────────────────────────────────────────────────────────
     ORCHESTRA_URL: str = "https://api.unify.ai/v0"
+    # Console origin used to build user-facing links (canvas and dashboard
+    # views). Per-environment deployments override this or every shared link
+    # points at production Console regardless of where the row lives.
+    CONSOLE_URL: str = "https://console.unify.ai"
     UNITY_COORDINATOR_EMAIL_ADDRESS: str = "twin@unify.ai"
     # Catch-all domain for multiplayer twin alias addresses, and the Workspace
     # mailbox that receives them. Alias addresses have no Workspace user of

--- a/unify/settings.py
+++ b/unify/settings.py
@@ -78,6 +78,8 @@ class ProductionSettings(BaseSettings):
     # ─────────────────────────────────────────────────────────────────────────
     # LLM Provider Credentials
     # ─────────────────────────────────────────────────────────────────────────
+    # OpenAI — speech-to-text and realtime voice only. OpenAI chat models are
+    # reached as ``openai/<id>@openrouter``, so this cannot satisfy LLM access.
     OPENAI_API_KEY: SecretStr = SecretStr("")
     ANTHROPIC_API_KEY: SecretStr = SecretStr("")
     DEEPSEEK_API_KEY: SecretStr = SecretStr("")
@@ -314,7 +316,6 @@ class ProductionSettings(BaseSettings):
         if not self.UNITY_VALIDATE_LLM_PROVIDERS:
             return
         available = {
-            "OPENAI_API_KEY": self.OPENAI_API_KEY,
             "ANTHROPIC_API_KEY": self.ANTHROPIC_API_KEY,
             "DEEPSEEK_API_KEY": self.DEEPSEEK_API_KEY,
             "OPENROUTER_API_KEY": self.OPENROUTER_API_KEY,
@@ -322,7 +323,7 @@ class ProductionSettings(BaseSettings):
         if not any(available.values()):
             raise RuntimeError(
                 "At least one LLM provider credential is required. "
-                "Set OPENROUTER_API_KEY, OPENAI_API_KEY, ANTHROPIC_API_KEY, "
+                "Set OPENROUTER_API_KEY, ANTHROPIC_API_KEY, "
                 "and/or DEEPSEEK_API_KEY.",
             )
 

--- a/unify/task_scheduler/custom_tasks.py
+++ b/unify/task_scheduler/custom_tasks.py
@@ -218,14 +218,28 @@ def collect_custom_tasks(
 
 def compute_custom_tasks_hash(
     source_tasks: Optional[Dict[str, Dict[str, Any]]] = None,
+    *,
+    entrypoint_resolution: Optional[Dict[str, Optional[int]]] = None,
 ) -> str:
-    """Compute an aggregate hash of custom task entries."""
+    """Aggregate fingerprint of the custom task entries and their derived
+    entrypoint resolution.
+
+    Per-entry ``custom_hash`` covers authored source fields only, so it is
+    blind to the functions store being re-registered under new ids. Folding
+    the ``entrypoint_function`` → ``function_id`` resolution into the
+    aggregate makes a function renumbering invalidate the stored hash,
+    which forces the per-key pass whose ``derived_stale`` check re-points
+    dangling rows.
+    """
     tasks = source_tasks if source_tasks is not None else {}
     if not tasks:
         return ""
 
-    sorted_hashes = [tasks[key]["custom_hash"] for key in sorted(tasks.keys())]
-    combined = "|".join(sorted_hashes)
+    parts = [tasks[key]["custom_hash"] for key in sorted(tasks.keys())]
+    parts += [
+        f"{name}={fid}" for name, fid in sorted((entrypoint_resolution or {}).items())
+    ]
+    combined = "|".join(parts)
     return hashlib.sha256(combined.encode()).hexdigest()[:16]
 
 

--- a/unify/task_scheduler/task_scheduler.py
+++ b/unify/task_scheduler/task_scheduler.py
@@ -1263,7 +1263,13 @@ class TaskScheduler(BaseTaskScheduler):
                 scheduler=self,
                 entrypoint=task.entrypoint,
                 entrypoint_kwargs=entrypoint_kwargs,
-                entrypoint_repair_attempts=1 if task.entrypoint is not None else 0,
+                # Deployment-owned tasks (custom_hash set) are healed by
+                # bundle resync, never by LLM repair — including when the
+                # entrypoint row itself is missing, where the per-function
+                # ownership guard has nothing left to inspect.
+                entrypoint_repair_attempts=(
+                    1 if task.entrypoint is not None and not task.custom_hash else 0
+                ),
                 entrypoint_repair_context=(
                     {
                         "task_run_context": entrypoint_kwargs.get(
@@ -1398,7 +1404,13 @@ class TaskScheduler(BaseTaskScheduler):
             scheduler=self,
             entrypoint=definition.entrypoint,
             entrypoint_kwargs=entrypoint_kwargs,
-            entrypoint_repair_attempts=1 if definition.entrypoint is not None else 0,
+            # Same ownership rule as the scheduled path: bundle-owned tasks
+            # never LLM-repair, even when the entrypoint row is gone.
+            entrypoint_repair_attempts=(
+                1
+                if definition.entrypoint is not None and not definition.custom_hash
+                else 0
+            ),
             entrypoint_repair_context=(
                 {
                     "task_run_context": entrypoint_kwargs.get(
@@ -3524,6 +3536,26 @@ class _TaskSyncAdapter(CustomSyncAdapter):
             )
             is None
         )
+
+    def derived_stale(
+        self,
+        key: str,
+        live_row: Dict[str, Any],
+        fields: Dict[str, Any],
+    ) -> bool:
+        """The stored ``entrypoint`` is a function id resolved from
+        ``entrypoint_function`` at write time. When the functions store is
+        re-registered under new ids, the row dangles while its content
+        hash — which covers the name, never the id — still matches.
+        """
+        entrypoint_function = fields.get("entrypoint_function")
+        if not entrypoint_function:
+            return False
+        resolved = self._function_name_to_id.get(entrypoint_function)
+        if resolved is None:
+            return False
+        stored = live_row.get("entrypoint")
+        return stored is None or int(stored) != int(resolved)
 
     def insert(self, key: str, fields: Dict[str, Any]) -> None:
         self._scheduler._insert_custom_task(

--- a/unify/task_scheduler/task_scheduler.py
+++ b/unify/task_scheduler/task_scheduler.py
@@ -3437,15 +3437,21 @@ class TaskScheduler(BaseTaskScheduler):
                 source_tasks = source_tasks or {}
                 synced_key = (tasks_context, source_id)
 
+                name_to_id = function_name_to_id or {}
                 return run_custom_sync(
                     adapter=_TaskSyncAdapter(
                         self,
-                        function_name_to_id=function_name_to_id or {},
+                        function_name_to_id=name_to_id,
                         source_id=source_id,
                     ),
                     source=source_tasks,
                     expected_hash=compute_custom_tasks_hash(
                         source_tasks=source_tasks,
+                        entrypoint_resolution={
+                            name: name_to_id.get(name)
+                            for entry in source_tasks.values()
+                            if (name := entry.get("entrypoint_function"))
+                        },
                     ),
                     stored_hash=self._get_stored_custom_tasks_hash(source_id),
                     already_synced=synced_key in self._custom_tasks_synced_sources,


### PR DESCRIPTION
Release PR from staging to main.

Carries the reconcile identity fixes (functions/venvs adopt in place instead of renumbering; tasks re-resolve dangling entrypoint ids via the derived_stale hook) and the repair-path fixes (deployment-owned tasks never LLM-repair, image promotion validates base64 magic bytes, repair failures no longer mask the original error) from the 2026-08-03 production incident.