### PR TITLE
[parallel_run.sh tests/function_manager/core/test_filter_scope.py tests/task_scheduler/test_custom_tasks.py] Release: staging → main

### DIFF
--- a/.agents/plans/out-of-process-steering.md
+++ b/.agents/plans/out-of-process-steering.md
@@ -1,38 +1,21 @@
 # Plan: steering out-of-process execution
 
-**Status:** Phase 1 built and tested — venv (one-shot and pooled) and shell.
-Phase 2 (instrumented child source) not started, deliberately. Non-local
-surfaces turned out not to share the RPC transport at all (see below) and are
-out of scope for this mechanism.
+**Status:** Phases 1 and 2 built and tested. Phase 1 — dispatch-boundary
+steering over the RPC channel — covers venv (one-shot and pooled) and shell.
+Phase 2 — instrumented child source plus a push control channel — closes the
+non-dispatching-loop gap for venv. Non-local surfaces turned out not to share
+the RPC transport at all (see below) and are out of scope for this mechanism.
 
 Live steering — correcting a block of code while it is still running — works
-for every in-process Python path and, at the dispatch boundary, for code
-running in venv subprocesses and shell scripts. This document records how, and
+for every in-process Python path, at the dispatch boundary for venv and shell
+subprocesses, and between dispatches for venv. This document records how, and
 what was learned closing the plan's open questions.
 
 Read `unify/function_manager/steering.py` first. Its four parts (probes,
 idempotency cache, retry via source splice, bounded lifetime) are reused
-out-of-process rather than replaced; the out-of-process entry point is
-`dispatch_with_steering` in the same module.
-
-## Read this before deciding how much more to build
-
-The work split into two phases with very different costs, and **Phase 1 is
-worth having on its own**. It is not groundwork for Phase 2; it is the whole
-feature for most cases.
-
-Phase 1 makes out-of-process execution correctable at every side effect that
-goes through primitives, and that is the case the mechanism exists for — the
-reason to steer is to stop a side effect before it happens, and side effects
-are overwhelmingly primitive dispatches. It needed no changes to how the child
-executes code, and it covers venv and shell at once.
-
-Phase 2 closes one specific remaining gap: a loop in the child that does no
-primitive call, and so is invisible to the parent. It is venv-only, it is the
-only part with a performance question, and it should be built when a real
-workload needs it rather than for completeness.
-
-If Phase 2 never happens, this feature is not half-finished.
+out-of-process rather than replaced; the out-of-process entry points are
+`dispatch_with_steering` and `SteeringSession.relay_corrections` in the same
+module.
 
 ---
 
@@ -45,17 +28,21 @@ If Phase 2 never happens, this feature is not half-finished.
 - `FunctionManager._execute_in_default_env` — the route that skips the sandbox
   entirely and runs a stored function directly
 
-And every out-of-process path that round-trips primitives over JSON-RPC
-(dispatch-boundary, no instrumentation):
+Venv subprocesses, with the same statement-level probes the in-process paths
+get — the parent instruments the source before shipping it, and interrupts
+land both at RPC replies and, via the control channel, inside loops that make
+no primitive call:
 
 - One-shot venv subprocesses — `FunctionManager.execute_in_venv`
 - Pooled persistent venv sessions — `_VenvConnection.execute`
-- Shell scripts using the `unity-primitive` bridge —
-  `FunctionManager.execute_shell_script` (cache and pause only; see the
-  boundaries section for why interrupts cannot fire on shell)
 
-**Not covered.** Non-local surfaces (`surface != "local"`), and any child-side
-work between dispatches (Phase 2).
+Shell scripts using the `unity-primitive` bridge get dispatch-boundary
+steering only — `FunctionManager.execute_shell_script` (cache and pause; see
+the boundaries section for why interrupts cannot fire on shell).
+
+**Not covered.** Non-local surfaces (`surface != "local"`), synchronous
+functions (no awaits, so no probes — parity with in-process), and blocking
+calls between checkpoints.
 
 ---
 
@@ -68,10 +55,12 @@ to and from the child process". We already had one.
 docstring:
 
 ```
-{"type": "rpc_call",      "id": str, "path": str, "kwargs": dict}   # child → parent
-{"type": "rpc_result",    "id": str, "result": Any}                 # parent → child
-{"type": "rpc_error",     "id": str, "error": str}                  # parent → child
-{"type": "rpc_interrupt", "id": str, "reason": str}                 # parent → child
+{"type": "rpc_call",      "id": str, "path": str, "kwargs": dict}    # child → parent
+{"type": "rpc_result",    "id": str, "result": Any}                  # parent → child
+{"type": "rpc_error",     "id": str, "error": str}                   # parent → child
+{"type": "rpc_interrupt", "id": str, "reason": str}                  # parent → child
+{"type": "control", "action": "interrupt",
+ "reason": str, "functions": [str]}                                  # parent → child, unsolicited
 ```
 
 Every `primitives.*` call made inside a venv or shell child round-trips to the
