### PR TITLE
feat(workflows): move the shelf to the Builtins project

### DIFF
--- a/scripts/seed_builtins_catalog.py
+++ b/scripts/seed_builtins_catalog.py
@@ -963,6 +963,7 @@ def main(argv: list[str] | None = None) -> int:
     from unify.function_manager.builtins_catalog import seed_builtin_primitives
     from unify.guidance_manager.builtins_catalog import seed_builtin_guidance
     from unify.integrations.builtins_catalog import seed_builtin_integrations
+    from unify.workflow_manager.builtins_catalog import seed_builtin_workflows
 
     project = builtins_project()
     logging.info(
@@ -972,6 +973,7 @@ def main(argv: list[str] | None = None) -> int:
     )
     primitives_changed = seed_builtin_primitives()
     guidance_changed = seed_builtin_guidance()
+    workflows_changed = seed_builtin_workflows()
     if args.skip_integrations:
         integrations_changed = False
     elif args.integration_bootstrap_manifest:
@@ -994,6 +996,7 @@ def main(argv: list[str] | None = None) -> int:
     for name, changed in (
         ("primitives", primitives_changed),
         ("guidance", guidance_changed),
+        ("workflows", workflows_changed),
         ("integrations", integrations_changed),
     ):
         state = "updated" if changed else "already up to date"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -526,12 +526,17 @@ def pytest_sessionstart(session):
     from unify.function_manager.builtins_catalog import seed_builtin_primitives
     from unify.guidance_manager.builtins_catalog import seed_builtin_guidance
     from unify.integrations.builtins_catalog import seed_builtin_integrations
+    from unify.workflow_manager.builtins_catalog import seed_builtin_workflows
 
     with _cross_process_column_lock(builtins_project(), "builtins_seed"):
         with builtins_seed_key_override():
             seed_builtin_primitives()
             seed_builtin_guidance()
             seed_builtin_integrations()
+            # Workflows: storage only (bundles=None resolves the sibling
+            # unify-deploy tree when present; tests that need rows seed
+            # explicit bundles themselves).
+            seed_builtin_workflows(bundles=[])
 
     # ------------------------------------------------------------------
     #  Configure EventBus publishing (disabled by default in tests)

--- a/tests/workflow_manager/test_catalog.py
+++ b/tests/workflow_manager/test_catalog.py
@@ -194,9 +194,8 @@ def test_human_schedule_reads_as_plain_language():
     """Reading surfaces show a workflow's cadence before it is installed,
     and that phrasing is the part a user actually weighs. Derived once
     here so every surface says it identically."""
-    from unify.workflow_manager.workflow_manager import WorkflowManager
+    from unify.workflow_manager.builtins_catalog import human_schedule as schedule
 