@@ -126,31 +115,63 @@ session that steered it) and `tests/function_manager/shell/test_shell_steering.p
 
 ---
 
-## Phase 2 — instrumented child source (venv only, not started)
+## Phase 2 — instrumented child source over a push control channel
 
-Full parity inside non-dispatching loops, and the only part with a performance
-question.
+Phase 1 fires only when the child dispatches; a loop that makes no primitive
+call is invisible. Phase 2 closes that for venv: the parent ships instrumented
+source, and a correction reaches the child as a pushed directive its next
+checkpoint reads at in-process cost.
 
-The parent holds the source before it ships it, so the existing AST pass can
-run parent-side and the child receives already-instrumented code. `_cp`,
-`_int` and `_around_cp` become shims in the child that consult the parent.
+**Instrumentation is parent-side and shared.** `_instrument_for_child`
+(`function_manager.py`) runs the same AST pass in-process code uses, on the
+clean source each attempt ships — the patch splice always happens on
+uninstrumented source, exactly as in-process. Source that does not parse ships
+unchanged so the child reports the SyntaxError normally.
 
-**The cost is the problem.** In-process a checkpoint is ~10 µs (measured). A
-round trip over a pipe is 0.1–1 ms. A per-iteration checkpoint on a
-1000-iteration loop turns ~10 ms of overhead into up to a second of pure IPC.
-Naively making every checkpoint an RPC is not viable.
+**The child runs the probes against shims, not the parent.** `venv_runner`
+installs `_cp` / `_int` / `_around_cp` / `runtime` in the sandbox globals.
+`runtime` is a no-op position sink (out-of-process the cache keys by
+occurrence alone); `_int(name)` raises the child's `ControlledInterruption`
+when a pending directive names `name`. An interrupted run's completion carries
+an `"interrupted"` marker, which the parent's execute loops translate back
+into the retry.
 
-**The fix is a second channel.** Keep the existing RPC channel
-request/response, and add a one-way parent→child control channel that the child
-reads **non-blockingly** at each checkpoint:
+**The "second channel" needed no second pipe.** The plan expected a dedicated
+control fd read non-blockingly per checkpoint (~µs). What shipped is cheaper:
+control directives are multiplexed onto stdin, and a single daemon thread owns
+the descriptor for the child's lifetime, routing RPC replies to their blocked
+callers, directives into module state, and runner commands to the main thread.
+An idle checkpoint pair (`_cp` + `_int`) is then two attribute reads —
+**0.1 µs/iteration measured**, against ~10 µs in-process and the 0.1–1 ms
+round trip the plan ruled out. The performance question dissolved rather than
+needing tuning.
 
-- idle cost ≈ a non-blocking pipe read, on the order of microseconds
-- a pending correction is a byte on that channel; the child then raises
+Two constraints the reader thread has to honour, both learned the hard way:
 
-This is what makes per-iteration probes affordable out-of-process, and it is
-the piece to design carefully rather than the AST work, which is already
-written. Build it when a real workload needs correction inside a
-non-dispatching loop.
+- **It must read the raw fd (`os.read`), not buffered `readline`.** A thread
+  blocked in `readline` holds the TextIOWrapper lock; a fork()ed
+  multiprocessing child inherits that held lock from a thread it doesn't
+  have, and deadlocks in its own bootstrap closing `sys.stdin`. This is also
+  what makes unsolicited directives deliverable at all — a select-over-
+  buffered-readline loop leaves a directive glued to an RPC reply invisible
+  in the buffer.
+- **Interrupt state clears on each `execute`.** A pooled child is persistent;
+  a directive consumed by attempt N must not fire at attempt N+1's first
+  probe. Ordering is safe because directive and execute share one pipe and
+  one reader.
+
+**The parent side is a watcher, not a poller of the child.**
+`SteeringSession.relay_corrections` runs alongside each attempt's message
+loop, collecting interjections while the child runs between dispatches —
+without it, nothing would even author a patch until the next RPC arrived. When
+a correction targets the running block it sends one directive and returns; the
+attempt's loops handle the rest through the same retry path as Phase 1.
+
+Tests: the "corrections between dispatches" section of
+`test_venv_steering.py` — a 2000-iteration loop with no primitive calls is cut
+short mid-run on both the one-shot and pooled paths, replaying its completed
+prefix, and a stale directive provably does not leak into the next request on
+the same pooled connection.
 
 ---
 
@@ -193,9 +214,16 @@ pinning that a later call on the same connection runs unsteered.
 
 **Synchronous blocking code** remains opaque, exactly as in-process. A
 blocking call holds the child between dispatches, and during that window a
-correction cannot land. (One extra wrinkle out-of-process: the child's RPC
-wait has a 300 s timeout, so a pause held longer than that fails the blocked
-call rather than extending it.)
+correction cannot land; synchronous ``def``s get no await probes on either
+side of the boundary. (One extra wrinkle out-of-process: the child's RPC wait
+has a 300 s timeout, so a pause held longer than that fails the blocked call
+rather than extending it.)
+
+**Pause is not propagated between dispatches.** The parent holds RPC replies
+while paused, which stalls the child at its next dispatch, but the child's
+``_cp`` shim is a plain yield point. Nothing in the runtime drives
+``SteeringRuntime.pause`` today; if something starts to, the control channel
+is where a pause directive would ride.
 
 **Retraction** is still impossible. Replay records that a side effect
 happened; it cannot undo one. A patch redirects work that has not happened

--- a/tests/function_manager/core/test_filter_scope.py
+++ b/tests/function_manager/core/test_filter_scope.py
@@ -57,6 +57,29 @@ def test_filter_scope_filters_list_functions():
     assert "hello_world" not in listing
 
 
+@_handle_project
+def test_entrypoint_id_catalogue_ignores_runtime_discovery_scope():
+    """Deployment references resolve against storage, not actor visibility.
+
+    A runtime can hide functions because an integration is disabled or an
+    execution environment is unavailable. That must affect discovery only:
+    task reconciliation still needs the stored ids for functions that execute
+    in another environment.
+    """
+    fm_all = _FM()
+    fm_all.add_functions(implementations=[_PY_ALPHA, _PY_BETA])
+    fm_all.add_functions(implementations=_SH_HELLO, language="sh")
+    all_ids = fm_all.list_function_name_to_ids()
+
+    fm_scoped = _FM(
+        filter_scope="language == 'python'",
+        exclude_compositional_ids={all_ids["alpha"], all_ids["hello_world"]},
+    )
+
+    assert set(fm_scoped.list_functions()) == {"beta"}
+    assert fm_scoped.list_function_name_to_ids() == all_ids
+
+
 # --------------------------------------------------------------------------- #
 #  filter_functions                                                            #
 # --------------------------------------------------------------------------- #

--- a/tests/function_manager/python/test_venv_steering.py
+++ b/tests/function_manager/python/test_venv_steering.py
@@ -1,12 +1,18 @@
 """Steering venv-backed execution from the parent side of the RPC channel.
 
-Out-of-process code needs no instrumentation to be steered: every
-``primitives.*`` call round-trips to the parent and blocks the child until the
-reply arrives, so the reply itself is the checkpoint. These tests assert that
-the parent memoises those dispatches for replay, interrupts the child at a
-dispatch when a correction lands, and re-runs the patched source — on both the
-one-shot subprocess path and the pooled persistent-connection path, since the
-pooled path is the one that would no-op silently if its handler were missed.
+Out-of-process code needs no instrumentation to be steered at its side
+effects: every ``primitives.*`` call round-trips to the parent and blocks the
+child until the reply arrives, so the reply itself is the checkpoint. These
+tests assert that the parent memoises those dispatches for replay, interrupts
+the child at a dispatch when a correction lands, and re-runs the patched
+source — on both the one-shot subprocess path and the pooled
+persistent-connection path, since the pooled path is the one that would no-op
+silently if its handler were missed.
+
+Between dispatches the child is invisible to the RPC channel, so the parent
+additionally ships instrumented source and pushes interrupt directives over a
+control channel; the tests at the end pin that a correction reaches a loop
+that makes no primitive call at all.
 
 The mechanism is asserted with the patch supplied directly; whether a real
 model writes a usable one is the eval question, covered on the in-process
@@ -323,6 +329,217 @@ async def test_correction_reaches_a_pooled_venv_run(function_manager_factory):
         assert "eu-delta" in comms.sent
         assert session.cache.hits >= 1, "the retry redid the prefix"
         assert out["result"] == ["sent:eu-alpha", "sent:eu-delta"]
+    finally:
+        await pool.close()
+        _cleanup_venv(fm, venv_id)
+
+
+# ── corrections between dispatches (instrumented child source) ─────────────
+COMPUTE_LOOP_IMPLEMENTATION = (
+    "async def crunch_numbers():\n"
+    "    await primitives.comms.send(to='started')\n"
+    "    total = 0\n"
+    "    for i in range(2000):\n"
+    "        total += i\n"
+    "        await asyncio.sleep(0.005)\n"
+    "    await primitives.comms.send(to='finished')\n"
+    "    return total\n"
+)
+
+CUT_SHORT_PATCH = (
+    "async def crunch_numbers():\n"
+    "    await primitives.comms.send(to='started')\n"
+    "    await primitives.comms.send(to='cut-short')\n"
+    "    return -1\n"
+)
+
+
+async def _cut_short_author(*, interjections, session):
+    return InterruptionRequest(
+        reason=interjections[0],
+        patches=[Patch(function_name="crunch_numbers", source=CUT_SHORT_PATCH)],
+    )
+
+
+def test_instrumented_source_carries_probes():
+    from unify.function_manager.function_manager import _instrument_for_child
+
+    shipped = _instrument_for_child(COMPUTE_LOOP_IMPLEMENTATION)
+    assert "_cp(" in shipped and "_int(" in shipped
+
+
+def test_unparseable_source_ships_unchanged():
+    from unify.function_manager.function_manager import _instrument_for_child
+
+    source = "def broken(\n"
+    assert _instrument_for_child(source) == source
+
+
+@pytest.mark.asyncio
+async def test_child_int_shim_raises_only_for_targeted_functions():
+    from unify.function_manager import venv_runner
+
+    venv_runner._apply_control(
+        {
+            "type": "control",
+            "action": "interrupt",
+            "reason": "stop",
+            "functions": ["crunch_numbers"],
+        },
+    )
+    try:
+        with pytest.raises(venv_runner.ControlledInterruption):
+            await venv_runner._int("crunch_numbers")
+        await venv_runner._int("unrelated")
+        await venv_runner._cp("still a plain yield point")
+    finally:
+        venv_runner._clear_interrupt()
+
+
+@pytest.mark.asyncio
+async def test_relay_sends_one_directive_when_a_correction_targets():
+    queue: asyncio.Queue = asyncio.Queue()
+    session = SteeringSession(interject_q=queue, patch_author=_cut_short_author)
+    sent: list = []
+
+    async def _send_control(message):
+        sent.append(message)
+
+    relay = asyncio.create_task(
+        session.relay_corrections(
+            COMPUTE_LOOP_IMPLEMENTATION,
+            _send_control,
+            poll_interval=0.01,
+        ),
+    )
+    await queue.put("cut it short")
+    await asyncio.wait_for(relay, timeout=2.0)
+
+    assert len(sent) == 1
+    directive = sent[0]
+    assert directive["action"] == "interrupt"
+    assert directive["functions"] == ["crunch_numbers"]
+    assert session.interruption is not None, "the retry loop owns consuming it"
+
+
+@pytest.mark.asyncio
+async def test_relay_ignores_corrections_that_target_nothing_here():
+    queue: asyncio.Queue = asyncio.Queue()
+    session = SteeringSession(interject_q=queue, patch_author=_cut_short_author)
+    sent: list = []
+
+    async def _send_control(message):
+        sent.append(message)
+
+    relay = asyncio.create_task(
+        session.relay_corrections(
+            "async def other_function():\n    return 1\n",
+            _send_control,
+            poll_interval=0.01,
+        ),
+    )
+    await queue.put("cut it short")
+    await asyncio.sleep(0.1)
+    relay.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await relay
+
+    assert sent == []
+
+
+@_handle_project
+@pytest.mark.asyncio
+async def test_correction_reaches_a_non_dispatching_loop_one_shot(
+    function_manager_factory,
+):
+    """The loop makes no primitive call, so only an instrumented checkpoint
+    fed by the control channel can see the correction arrive."""
+    fm = function_manager_factory()
+    venv_id = fm.add_venv(venv=MINIMAL_VENV_CONTENT)
+
+    comms = _Comms()
+    queue: asyncio.Queue = asyncio.Queue()
+    session = SteeringSession(interject_q=queue, patch_author=_cut_short_author)
+    steerer = _patch_after(comms, 1, queue, "cut it short")
+
+    try:
+        with use_session(session):
+            out = await fm.execute_in_venv(
+                venv_id=venv_id,
+                implementation=COMPUTE_LOOP_IMPLEMENTATION,
+                call_kwargs={},
+                is_async=True,
+                primitives=_Prims(comms),
+            )
+        await steerer
+
+        assert out["error"] is None, out["error"]
+        assert session.retries == 1
+        # The loop was cut short: its trailing dispatch never ran.
+        assert "finished" not in comms.sent
+        # Replayed, not re-sent.
+        assert comms.sent.count("started") == 1
+        assert "cut-short" in comms.sent
+        assert out["result"] == -1
+        assert session.cache.hits >= 1, "the retry redid the prefix"
+    finally:
+        _cleanup_venv(fm, venv_id)
+
+
+@_handle_project
+@pytest.mark.asyncio
+async def test_correction_reaches_a_non_dispatching_loop_pooled(
+    function_manager_factory,
+):
+    """Same, on the persistent child — whose interrupt state must also come
+    back clean for the very next request on that connection."""
+    fm = function_manager_factory()
+    venv_id = fm.add_venv(venv=MINIMAL_VENV_CONTENT)
+    await fm.prepare_venv(venv_id=venv_id)
+    pool = VenvPool()
+
+    comms = _Comms()
+    queue: asyncio.Queue = asyncio.Queue()
+    session = SteeringSession(interject_q=queue, patch_author=_cut_short_author)
+    steerer = _patch_after(comms, 1, queue, "cut it short")
+
+    try:
+        with use_session(session):
+            out = await pool.execute_in_venv(
+                venv_id=venv_id,
+                implementation=COMPUTE_LOOP_IMPLEMENTATION,
+                call_kwargs={},
+                is_async=True,
+                session_id=0,
+                primitives=_Prims(comms),
+                function_manager=fm,
+            )
+        await steerer
+
+        assert out["error"] is None, out["error"]
+        assert session.retries == 1
+        assert "finished" not in comms.sent
+        assert comms.sent.count("started") == 1
+        assert "cut-short" in comms.sent
+        assert out["result"] == -1
+
+        # A fresh steered call on the same connection: instrumented probes
+        # run against the same child, and a stale directive would interrupt
+        # it immediately.
+        later = _Comms()
+        later_session = SteeringSession()
+        with use_session(later_session):
+            again = await pool.execute_in_venv(
+                venv_id=venv_id,
+                implementation=IMPLEMENTATION,
+                call_kwargs={"vendors": list(VENDORS)},
+                is_async=True,
+                session_id=0,
+                primitives=_Prims(later),
+                function_manager=fm,
+            )
+        assert again["error"] is None, again["error"]
+        assert later.sent == VENDORS, "a stale directive steered this call"
     finally:
         await pool.close()
         _cleanup_venv(fm, venv_id)

--- a/tests/task_scheduler/test_custom_tasks.py
+++ b/tests/task_scheduler/test_custom_tasks.py
@@ -319,6 +319,62 @@ def test_task_adapter_derived_stale_detects_repointed_entrypoint():
     assert not adapter.derived_stale("k", {"entrypoint": 1}, {})
 
 
+@_handle_project
+@pytest.mark.asyncio
+@pytest.mark.requires_orchestra
+async def test_unresolved_entrypoint_update_preserves_stored_id(
+    task_scheduler_factory,
+    tmp_path,
+):
+    """A filtered lookup must never turn a symbolic task agentic.
+
+    Resolution can be temporarily incomplete when the reconciling runtime
+    cannot discover a function that executes elsewhere. Updating other task
+    fields in that state must leave the last known entrypoint intact.
+    """
+    from unify.function_manager.function_manager import FunctionManager
+
+    function_manager = FunctionManager(include_primitives=False)
+    function_manager.add_functions(
+        implementations="def run_elsewhere():\n    return 'ok'\n",
+    )
+    function_id = function_manager.list_function_name_to_ids()["run_elsewhere"]
+
+    tasks_dir = tmp_path / "entrypoint-preservation"
+    tasks_dir.mkdir()
+
+    def write_source(description):
+        row = {
+            "key": "ops/runs-elsewhere",
+            "name": "Runs elsewhere",
+            "description": description,
+            "repeat": [{"frequency": "daily"}],
+            "entrypoint_function": "run_elsewhere",
+        }
+        (tasks_dir / TASKS_JSONL_FILENAME).write_text(json.dumps(row) + "\n")
+        return collect_custom_tasks(path=tasks_dir)
+
+    scheduler = task_scheduler_factory()
+    scheduler.sync_custom_tasks(
+        source_tasks=write_source("Version one."),
+        function_name_to_id={"run_elsewhere": function_id},
+    )
+
+    scheduler._custom_tasks_synced_sources.clear()
+    scheduler.sync_custom_tasks(
+        source_tasks=write_source("Version two."),
+        function_name_to_id={},
+    )
+
+    rows = scheduler._filter_tasks(
+        filter="custom_key == 'ops/runs-elsewhere'",
+        limit=1,
+    )
+    assert len(rows) == 1
+    assert rows[0].entrypoint == function_id
+    assert rows[0].description == "Version two."
+
+
 def test_entrypoint_resolution_participates_in_the_sync_hash():
     """A function renumbering must invalidate the stored aggregate hash,
     or the reconcile short-circuits and dangling entrypoints never heal."""

--- a/unify/function_manager/function_manager.py
+++ b/unify/function_manager/function_manager.py
@@ -4989,10 +4989,18 @@ class FunctionManager(BaseFunctionManager):
     # 2. Listing -------------------------------------------------------- #
 
     def list_function_name_to_ids(self) -> Dict[str, int]:
-        """Return ``{name: function_id}`` without pulling implementations.
+        """Return the authoritative ``{name: function_id}`` catalogue.
 
         Used by deployment reconcile for guidance/task entrypoint resolution.
         Prefer this over :meth:`list_functions` when only ids are needed.
+
+        Deployment references are resolved independently of the current
+        runtime's discovery surface. A headless runtime can legitimately hide
+        desktop- or integration-gated functions from actor discovery, but
+        their stored ids must still be available when reconciling tasks that
+        execute in a different environment. Therefore compositional rows are
+        read without ``filter_scope`` or environment exclusions here; ordinary
+        list/filter/search operations remain scoped.
         """
 
         mapping: Dict[str, int] = {}
@@ -5000,7 +5008,6 @@ class FunctionManager(BaseFunctionManager):
             try:
                 logs = unisdk.get_logs(
                     context=context,
-                    filter=self._scoped_filter(None),
                     from_fields=["name", "function_id"],
                 )
             except Exception:

--- a/unify/function_manager/function_manager.py
+++ b/unify/function_manager/function_manager.py
@@ -379,6 +379,22 @@ def _parse_shell_script_metadata(source: str) -> Dict[str, Optional[str]]:
     }
 
 
+def _instrument_for_child(source: str) -> str:
+    """Ship steering probes with source bound for a venv subprocess.
+
+    The child runs the probes against shims ``venv_runner`` installs, which
+    read the control channel — so a loop that makes no primitive call is
+    still interruptible between dispatches. Source that does not parse ships
+    unchanged, so the child reports the SyntaxError exactly as an unsteered
+    run would.
+    """
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return source
+    return ast.unparse(instrument(tree, tool_namespaces=set(DEFAULT_TOOL_NAMESPACES)))
+
+
 class _VenvConnection:
     """
     Manages a persistent connection to a venv subprocess in server mode.
@@ -526,12 +542,18 @@ class _VenvConnection:
                     f"Venv {self._venv_id} subprocess has died (returncode={self._process.returncode})",
                 )
 
+            steering = active_session()
+
             async def _attempt(source: str) -> dict:
                 """Send one execute request for *source* and relay its RPC."""
                 await self._write_message(
                     {
                         "type": "execute",
-                        "implementation": source,
+                        "implementation": (
+                            _instrument_for_child(source)
+                            if steering is not None
+                            else source
+                        ),
                         "call_kwargs": call_kwargs,
                         "is_async": is_async,
                         "env_overlay": env_overlay or {},
@@ -541,39 +563,68 @@ class _VenvConnection:
                 # Set when a correction interrupted this attempt; the child's
                 # completion is then an unwind to discard, not a result.
                 interrupted: Optional[ControlledInterruption] = None
+                # Corrections that land between dispatches reach the child
+                # through the control channel, not through an RPC reply.
+                watcher = (
+                    asyncio.create_task(
+                        steering.relay_corrections(source, self._write_message),
+                    )
+                    if steering is not None
+                    else None
+                )
 
-                while True:
-                    msg = await self._read_message()
-                    msg_type = msg.get("type")
+                try:
+                    while True:
+                        msg = await self._read_message()
+                        msg_type = msg.get("type")
 
-                    if msg_type == "complete":
-                        if interrupted is not None:
-                            raise interrupted
-                        return msg
+                        if msg_type == "complete":
+                            if interrupted is not None:
+                                raise interrupted
+                            child_interrupted = msg.get("interrupted")
+                            if child_interrupted:
+                                # The child unwound at an instrumented
+                                # checkpoint; discard the attempt and retry.
+                                raise ControlledInterruption(child_interrupted)
+                            return msg
 
-                    if msg_type == "rpc_call":
-                        # Handle RPC call from subprocess
-                        try:
-                            reply = await self._handle_rpc_call(
-                                msg,
-                                primitives=primitives,
-                                computer_primitives=computer_primitives,
+                        if msg_type == "rpc_call":
+                            # Handle RPC call from subprocess
+                            try:
+                                reply = await self._handle_rpc_call(
+                                    msg,
+                                    primitives=primitives,
+                                    computer_primitives=computer_primitives,
+                                )
+                            except ControlledInterruption as interruption:
+                                # The child is blocked on this reply, so
+                                # telling it to unwind here is the interrupt
+                                # probe realised without instrumentation.
+                                interrupted = interruption
+                                reply = {
+                                    "type": "rpc_interrupt",
+                                    "id": msg.get("id"),
+                                    "reason": str(interruption),
+                                }
+                            await self._write_message(reply)
+                        else:
+                            logger.warning(
+                                f"Venv {self._venv_id}: unexpected message type '{msg_type}'",
                             )
-                        except ControlledInterruption as interruption:
-                            # The child is blocked on this reply, so telling
-                            # it to unwind here is the interrupt probe
-                            # realised without instrumentation.
-                            interrupted = interruption
-                            reply = {
-                                "type": "rpc_interrupt",
-                                "id": msg.get("id"),
-                                "reason": str(interruption),
-                            }
-                        await self._write_message(reply)
-                    else:
-                        logger.warning(
-                            f"Venv {self._venv_id}: unexpected message type '{msg_type}'",
-                        )
+                finally:
+                    if watcher is not None:
+                        watcher.cancel()
+                        try:
+                            await watcher
+                        except asyncio.CancelledError:
+                            pass
+                        except Exception:
+                            # A control send can lose the race with the run
+                            # ending; the attempt's own outcome stands.
+                            logger.debug(
+                                "steering: correction watcher failed",
+                                exc_info=True,
+                            )
 
             async def _run(source: str) -> dict:
                 if timeout is None:
@@ -586,7 +637,6 @@ class _VenvConnection:
                     self._tainted = True
                     raise
 
-            steering = active_session()
             if steering is None:
                 return await _run(implementation)
             return await run_with_steering(implementation, _run, session=steering)
@@ -6519,11 +6569,15 @@ class FunctionManager(BaseFunctionManager):
 
         from unify.provider_proxy.session import build_sandbox_env
 
+        steering = active_session()
+
         async def _attempt(source: str) -> Dict[str, Any]:
             """Run one subprocess attempt at *source*, relaying its RPC."""
             execute_payload: Dict[str, Any] = {
                 "type": "execute",
-                "implementation": source,
+                "implementation": (
+                    _instrument_for_child(source) if steering is not None else source
+                ),
                 "call_kwargs": call_kwargs,
                 "is_async": is_async,
                 "env_overlay": env_overlay,
@@ -6541,9 +6595,12 @@ class FunctionManager(BaseFunctionManager):
                 env=build_sandbox_env(),
             )
 
+            async def _send(message: Dict[str, Any]) -> None:
+                process.stdin.write((json.dumps(message) + "\n").encode())
+                await process.stdin.drain()
+
             # Send initial execution request
-            process.stdin.write((json.dumps(execute_payload) + "\n").encode())
-            await process.stdin.drain()
+            await _send(execute_payload)
 
             # Handle bidirectional communication
             stderr_output = []
@@ -6560,6 +6617,13 @@ class FunctionManager(BaseFunctionManager):
             # Set when a correction interrupted this attempt; the child's
             # completion is then an unwind to discard, not a result.
             interrupted: Optional[ControlledInterruption] = None
+            # Corrections that land between dispatches reach the child
+            # through the control channel, not through an RPC reply.
+            watcher = (
+                asyncio.create_task(steering.relay_corrections(source, _send))
+                if steering is not None
+                else None
+            )
 
             try:
                 while True:
@@ -6617,14 +6681,18 @@ class FunctionManager(BaseFunctionManager):
                                 "error": str(e),
                             }
 
-                        process.stdin.write((json.dumps(response) + "\n").encode())
-                        await process.stdin.drain()
+                        await _send(response)
 
                     elif msg_type == "complete":
                         # Subprocess finished
                         await stderr_task
                         if interrupted is not None:
                             raise interrupted
+                        child_interrupted = msg.get("interrupted")
+                        if child_interrupted:
+                            # The child unwound at an instrumented checkpoint;
+                            # discard the attempt and retry.
+                            raise ControlledInterruption(child_interrupted)
                         return {
                             "result": msg.get("result"),
                             "error": msg.get("error"),
@@ -6644,6 +6712,20 @@ class FunctionManager(BaseFunctionManager):
                     "stderr": "".join(stderr_output),
                 }
             finally:
+                if watcher is not None:
+                    watcher.cancel()
+                    try:
+                        await watcher
+                    except asyncio.CancelledError:
+                        pass
+                    except Exception:
+                        # A control send can lose the race with the run
+                        # ending; the attempt's own outcome stands.
+                        logger.debug(
+                            "steering: correction watcher failed",
+                            exc_info=True,
+                        )
+
                 # Cancel stderr reader task
                 stderr_task.cancel()
                 try:
@@ -6658,7 +6740,6 @@ class FunctionManager(BaseFunctionManager):
         # One-shot subprocesses give a retry a clean slate: each attempt is a
         # fresh child, and the parent-side cache is what carries the completed
         # prefix across attempts.
-        steering = active_session()
         if steering is None:
             return await _attempt(implementation)
         return await run_with_steering(implementation, _attempt, session=steering)

--- a/unify/function_manager/steering.py
+++ b/unify/function_manager/steering.py
@@ -29,12 +29,14 @@ call begins and discarded when it returns. Nothing survives into the next call,
 which is what keeps the positional cache key sound: the surrounding code cannot
 have changed underneath it, because the block is still the one that is running.
 
-Code that runs in another process — a venv subprocess, a shell script — is
-steered without instrumentation, because its JSON-RPC protocol already blocks
-the child at every primitive dispatch until the parent replies. The parent
-treats each reply as a checkpoint (:func:`dispatch_with_steering`) and re-sends
-patched source on retry; only dispatches are visible, so a loop that makes no
-primitive call cannot be paused or corrected out-of-process.
+Code that runs in another process is steered at two grains. Every primitive
+dispatch already blocks the child on the parent's JSON-RPC reply, so the reply
+is a checkpoint (:func:`dispatch_with_steering`) — venv and shell both get
+this without instrumentation. Between dispatches, venv children additionally
+run parent-instrumented source whose probes read a pushed control directive
+(:meth:`SteeringSession.relay_corrections`), so a loop that makes no primitive
+call is still interruptible; on retry the parent re-sends patched source
+either way.
 
 What this deliberately does not do
 ----------------------------------
@@ -380,6 +382,40 @@ class SteeringSession:
 
     def note_applied(self, patch: Patch) -> None:
         self._applied.append(patch)
+
+    async def relay_corrections(
+        self,
+        source: str,
+        send_control: typing.Callable[[Dict[str, Any]], typing.Awaitable[None]],
+        *,
+        poll_interval: float = 0.05,
+    ) -> None:
+        """Deliver corrections to code running where no checkpoint can look.
+
+        Out-of-process, the parent's checkpoints fire only when the child
+        dispatches; a child inside a loop that makes no primitive call never
+        gives the parent a chance to collect interjections, let alone act on
+        them. This watches the intake while an attempt runs and, once a
+        correction targets the running block, pushes one interrupt directive
+        over *send_control* so the child's next instrumented checkpoint
+        raises. Runs until then, or until the attempt ends and cancels it.
+        """
+        while True:
+            await self._collect()
+            request = self.interruption
+            if request is not None and _targets_running_block(request, source):
+                await send_control(
+                    {
+                        "type": "control",
+                        "action": "interrupt",
+                        "reason": request.reason or "steered",
+                        "functions": sorted(
+                            {patch.function_name for patch in request.patches},
+                        ),
+                    },
+                )
+                return
+            await asyncio.sleep(poll_interval)
 
     def notify(self, payload: Dict[str, Any]) -> None:
         if self._notification_q is None:

--- a/unify/function_manager/venv_runner.py
+++ b/unify/function_manager/venv_runner.py
@@ -18,14 +18,23 @@ Main process responds with:
     {"type": "rpc_error", "id": str, "error": str}
     {"type": "rpc_interrupt", "id": str, "reason": str}
 
+The main process can also push a control directive at any time, outside the
+request/response rhythm. A directive is not a reply: it is read by the
+checkpoint shims that parent-instrumented source calls between dispatches.
+
+    {"type": "control", "action": "interrupt", "reason": str, "functions": [str]}
+
 Final response from subprocess:
     {"type": "complete", "result": Any, "error": str|null, "stdout": str, "stderr": str}
 
-The script:
-1. Reads initial execution request from stdin
-2. Sets up proxy objects for primitives and computer_primitives
-3. Executes the function, handling RPC calls as they occur
-4. Returns the final result
+An interrupted run's completion additionally carries {"interrupted": str}, so
+the parent can tell an unwound attempt from a genuine failure.
+
+A single daemon thread owns stdin for the process lifetime and routes each
+message to whoever is waiting on it: RPC replies to their blocked callers,
+control directives into checkpoint-visible state, and runner commands
+(execute / get_state / shutdown) to the main thread. Function execution
+happens on the main thread.
 """
 
 import asyncio
@@ -98,17 +107,29 @@ def _setup_signal_handlers() -> None:
 # Global state for RPC communication
 _rpc_responses: Dict[str, Queue] = {}
 _rpc_lock = threading.Lock()
-_stdin_lock = threading.Lock()
 _stdout_lock = threading.Lock()
+
+#: Messages that drive the runner itself (execute / get_state / shutdown),
+#: queued by the stdin reader for main()/main_server() to consume. None is
+#: the EOF sentinel.
+_main_msgs: Queue = Queue()
+
+#: The pending interrupt directive, written only by the stdin reader thread
+#: and read by the checkpoint shims. Keeping it as plain module state is the
+#: point: a checkpoint costs one attribute read, not an RPC round trip.
+_interrupt_reason: str | None = None
+_interrupt_functions: frozenset = frozenset()
 
 
 class ControlledInterruption(Exception):
-    """Raised at a blocked RPC call site when the parent interrupts the run.
+    """Raised inside the run when the parent interrupts it.
 
     The parent holds a correction for this block and wants the attempt to
     unwind so it can re-send patched source. Calls the attempt already
     completed replay from the parent's cache on the re-run, so unwinding here
-    does not repeat their effects.
+    does not repeat their effects. Raised either by a blocked RPC call site
+    receiving ``rpc_interrupt``, or by an instrumented ``_int`` checkpoint
+    seeing a control directive.
     """
 
 
@@ -120,13 +141,75 @@ def send_message(msg: dict) -> None:
         sys.__stdout__.flush()
 
 
-def read_message() -> dict:
-    """Read a JSON message from stdin (from main process)."""
-    with _stdin_lock:
-        line = sys.__stdin__.readline()
-        if not line:
-            raise EOFError("stdin closed")
-        return json.loads(line.strip())
+def _apply_control(msg: dict) -> None:
+    """Record a control directive where the checkpoints will see it."""
+    global _interrupt_reason, _interrupt_functions
+    if msg.get("action") == "interrupt":
+        _interrupt_functions = frozenset(msg.get("functions") or ())
+        _interrupt_reason = str(msg.get("reason") or "steered")
+
+
+def _clear_interrupt() -> None:
+    """Forget a consumed interrupt so the next (patched) run starts clean."""
+    global _interrupt_reason, _interrupt_functions
+    _interrupt_reason = None
+    _interrupt_functions = frozenset()
+
+
+def _fail_pending_rpc(error: str) -> None:
+    """Unblock every caller waiting on an RPC reply that can no longer come."""
+    with _rpc_lock:
+        for response_queue in _rpc_responses.values():
+            response_queue.put({"type": "rpc_error", "error": error})
+
+
+def _stdin_reader_loop() -> None:
+    """Route every stdin message to whoever is waiting on it.
+
+    One blocking reader owns stdin for the process lifetime, which is what
+    lets control directives arrive outside the request/response rhythm: a
+    select loop over buffered readline cannot, because a directive glued to
+    an RPC reply sits invisible in the TextIO buffer where select never
+    fires again.
+
+    Reads the raw descriptor rather than the buffered text wrapper: a
+    blocking ``readline`` holds the wrapper's lock, and a fork()ed
+    multiprocessing child that inherits the held lock deadlocks in its own
+    bootstrap when it closes ``sys.stdin``. ``os.read`` holds no Python-level
+    lock while it waits.
+    """
+    fd = sys.__stdin__.fileno()
+    buffer = b""
+    while True:
+        try:
+            chunk = os.read(fd, 65536)
+        except OSError:
+            chunk = b""
+        if not chunk:
+            _fail_pending_rpc("stdin closed")
+            _main_msgs.put(None)
+            return
+        buffer += chunk
+        while b"\n" in buffer:
+            line, buffer = buffer.split(b"\n", 1)
+            if not line.strip():
+                continue
+            try:
+                msg = json.loads(line.decode())
+            except (json.JSONDecodeError, UnicodeDecodeError) as e:
+                _main_msgs.put({"type": "_invalid_json", "error": str(e)})
+                continue
+            msg_type = msg.get("type")
+            if msg_type in ("rpc_result", "rpc_error", "rpc_interrupt"):
+                dispatch_rpc_response(msg)
+            elif msg_type == "control":
+                _apply_control(msg)
+            else:
+                _main_msgs.put(msg)
+
+
+def _start_stdin_reader() -> None:
+    threading.Thread(target=_stdin_reader_loop, daemon=True).start()
 
 
 def rpc_call_sync(path: str, kwargs: dict) -> Any:
@@ -381,6 +464,65 @@ def get_oauth_access_token(provider: str, *, min_ttl_seconds: int = 300) -> str:
 
 
 # ────────────────────────────────────────────────────────────────────────────
+# Steering Checkpoint Shims
+# ────────────────────────────────────────────────────────────────────────────
+# The parent instruments the source it ships when a steering session is in
+# flight, so a loop that makes no primitive call still runs a probe every
+# iteration. In-process those probes consult the session; here they consult
+# the control state the stdin reader maintains, which costs an attribute read
+# when nothing is pending — the reason a directive is pushed down the channel
+# rather than fetched with a per-checkpoint round trip.
+
+
+class _ChildRuntime:
+    """Receives the position probes instrumented source emits.
+
+    Position feeds the cache key in-process; out-of-process the parent keys
+    dispatches by occurrence alone, so these only need to exist and be free.
+    """
+
+    def push_path_context(self, context_id: str) -> None:
+        pass
+
+    def pop_path_context(self) -> None:
+        pass
+
+    def start_loop_context(self, loop_id: str) -> None:
+        pass
+
+    def increment_loop_iteration(self, loop_id: str) -> None:
+        pass
+
+    def end_loop_context(self, loop_id: str) -> None:
+        pass
+
+
+async def _cp(label: str = "") -> None:
+    """Cooperative checkpoint; a yield point and nothing more.
+
+    Pause is not propagated to subprocesses: the parent already holds RPC
+    replies while paused, and nothing in the runtime drives a pause between
+    dispatches.
+    """
+    return
+
+
+async def _int(func_name: str) -> None:
+    """Raise if the parent's pending correction targets *func_name*."""
+    if _interrupt_reason is not None and func_name in _interrupt_functions:
+        raise ControlledInterruption(_interrupt_reason)
+
+
+async def _around_cp(label: str, awaitable: Any) -> Any:
+    """Bracket one awaited dispatch, mirroring the in-process probe."""
+    await _cp(f"Before: {label}")
+    try:
+        return await awaitable
+    finally:
+        await _cp(f"After: {label}")
+
+
+# ────────────────────────────────────────────────────────────────────────────
 # Execution Environment
 # ────────────────────────────────────────────────────────────────────────────
 
@@ -500,6 +642,12 @@ def create_safe_globals(is_async: bool = True):
         "query_llm": query_llm,
         "list_llms": list_llms,
         "get_oauth_access_token": get_oauth_access_token,
+        # Steering probes: parent-instrumented source calls these; inert
+        # until a control directive arrives.
+        "_cp": _cp,
+        "_int": _int,
+        "_around_cp": _around_cp,
+        "runtime": _ChildRuntime(),
     }
 
     # Try to add pydantic if available in this venv
@@ -542,6 +690,7 @@ def execute_sync_in_globals(
     stderr_capture = io.StringIO()
     result = None
     error = None
+    interrupted = None
 
     try:
         # Extract function name from implementation BEFORE exec
@@ -558,15 +707,23 @@ def execute_sync_in_globals(
 
             result = fn(**call_kwargs)
 
+    except ControlledInterruption as ci:
+        # An unwind the parent asked for, not a failure: mark it so the
+        # parent can discard this attempt and re-run the patched source.
+        interrupted = str(ci) or "interrupted"
+        error = traceback.format_exc()
     except Exception:
         error = traceback.format_exc()
 
-    return {
+    out = {
         "result": result,
         "error": error,
         "stdout": stdout_capture.getvalue(),
         "stderr": stderr_capture.getvalue(),
     }
+    if interrupted is not None:
+        out["interrupted"] = interrupted
+    return out
 
 
 async def execute_async(implementation: str, call_kwargs: dict) -> dict:
@@ -601,6 +758,7 @@ async def execute_async_in_globals(
     stderr_capture = io.StringIO()
     result = None
     error = None
+    interrupted = None
 
     try:
         # Extract function name from implementation BEFORE exec
@@ -619,15 +777,23 @@ async def execute_async_in_globals(
         with redirect_stdout(stdout_capture), redirect_stderr(stderr_capture):
             result = await fn(**call_kwargs)
 
+    except ControlledInterruption as ci:
+        # An unwind the parent asked for, not a failure: mark it so the
+        # parent can discard this attempt and re-run the patched source.
+        interrupted = str(ci) or "interrupted"
+        error = traceback.format_exc()
     except Exception:
         error = traceback.format_exc()
 
-    return {
+    out = {
         "result": result,
         "error": error,
         "stdout": stdout_capture.getvalue(),
         "stderr": stderr_capture.getvalue(),
     }
+    if interrupted is not None:
+        out["interrupted"] = interrupted
+    return out
 
 
 def make_json_serializable(obj):
@@ -851,106 +1017,58 @@ def apply_env_overlay(env_overlay: dict | None) -> None:
 # ────────────────────────────────────────────────────────────────────────────
 
 
-def run_with_rpc_loop(
+def _run_request(
     implementation: str,
     call_kwargs: dict,
     is_async: bool,
-    initial_state: dict = None,
+    globals_dict: dict,
 ) -> dict:
+    """Run one execute request on the main thread.
+
+    The stdin reader thread keeps routing RPC replies and control directives
+    while this blocks, so calls into the parent resolve and interrupts land
+    mid-run.
     """
-    Run a function with RPC support.
-
-    This handles bidirectional communication:
-    - Executes the function in a separate thread
-    - Main thread handles RPC responses from stdin
-
-    Args:
-        implementation: Function source code to execute.
-        call_kwargs: Keyword arguments to pass to the function.
-        is_async: Whether the function is async.
-        initial_state: Optional serialized state to inject before execution
-            (used for read_only mode to inherit state from persistent session).
-    """
-    result_queue: Queue = Queue()
-
-    def execute_function():
-        """Execute the function and put result in queue."""
-        try:
-            # Create globals with optional initial state injection
-            globals_dict = create_safe_globals(is_async=is_async)
-            if initial_state:
-                inject_state_into_globals(initial_state, globals_dict)
-
-            if is_async:
-                res = asyncio.run(
-                    execute_async_in_globals(implementation, call_kwargs, globals_dict),
-                )
-            else:
-                res = execute_sync_in_globals(implementation, call_kwargs, globals_dict)
-            result_queue.put(res)
-        except Exception:
-            result_queue.put(
-                {
-                    "result": None,
-                    "error": traceback.format_exc(),
-                    "stdout": "",
-                    "stderr": "",
-                },
+    _clear_interrupt()
+    try:
+        if is_async:
+            return asyncio.run(
+                execute_async_in_globals(implementation, call_kwargs, globals_dict),
             )
-
-    # Start function execution in a thread
-    exec_thread = threading.Thread(target=execute_function, daemon=True)
-    exec_thread.start()
-
-    # Main thread handles RPC responses
-    while exec_thread.is_alive():
-        # Check for RPC responses with a timeout so we can check if thread is done
-        try:
-            # Use select or polling to check stdin with timeout
-            import select
-
-            readable, _, _ = select.select([sys.__stdin__], [], [], 0.1)
-            if readable:
-                line = sys.__stdin__.readline()
-                if line:
-                    msg = json.loads(line.strip())
-                    if msg.get("type") in ("rpc_result", "rpc_error", "rpc_interrupt"):
-                        dispatch_rpc_response(msg)
-        except Exception:
-            # On Windows or if select fails, just do blocking read with thread check
-            pass
-
-    # Get the result
-    return result_queue.get(timeout=1)
+        return execute_sync_in_globals(implementation, call_kwargs, globals_dict)
+    except Exception:
+        return {
+            "result": None,
+            "error": traceback.format_exc(),
+            "stdout": "",
+            "stderr": "",
+        }
 
 
 def main():
     """Main entry point for one-shot runner mode."""
     # Set up signal handlers for graceful shutdown
     _setup_signal_handlers()
+    _start_stdin_reader()
 
-    # Read initial execution request from stdin
-    try:
-        line = sys.__stdin__.readline()
-        if not line:
-            send_message(
-                {
-                    "type": "complete",
-                    "result": None,
-                    "error": "No input received",
-                    "stdout": "",
-                    "stderr": "",
-                },
-            )
-            sys.exit(1)
-
-        input_data = json.loads(line.strip())
-    except json.JSONDecodeError as e:
+    input_data = _main_msgs.get()
+    if input_data is None:
         send_message(
             {
                 "type": "complete",
                 "result": None,
-                "error": f"Invalid JSON input: {e}",
+                "error": "No input received",
+                "stdout": "",
+                "stderr": "",
+            },
+        )
+        sys.exit(1)
+    if input_data.get("type") == "_invalid_json":
+        send_message(
+            {
+                "type": "complete",
+                "result": None,
+                "error": f"Invalid JSON input: {input_data.get('error')}",
                 "stdout": "",
                 "stderr": "",
             },
@@ -976,13 +1094,11 @@ def main():
     initial_state = input_data.get("initial_state")
     apply_env_overlay(input_data.get("env_overlay"))
 
-    # Execute with RPC support, optionally with initial state
-    result = run_with_rpc_loop(
-        implementation,
-        call_kwargs,
-        is_async,
-        initial_state=initial_state,
-    )
+    globals_dict = create_safe_globals(is_async=is_async)
+    if initial_state:
+        inject_state_into_globals(initial_state, globals_dict)
+
+    result = _run_request(implementation, call_kwargs, is_async, globals_dict)
 
     # Make result JSON-serializable
     result["result"] = make_json_serializable(result["result"])
@@ -1001,64 +1117,6 @@ def main():
 # ────────────────────────────────────────────────────────────────────────────
 
 
-def run_server_with_rpc_loop(
-    implementation: str,
-    call_kwargs: dict,
-    is_async: bool,
-    globals_dict: dict,
-) -> dict:
-    """
-    Run a function with RPC support using a persistent globals dict.
-
-    This handles bidirectional communication:
-    - Executes the function in a separate thread
-    - Main thread handles RPC responses from stdin
-    """
-    result_queue: Queue = Queue()
-
-    def execute_function():
-        """Execute the function and put result in queue."""
-        try:
-            if is_async:
-                res = asyncio.run(
-                    execute_async_in_globals(implementation, call_kwargs, globals_dict),
-                )
-            else:
-                res = execute_sync_in_globals(implementation, call_kwargs, globals_dict)
-            result_queue.put(res)
-        except Exception:
-            result_queue.put(
-                {
-                    "result": None,
-                    "error": traceback.format_exc(),
-                    "stdout": "",
-                    "stderr": "",
-                },
-            )
-
-    # Start function execution in a thread
-    exec_thread = threading.Thread(target=execute_function, daemon=True)
-    exec_thread.start()
-
-    # Main thread handles RPC responses
-    while exec_thread.is_alive():
-        try:
-            import select
-
-            readable, _, _ = select.select([sys.__stdin__], [], [], 0.1)
-            if readable:
-                line = sys.__stdin__.readline()
-                if line:
-                    msg = json.loads(line.strip())
-                    if msg.get("type") in ("rpc_result", "rpc_error", "rpc_interrupt"):
-                        dispatch_rpc_response(msg)
-        except Exception:
-            pass
-
-    # Get the result
-    return result_queue.get(timeout=1)
-
-
 def main_server():
     """
     Persistent server mode entry point.
@@ -1072,6 +1130,7 @@ def main_server():
             {"type": "execute", "implementation": str, "call_kwargs": dict, "is_async": bool}
             {"type": "get_state"}
             {"type": "shutdown"}
+            {"type": "control", "action": "interrupt", ...}  (mid-execute)
 
         Output messages:
             {"type": "complete", "result": Any, "error": str|null, "stdout": str, "stderr": str}
@@ -1079,6 +1138,7 @@ def main_server():
             {"type": "ack"}  (response to shutdown)
     """
     _setup_signal_handlers()
+    _start_stdin_reader()
 
     # Send ready signal so parent knows we're listening
     send_message({"type": "ready"})
@@ -1089,26 +1149,21 @@ def main_server():
     base_globals = create_safe_globals(is_async=True)
 
     while True:
-        try:
-            line = sys.__stdin__.readline()
-            if not line:
-                # stdin closed, exit gracefully
-                break
-
-            input_data = json.loads(line.strip())
-        except json.JSONDecodeError as e:
+        input_data = _main_msgs.get()
+        if input_data is None:
+            # stdin closed, exit gracefully
+            break
+        if input_data.get("type") == "_invalid_json":
             send_message(
                 {
                     "type": "complete",
                     "result": None,
-                    "error": f"Invalid JSON input: {e}",
+                    "error": f"Invalid JSON input: {input_data.get('error')}",
                     "stdout": "",
                     "stderr": "",
                 },
             )
             continue
-        except EOFError:
-            break
 
         msg_type = input_data.get("type", "execute")
 
@@ -1143,13 +1198,7 @@ def main_server():
         is_async = input_data.get("is_async", True)
         apply_env_overlay(input_data.get("env_overlay"))
 
-        # Execute with RPC support using persistent globals
-        result = run_server_with_rpc_loop(
-            implementation,
-            call_kwargs,
-            is_async,
-            globals_dict,
-        )
+        result = _run_request(implementation, call_kwargs, is_async, globals_dict)
 
         # Make result JSON-serializable
         result["result"] = make_json_serializable(result["result"])

--- a/uv.lock
+++ b/uv.lock
@@ -9592,9 +9592,11 @@ requires-dist = [
 dev = [
     { name = "autoflake", specifier = ">=2.3.1" },
     { name = "black", specifier = "==26.5.1" },
+    { name = "fastapi", specifier = ">=0.136.3" },
     { name = "opentelemetry-api", specifier = ">=1.20.0" },
     { name = "opentelemetry-exporter-otlp", specifier = ">=1.20.0" },
     { name = "opentelemetry-sdk", specifier = ">=1.20.0" },
+    { name = "orjson", specifier = ">=3.10.0" },
     { name = "pre-commit", specifier = ">=4.0.1" },
     { name = "pytest", specifier = ">=8.4.2" },
     { name = "pytest-asyncio", specifier = ">=0.24.0" },


### PR DESCRIPTION
Release PR from staging to main.\n\nThe production-critical change makes deployment task entrypoint resolution use the authoritative compositional function catalogue rather than the reconciling runtime's filtered discovery surface. This restores desktop/integration-gated Sales Navigator task bindings while keeping actor discovery scoped. It also adds regression coverage proving unresolved updates preserve the last known symbolic entrypoint.\n\nLocal verification: pre-commit clean; 24/24 tests passed across the affected FunctionManager and TaskScheduler files.\n\nAlso carries the two commits already on staging: the dev dependency re-lock and venv steering correction.