-    schedule = WorkflowManager._human_schedule
     weekdays = {
         "repeat": [
             {
@@ -233,10 +232,10 @@ def test_human_schedule_reads_as_plain_language():
 
 def test_bundle_sets_names_what_each_surface_receives(tmp_path: Path):
     """The 'what this installs' list a reader shows before installing."""
-    from unify.workflow_manager.workflow_manager import WorkflowManager
+    from unify.workflow_manager.builtins_catalog import bundle_sets
 
     bundle = load_bundle(_write_bundle(tmp_path))
-    sets = WorkflowManager._bundle_sets(bundle)
+    sets = bundle_sets(bundle)
 
     assert sets["guidance"] == [{"name": "Triage"}]
     assert sets["tasks"] == [{"name": "Morning run", "schedule": "Every day"}]

--- a/tests/workflow_manager/test_install_uninstall_live.py
+++ b/tests/workflow_manager/test_install_uninstall_live.py
@@ -405,57 +405,55 @@ async def test_bootstrap_fills_the_shelf_and_reconciles_installed(
 
 @_handle_project
 @pytest.mark.asyncio
-async def test_catalog_publishes_for_reading_surfaces_and_short_circuits(
+async def test_catalog_seeds_the_builtins_shelf_and_short_circuits(
     live_managers,
     bundle,
 ):
-    """The shelf a reading surface renders without waking the assistant.
-
-    A hosted assistant is usually asleep when someone opens Console, so
-    the catalogue is mirrored into rows rather than served from the
-    assistant's memory. The publish must also be cheap on every boot
-    between deploys, which is almost all of them: an unchanged catalogue
-    costs one meta read and writes nothing.
+    """The shelf a reading surface renders lives in the public-read
+    Builtins project — platform data, one copy for everyone, exactly like
+    the integrations app catalogue — while everything per-assistant stays
+    in the assistant's own contexts. The seed must also be cheap on every
+    run between deploys: an unchanged catalogue reads one meta row and
+    writes nothing.
     """
     import json as _json
 
-    gm, ts, wm = live_managers
-    wm.register_bundle(bundle)
-
-    first = wm.publish_catalog()
-    assert first["published"] == [SLUG]
-    assert first["removed"] == []
-
-    rows = unisdk.get_logs(context=wm._catalog_ctx)
-    (row,) = [dict(lg.entries or {}) for lg in rows]
-    assert row["slug"] == SLUG
-    assert row["name"] == "Live demo workflow"
-    assert _json.loads(row["surfaces"]) == ["guidance", "tasks"]
-
-    # "What this installs", derived so a reader can show it pre-install.
-    sets = _json.loads(row["sets"])
-    assert sets["guidance"] == [{"name": "Workflow triage procedure"}] or (
-        {"name": "Workflow tone procedure"} in sets["guidance"]
+    from unify.common.builtins import builtins_project, builtins_seed_key_override
+    from unify.workflow_manager.builtins_catalog import (
+        BUILTINS_WORKFLOWS_CONTEXT,
+        seed_builtin_workflows,
     )
-    assert sets["tasks"] == [
-        {"name": "Workflow morning run", "schedule": "Every day"},
-    ]
 
-    # Unchanged catalogue: no writes at all.
-    again = wm.publish_catalog()
-    assert again == {"unchanged": True, "published": [], "removed": []}
+    project = builtins_project()
 
-    # A bundle leaving the catalogue leaves the shelf too.
-    wm._catalogue.clear()
-    wm.register_bundle(
-        WorkflowBundle(slug="other_demo", name="Other demo", surfaces={}),
-    )
-    third = wm.publish_catalog()
-    assert third["published"] == ["other_demo"]
-    assert third["removed"] == [SLUG]
+    def shelf():
+        logs = unisdk.get_logs(
+            project=project,
+            context=BUILTINS_WORKFLOWS_CONTEXT,
+            limit=100,
+        )
+        return {
+            str((lg.entries or {}).get("slug")): dict(lg.entries or {}) for lg in logs
+        }
 
-    slugs = {
-        str((lg.entries or {}).get("slug"))
-        for lg in unisdk.get_logs(context=wm._catalog_ctx)
-    }
-    assert slugs == {"other_demo"}
+    with builtins_seed_key_override():
+        assert seed_builtin_workflows(bundles=[bundle]) is True
+
+        row = shelf()[SLUG]
+        assert row["name"] == "Live demo workflow"
+        assert _json.loads(row["surfaces"]) == ["guidance", "tasks"]
+        sets = _json.loads(row["sets"])
+        assert sets["tasks"] == [
+            {"name": "Workflow morning run", "schedule": "Every day"},
+        ]
+
+        # Unchanged catalogue: the hash short-circuits, nothing is written.
+        assert seed_builtin_workflows(bundles=[bundle]) is False
+
+        # A bundle leaving the curated tree leaves the shelf.
+        other = WorkflowBundle(slug="other_demo", name="Other demo", surfaces={})
+        assert seed_builtin_workflows(bundles=[other]) is True
+        assert set(shelf()) == {"other_demo"}
+
+        # The harness re-seeds an empty catalogue for the next session.
+        seed_builtin_workflows(bundles=[])

--- a/unify/workflow_manager/__init__.py
+++ b/unify/workflow_manager/__init__.py
@@ -23,6 +23,7 @@ __all__ = [
     "WorkflowManager",
     "WorkflowRequirement",
     "bootstrap_workflow_catalog",
+    "seed_builtin_workflows",
     "load_bundle",
     "load_catalog",
     "register_default_surfaces",
@@ -38,6 +39,7 @@ _lazy_map = {
     "WorkflowBundle": "unify.workflow_manager.bundle",
     "WorkflowRequirement": "unify.workflow_manager.bundle",
     "bootstrap_workflow_catalog": "unify.workflow_manager.catalog",
+    "seed_builtin_workflows": "unify.workflow_manager.builtins_catalog",
     "load_bundle": "unify.workflow_manager.catalog",
     "load_catalog": "unify.workflow_manager.catalog",
     "schedule_bootstrap_workflow_catalog": "unify.workflow_manager.catalog",
@@ -71,6 +73,7 @@ if TYPE_CHECKING:
         WorkflowBundle,
         WorkflowRequirement,
     )
+    from .builtins_catalog import seed_builtin_workflows
     from .catalog import (
         bootstrap_workflow_catalog,
         load_bundle,

--- a/unify/workflow_manager/builtins_catalog.py
+++ b/unify/workflow_manager/builtins_catalog.py
@@ -1,0 +1,293 @@
+"""Public-read Builtins catalogue for the workflow shelf.
+
+The shelf listing is platform data, not tenant data: one hand-curated
+collection, identical for every assistant, exactly like the integrations
+app catalogue. It lives as rows in the public-read Builtins project so a
+reading surface (Console's gallery) renders it without waking an
+assistant — a hosted assistant is an on-demand job and is usually asleep
+when someone opens Console.
+
+Everything per-assistant stays in each assistant's own contexts: the
+installation rows, params, requirement/connection state, and the planted
+content itself. Only the listing is global.
+
+Seeding runs in bootstrap/admin processes (the deploy seed script, the
+self-host install, the test harness) whose key owns the Builtins project;
+assistants never write here. It is hash-guarded, so repeated runs are
+cheap and idempotent — the same contract as the primitives, guidance and
+integrations catalogues beside it.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Optional
+
+import unisdk
+from unisdk.utils.http import RequestError
+
+from ..common.authorship import strip_authoring_assistant_id
+from ..common.builtins import (
+    builtins_project,
+    ensure_builtins_project,
+    read_seed_hashes,
+    write_seed_hashes,
+)
+from ..common.log_utils import create_logs as unity_create_logs
+from ..function_manager.hash_utils import stable_hash_for_rows
+from .bundle import WorkflowBundle
+from .types.catalog_entry import WorkflowCatalogEntry
+
+logger = logging.getLogger(__name__)
+
+BUILTINS_WORKFLOWS_CONTEXT = "Workflows/Catalog"
+BUILTINS_WORKFLOWS_META_CONTEXT = "Workflows/Meta"
+_HASH_MAP_KEY = "workflows_catalog_hash_by_unit"
+_UNIT = "workflows"
+
+
+def _ensure_catalog_storage(project: str) -> None:
+    ensure_builtins_project(project)
+    unisdk.create_context(
+        BUILTINS_WORKFLOWS_CONTEXT,
+        description="Public catalogue of installable workflows.",
+        unique_keys={"slug": "str"},
+        project=project,
+    )
+    unisdk.create_context(
+        BUILTINS_WORKFLOWS_META_CONTEXT,
+        description="Seeding state for the workflow catalogue.",
+        unique_keys={"meta_id": "int"},
+        project=project,
+    )
+
+
+def human_schedule(entry: Mapping[str, Any]) -> str:
+    """A plain-language cadence for one task entry, or "" if it has none.
+
+    Reading surfaces show a workflow's recurring jobs before it is
+    installed, and "every weekday at 08:30" is the part a user actually
+    weighs. Derived here rather than in the reader so every surface says
+    it the same way.
+    """
+    repeat = entry.get("repeat") or []
+    if isinstance(repeat, str):
+        try:
+            repeat = json.loads(repeat)
+        except ValueError:
+            return ""
+    if not repeat:
+        return "Once, at install" if not entry.get("trigger") else "On a trigger"
+
+    first = repeat[0] if isinstance(repeat[0], Mapping) else {}
+    frequency = str(first.get("frequency") or "").lower()
+    weekdays = [str(d).upper() for d in (first.get("weekdays") or [])]
+    at = str(first.get("time_of_day") or "")[:5]
+
+    if frequency == "weekly" and weekdays:
+        if set(weekdays) == {"MO", "TU", "WE", "TH", "FR"}:
+            cadence = "Every weekday"
+        else:
+            order = ["MO", "TU", "WE", "TH", "FR", "SA", "SU"]
+            names = {
+                "MO": "Mon",
+                "TU": "Tue",
+                "WE": "Wed",
+                "TH": "Thu",
+                "FR": "Fri",
+                "SA": "Sat",
+                "SU": "Sun",
+            }
+            ordered = [names[d] for d in order if d in weekdays]
+            cadence = "Every " + ", ".join(ordered)
+    elif frequency:
+        cadence = {
+            "minutely": "Every minute",
+            "hourly": "Every hour",
+            "daily": "Every day",
+            "weekly": "Every week",
+            "monthly": "Every month",
+            "yearly": "Every year",
+        }.get(frequency, f"Every {frequency}")
+    else:
+        return ""
+
+    return f"{cadence} at {at}" if at else cadence
+
+
+def bundle_sets(bundle: WorkflowBundle) -> Dict[str, Any]:
+    """What a bundle sets up, per surface, for a reader to show."""
+    sets: Dict[str, Any] = {}
+    for surface, source in bundle.surfaces.items():
+        items = []
+        for key, entry in sorted(source.items()):
+            fields = entry if isinstance(entry, Mapping) else {}
+            item: Dict[str, Any] = {
+                "name": str(fields.get("name") or fields.get("title") or key),
+            }
+            if surface == "tasks":
+                schedule = human_schedule(fields)
+                if schedule:
+                    item["schedule"] = schedule
+            items.append(item)
+        sets[surface] = items
+    return sets
+
+
+def catalog_row(bundle: WorkflowBundle) -> Dict[str, Any]:
+    """One catalogue row's fields, derived wholly from the bundle."""
+    entry = WorkflowCatalogEntry(
+        slug=bundle.slug,
+        name=bundle.name,
+        version=bundle.version,
+        category=bundle.category,
+        icon_id=bundle.icon_id,
+        description=bundle.description,
+        requirements=json.dumps(
+            [
+                {
+                    "slug": requirement.slug,
+                    "name": requirement.name or requirement.slug,
+                }
+                for requirement in bundle.requirements
+            ],
+        ),
+        capabilities=json.dumps(list(bundle.capabilities)),
+        params_schema=json.dumps(bundle.params_schema, sort_keys=True),
+        surfaces=json.dumps(bundle.surface_names()),
+        sets=json.dumps(bundle_sets(bundle), sort_keys=True),
+    )
+    return strip_authoring_assistant_id(entry.model_dump(mode="json"))
+
+
+def _default_bundles() -> Optional[List[WorkflowBundle]]:
+    """The curated bundles this environment ships, or None when it has none.
+
+    Resolution order matches the runtime's: an explicit
+    ``UNITY_WORKFLOWS_DIR``, then the installed ``unify_deploy`` package.
+    ``None`` (as opposed to ``[]``) means "nothing to reconcile" — the seed
+    ensures storage exists and stops, so an environment without the curated
+    tree cannot empty a catalogue another environment seeded.
+    """
+    from ..settings import SETTINGS
+    from .catalog import load_catalog
+
+    configured = (SETTINGS.UNITY_WORKFLOWS_DIR or "").strip()
+    if configured:
+        return load_catalog(Path(configured))
+    try:
+        from unify_deploy.assistant_deployments.workflows import workflows_root
+
+        return load_catalog(workflows_root())
+    except Exception:
+        return None
+
+
+def seed_builtin_workflows(
+    *,
+    bundles: Optional[List[WorkflowBundle]] = None,
+    project: str | None = None,
+) -> bool:
+    """Seed the public workflow catalogue. Returns True when rows changed.
+
+    Omitting *bundles* resolves them from this environment's curated tree;
+    an environment with no tree only guarantees storage exists. Passing
+    ``bundles=[]`` explicitly empties the catalogue.
+    """
+    project = project or builtins_project()
+
+    if bundles is None:
+        bundles = _default_bundles()
+
+    # Read-only probe first: a pre-seeded, unchanged catalogue must be
+    # verifiable by any principal without owner-guarded writes.
+    try:
+        current_hashes = read_seed_hashes(
+            project,
+            meta_context=BUILTINS_WORKFLOWS_META_CONTEXT,
+            key=_HASH_MAP_KEY,
+        )
+        storage_ready = True
+    except RequestError:
+        storage_ready = False
+        current_hashes = {}
+
+    if bundles is None:
+        if not storage_ready:
+            _ensure_catalog_storage(project)
+        return False
+
+    rows = {bundle.slug: catalog_row(bundle) for bundle in bundles}
+    hash_fields = sorted(WorkflowCatalogEntry.model_fields)
+    expected_hash = stable_hash_for_rows(
+        list(rows.values()),
+        fields=hash_fields,
+        sort_field="slug",
+    )
+    if storage_ready and current_hashes.get(_UNIT) == expected_hash:
+        logger.debug("Workflow catalogue unchanged; skipping seed")
+        return False
+
+    _ensure_catalog_storage(project)
+
+    live_logs = unisdk.get_logs(
+        project=project,
+        context=BUILTINS_WORKFLOWS_CONTEXT,
+        limit=1000,
+    )
+    live = {
+        str((lg.entries or {}).get("slug")): lg
+        for lg in live_logs
+        if (lg.entries or {}).get("slug")
+    }
+
+    inserts = [payload for slug, payload in rows.items() if slug not in live]
+    if inserts:
+        unity_create_logs(
+            context=BUILTINS_WORKFLOWS_CONTEXT,
+            project=project,
+            entries=inserts,
+            stamp_authoring=True,
+            batched=True,
+        )
+
+    for slug, payload in rows.items():
+        existing = live.get(slug)
+        if existing is None:
+            continue
+        current = {key: (existing.entries or {}).get(key) for key in payload}
+        if current == payload:
+            continue
+        unisdk.update_logs(
+            project=project,
+            context=BUILTINS_WORKFLOWS_CONTEXT,
+            logs=[existing.id],
+            entries=payload,
+            overwrite=True,
+        )
+
+    stale = [lg.id for slug, lg in live.items() if slug not in rows]
+    if stale:
+        unisdk.delete_logs(
+            project=project,
+            context=BUILTINS_WORKFLOWS_CONTEXT,
+            logs=stale,
+        )
+
+    hashes = dict(current_hashes)
+    hashes[_UNIT] = expected_hash
+    write_seed_hashes(
+        project,
+        hashes,
+        meta_context=BUILTINS_WORKFLOWS_META_CONTEXT,
+        key=_HASH_MAP_KEY,
+    )
+    logger.info(
+        "Seeded workflow catalogue project=%s rows=%d removed=%d",
+        project,
+        len(rows),
+        len(stale),
+    )
+    return True

--- a/unify/workflow_manager/catalog.py
+++ b/unify/workflow_manager/catalog.py
@@ -181,9 +181,10 @@ def bootstrap_workflow_catalog(
         except Exception:
             logger.exception("Skipping malformed workflow bundle at %s", entry)
 
-    # Publish before reconciling: the shelf is what a reading surface needs
-    # first, and it must not wait on installs that may be slow or partial.
-    manager.publish_catalog()
+    # The shelf itself is NOT published here: the catalogue listing is
+    # platform data in the public-read Builtins project, seeded by admin
+    # processes (see builtins_catalog.seed_builtin_workflows). An assistant
+    # key cannot write Builtins and must not try.
 
     try:
         report = manager.reconcile_installed()

--- a/unify/workflow_manager/workflow_manager.py
+++ b/unify/workflow_manager/workflow_manager.py
@@ -16,7 +16,6 @@ which is what makes update and uninstall possible at all.
 from __future__ import annotations
 
 import functools
-import hashlib
 import json
 import logging
 import threading
@@ -35,7 +34,6 @@ from ..common.tool_outcome import ToolErrorException
 from .base import BaseWorkflowManager
 from .bundle import WORKFLOW_LIBRARY, SurfaceRegistry, WorkflowBundle
 from .requirements import RequirementResolver
-from .types.catalog_entry import WorkflowCatalogEntry
 from .types.meta import WorkflowMeta
 from .types.workflow import UNASSIGNED, WorkflowInstallation
 
@@ -43,7 +41,6 @@ logger = logging.getLogger(__name__)
 
 WORKFLOW_TABLE = "Workflows"
 WORKFLOW_META_TABLE = "Workflows/Meta"
-WORKFLOW_CATALOG_TABLE = "Workflows/Catalog"
 
 
 class WorkflowManager(BaseWorkflowManager):
@@ -64,22 +61,12 @@ class WorkflowManager(BaseWorkflowManager):
                 fields=model_to_fields(WorkflowMeta),
                 unique_keys={"meta_id": "int"},
             ),
-            TableContext(
-                name=WORKFLOW_CATALOG_TABLE,
-                description=(
-                    "Installable workflows published for reading surfaces. "
-                    "Derived from the bundles on disk; never authored here."
-                ),
-                fields=model_to_fields(WorkflowCatalogEntry),
-                unique_keys={"slug": "str"},
-            ),
         ]
 
     def __init__(self) -> None:
         super().__init__()
         self._ctx = ContextRegistry.get_context(self, WORKFLOW_TABLE)
         self._meta_ctx = ContextRegistry.get_context(self, WORKFLOW_META_TABLE)
-        self._catalog_ctx = ContextRegistry.get_context(self, WORKFLOW_CATALOG_TABLE)
         self._surfaces = SurfaceRegistry()
         self._catalogue: Dict[str, WorkflowBundle] = {}
         self._lock = threading.RLock()
@@ -745,233 +732,6 @@ class WorkflowManager(BaseWorkflowManager):
                 sorted(failures),
             )
         return result
-
-    # ------------------------------------------------------------------ #
-    # Publishing the catalogue for reading surfaces                      #
-    # ------------------------------------------------------------------ #
-    @staticmethod
-    def _human_schedule(entry: Mapping[str, Any]) -> str:
-        """A plain-language cadence for one task entry, or "" if it has none.
-
-        Reading surfaces show a workflow's recurring jobs before it is
-        installed, and "every weekday at 08:30" is the part a user actually
-        weighs. Derived here rather than in the reader so every surface
-        says it the same way.
-        """
-        repeat = entry.get("repeat") or []
-        if isinstance(repeat, str):
-            try:
-                repeat = json.loads(repeat)
-            except ValueError:
-                return ""
-        if not repeat:
-            return "Once, at install" if not entry.get("trigger") else "On a trigger"
-
-        first = repeat[0] if isinstance(repeat[0], Mapping) else {}
-        frequency = str(first.get("frequency") or "").lower()
-        weekdays = [str(d).upper() for d in (first.get("weekdays") or [])]
-        at = str(first.get("time_of_day") or "")[:5]
-
-        if frequency == "weekly" and weekdays:
-            weekday_set = {"MO", "TU", "WE", "TH", "FR"}
-            if set(weekdays) == weekday_set:
-                cadence = "Every weekday"
-            else:
-                order = ["MO", "TU", "WE", "TH", "FR", "SA", "SU"]
-                names = {
-                    "MO": "Mon",
-                    "TU": "Tue",
-                    "WE": "Wed",
-                    "TH": "Thu",
-                    "FR": "Fri",
-                    "SA": "Sat",
-                    "SU": "Sun",
-                }
-                ordered = [names[d] for d in order if d in weekdays]
-                cadence = "Every " + ", ".join(ordered)
-        elif frequency:
-            cadence = {
-                "minutely": "Every minute",
-                "hourly": "Every hour",
-                "daily": "Every day",
-                "weekly": "Every week",
-                "monthly": "Every month",
-                "yearly": "Every year",
-            }.get(frequency, f"Every {frequency}")
-        else:
-            return ""
-
-        return f"{cadence} at {at}" if at else cadence
-
-    @classmethod
-    def _bundle_sets(cls, bundle: WorkflowBundle) -> Dict[str, Any]:
-        """What a bundle sets up, per surface, for a reader to show."""
-        sets: Dict[str, Any] = {}
-        for surface, source in bundle.surfaces.items():
-            items = []
-            for key, entry in sorted(source.items()):
-                fields = entry if isinstance(entry, Mapping) else {}
-                item: Dict[str, Any] = {
-                    "name": str(fields.get("name") or fields.get("title") or key),
-                }
-                if surface == "tasks":
-                    schedule = cls._human_schedule(fields)
-                    if schedule:
-                        item["schedule"] = schedule
-                items.append(item)
-            sets[surface] = items
-        return sets
-
-    def _catalog_entry(self, bundle: WorkflowBundle) -> Dict[str, Any]:
-        """One catalogue row's fields, derived wholly from the bundle."""
-        entry = WorkflowCatalogEntry(
-            slug=bundle.slug,
-            name=bundle.name,
-            version=bundle.version,
-            category=bundle.category,
-            icon_id=bundle.icon_id,
-            description=bundle.description,
-            requirements=json.dumps(
-                [
-                    {
-                        "slug": requirement.slug,
-                        "name": requirement.name or requirement.slug,
-                    }
-                    for requirement in bundle.requirements
-                ],
-            ),
-            capabilities=json.dumps(list(bundle.capabilities)),
-            params_schema=json.dumps(bundle.params_schema, sort_keys=True),
-            surfaces=json.dumps(bundle.surface_names()),
-            sets=json.dumps(self._bundle_sets(bundle), sort_keys=True),
-        )
-        return strip_authoring_assistant_id(entry.model_dump(mode="json"))
-
-    def _get_stored_catalog_hash(self) -> str:
-        try:
-            logs = unisdk.get_logs(
-                context=self._meta_ctx,
-                filter="meta_id == 1",
-                limit=1,
-            )
-            if logs:
-                return str((logs[0].entries or {}).get("custom_workflow_hash", ""))
-        except Exception:
-            logger.debug("Could not read the workflow catalogue hash", exc_info=True)
-        return ""
-
-    def _store_catalog_hash(self, hash_value: str) -> None:
-        try:
-            logs = unisdk.get_logs(
-                context=self._meta_ctx,
-                filter="meta_id == 1",
-                limit=1,
-            )
-            if logs:
-                unisdk.update_logs(
-                    context=self._meta_ctx,
-                    logs=[logs[0].id],
-                    entries={"custom_workflow_hash": hash_value},
-                    overwrite=True,
-                )
-            else:
-                unity_create_logs(
-                    context=self._meta_ctx,
-                    entries=[{"meta_id": 1, "custom_workflow_hash": hash_value}],
-                    stamp_authoring=True,
-                )
-        except Exception:
-            logger.debug("Could not store the workflow catalogue hash", exc_info=True)
-
-    def publish_catalog(self) -> Dict[str, Any]:
-        """Mirror the in-memory catalogue into ``Workflows/Catalog``.
-
-        Reading surfaces then see the shelf without waking the assistant,
-        which matters because a hosted assistant is usually asleep when
-        someone opens Console.
-
-        Cheap by construction, in three steps:
-
-        1. **Hash short-circuit.** The published shape is fingerprinted and
-           compared with the stored aggregate. A boot whose catalogue has
-           not changed costs one meta read and nothing else — which is
-           every boot between deploys, i.e. almost all of them.
-        2. **One batched insert** for rows that are new, rather than a call
-           per bundle.
-        3. **Per-row updates only for rows that actually changed**, since
-           Orchestra applies one entries payload to every id in a call and
-           each row's content differs. Deletes batch into one call.
-
-        Nothing is authored in that context, so there is no user edit to
-        preserve and no merge to get wrong.
-
-        Best-effort by design: a publish failure must not stop an assistant
-        booting or block installs, because the in-memory catalogue is the
-        authority either way. Failures are logged and the next boot retries
-        (the hash is stored only on success, so a failed pass does not pin
-        itself as up to date).
-        """
-        bundles = self.available_bundles()
-        entries = {bundle.slug: self._catalog_entry(bundle) for bundle in bundles}
-        expected_hash = hashlib.sha256(
-            json.dumps(entries, sort_keys=True).encode(),
-        ).hexdigest()
-
-        if entries and self._get_stored_catalog_hash() == expected_hash:
-            logger.debug("Workflow catalogue unchanged; skipping publish")
-            return {"unchanged": True, "published": [], "removed": []}
-
-        published: List[str] = []
-        removed: List[str] = []
-        try:
-            live_logs = unisdk.get_logs(
-                context=self._catalog_ctx,
-                exclude_fields=list_private_fields(self._catalog_ctx),
-            )
-            live = {
-                str((lg.entries or {}).get("slug")): lg
-                for lg in live_logs
-                if (lg.entries or {}).get("slug")
-            }
-
-            inserts = [payload for slug, payload in entries.items() if slug not in live]
-            if inserts:
-                unity_create_logs(
-                    context=self._catalog_ctx,
-                    entries=inserts,
-                    stamp_authoring=True,
-                    batched=True,
-                )
-                published.extend(payload["slug"] for payload in inserts)
-
-            for slug, payload in entries.items():
-                existing = live.get(slug)
-                if existing is None:
-                    continue
-                current = {key: (existing.entries or {}).get(key) for key in payload}
-                if current == payload:
-                    continue
-                unisdk.update_logs(
-                    context=self._catalog_ctx,
-                    logs=[existing.id],
-                    entries=payload,
-                    overwrite=True,
-                )
-                published.append(slug)
-
-            stale = [lg.id for slug, lg in live.items() if slug not in entries]
-            if stale:
-                unisdk.delete_logs(context=self._catalog_ctx, logs=stale)
-                removed.extend(slug for slug in live if slug not in entries)
-        except Exception:
-            logger.exception(
-                "Could not publish the workflow catalogue; the shelf may read "
-                "stale until the next boot",
-            )
-            return {"published": sorted(published), "removed": sorted(removed)}
-
-        self._store_catalog_hash(expected_hash)
-        return {"published": sorted(published), "removed": sorted(removed)}
 
     @functools.wraps(BaseWorkflowManager.get_workflow, updated=())
     def get_workflow(self, *, slug: str) -> Dict[str, Any]:


### PR DESCRIPTION
The catalogue listing was published per assistant, but it is platform data: one hand-curated collection, identical for everyone, exactly like the integrations app catalogue beside it. Publishing it per assistant meant every assistant re-deriving the same rows, a shelf that did not exist until an assistant's first boot, and an assistant-owned write for content no assistant authors.

The shelf now lives in the public-read Builtins project, seeded by the same admin processes as the primitives, guidance and integrations catalogues — the deploy seed script, the self-host compose, the test harness — with the same contract: a read-only hash probe first, so an unchanged catalogue is verifiable by any principal without owner-guarded writes, then batched inserts, targeted updates and prune by slug. One distinction is deliberate: omitting bundles means "this environment has no curated tree", which ensures storage and stops, while an explicit empty list empties the catalogue — so an environment without unify-deploy installed can never wipe what another environment seeded.

Everything per-assistant stays exactly where it was: installation rows, params, requirement state, and the planted content itself. The per-assistant publish path is deleted, and the boot bootstrap now says why it does not publish — an assistant key cannot write Builtins and must not try. The derivation helpers (human schedules, the per-surface "what this installs" listing) move with the publisher.

<!--
Thanks for contributing to Unify! Please fill out the sections below.
For trivial changes (typo fixes, comment-only edits) you can shorten this template — just keep the Summary.

PRs land on `staging`, not `main`. See CONTRIBUTING.md.
-->

## Summary

<!-- 1–3 sentences: what problem does this PR solve, and why is this the right approach? -->



## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes incorrect behavior)
- [ ] Feature (non-breaking change that adds functionality)
- [ ] Refactor (no behavior change)
- [ ] Breaking change (API or data-model change — Unify has zero-backward-compat policy, but please call it out)
- [ ] Test-only (no source changes)
- [ ] Docs / chore / CI

## Areas touched

<!-- Check all that apply. Helps reviewers route. -->

- [ ] Actor / CodeAct
- [ ] ConversationManager / slow brain
- [ ] A specific state manager (Contact / Knowledge / Task / Transcript / Guidance / Function / File / Image / Web / Secret / Blacklist / Data / Memory)
- [ ] Async tool loop (`unify/common/_async_tool/`)
- [ ] Event bus / observability
- [ ] Gateway / external comms
- [ ] Tests / test infra (`tests/`, `conftest.py`, `parallel_run.sh`)
- [ ] CI / build / packaging

## Test plan

<!--
How did you verify this? Paste the command(s) you ran and the result.

The default expectation is to run the relevant directory:
  tests/parallel_run.sh tests/<module>/

For infrastructure changes that are hard to reach via tests, a quick
verification script under tests/_verify_*.py is encouraged
(see .agents/rules/surgical-verification-before-tests.md).
-->

```
tests/parallel_run.sh tests/...
```

- [ ] All relevant tests pass locally
- [ ] If this is a bug fix, I added a regression test (or explained why one isn't feasible)

## Behavior / migration notes

<!--
- Did this change a public manager API, primitive, or event payload?
- Are there schema/context changes in Orchestra that need a migration?
- Any new env vars or config flags? (Update `.env.advanced.example`.)
- If yes to any of the above, describe upgrade steps.
-->

None.

## Checklist

- [ ] PR is targeted at `staging` (not `main`)
- [ ] Followed conventional commit style (`feat(scope):`, `fix(scope):`, `refactor(scope):`, `chore(scope):`, etc.)
- [ ] No `try/except` added defensively — only around specific, recoverable errors
- [ ] No "new" / "updated" / "TODO from chat" temporal comments (see `.agents/rules/no-temporal-comments.md`)
- [ ] No test-specific shortcuts in production code (see `.agents/rules/no-test-info-in-production-code.md`)
- [ ] Updated `AGENTS.md` / `ARCHITECTURE.md` if I changed architectural conventions
