### PR TITLE
Feat/workflows

### DIFF
--- a/tests/workflow_manager/test_catalog.py
+++ b/tests/workflow_manager/test_catalog.py
@@ -24,6 +24,10 @@ version: "1.2.0"
 category: comms
 icon_id: briefing
 description: Your calendar and the unread that matters, before stand-up.
+about: |
+  Every weekday morning the briefing reads your calendar and inbox.
+
+  It arrives as one chat message before stand-up.
 requirements:
   - slug: gmail
     name: Gmail
@@ -78,6 +82,8 @@ def test_load_bundle_reads_identity_and_content(tmp_path: Path):
     assert bundle.version == "1.2.0"
     assert bundle.category == "comms"
     assert bundle.icon_id == "briefing"
+    assert bundle.about.startswith("Every weekday morning")
+    assert "\n\n" in bundle.about
     assert bundle.capabilities == ("filesystem",)
     assert bundle.params_schema["mailbox"]["required"] is True
 
@@ -239,3 +245,31 @@ def test_bundle_sets_names_what_each_surface_receives(tmp_path: Path):
 
     assert sets["guidance"] == [{"name": "Triage"}]
     assert sets["tasks"] == [{"name": "Morning run", "schedule": "Every day"}]
+
+
+def test_content_rows_carry_each_artifact_whole(tmp_path: Path):
+    """The listing names what a workflow sets up; the content rows beside
+    it carry the artifacts' substance, so a reader can open any of them
+    before anything is installed."""
+    from unify.workflow_manager.builtins_catalog import content_rows
+
+    bundle = load_bundle(_write_bundle(tmp_path))
+    rows = {row["content_key"]: row for row in content_rows(bundle)}
+
+    assert set(rows) == {
+        "daily_briefing/guidance/wf/triage",
+        "daily_briefing/tasks/wf/morning",
+    }
+
+    triage = rows["daily_briefing/guidance/wf/triage"]
+    assert triage["slug"] == "daily_briefing"
+    assert triage["surface"] == "guidance"
+    assert triage["key"] == "wf/triage"
+    assert triage["name"] == "Triage"
+    assert triage["body"] == "Oldest first."
+    assert triage["schedule"] == ""
+
+    morning = rows["daily_briefing/tasks/wf/morning"]
+    assert morning["name"] == "Morning run"
+    assert morning["body"] == "The recurring job."
+    assert morning["schedule"] == "Every day"

--- a/tests/workflow_manager/test_daily_briefing_acceptance.py
+++ b/tests/workflow_manager/test_daily_briefing_acceptance.py
@@ -32,9 +32,12 @@ def _bundle_dir() -> Path:
     configured = (os.environ.get("UNITY_WORKFLOWS_DIR") or "").strip()
     if configured:
         return Path(configured) / SLUG
-    return (
-        Path.home() / "unify-deploy/unify_deploy/assistant_deployments/workflows" / SLUG
-    )
+    # Resolve the sibling checkout from this repo's location, never from
+    # Path.home(): the test harness points HOME at a scratch dir, so a
+    # home-relative probe skips this test on every machine that uses the
+    # runner — silently, forever.
+    siblings = Path(__file__).resolve().parents[2].parent
+    return siblings / "unify-deploy/unify_deploy/assistant_deployments/workflows" / SLUG
 
 
 pytestmark = pytest.mark.skipif(

--- a/tests/workflow_manager/test_install_uninstall_live.py
+++ b/tests/workflow_manager/test_install_uninstall_live.py
@@ -412,14 +412,17 @@ async def test_catalog_seeds_the_builtins_shelf_and_short_circuits(
     """The shelf a reading surface renders lives in the public-read
     Builtins project — platform data, one copy for everyone, exactly like
     the integrations app catalogue — while everything per-assistant stays
-    in the assistant's own contexts. The seed must also be cheap on every
-    run between deploys: an unchanged catalogue reads one meta row and
-    writes nothing.
+    in the assistant's own contexts. The listing rows carry names; the
+    content rows beside them carry the artifacts' substance, so a reader
+    can open a procedure or a task brief before anything is installed.
+    The seed must also be cheap on every run between deploys: an
+    unchanged catalogue reads one meta row and writes nothing.
     """
     import json as _json
 
     from unify.common.builtins import builtins_project, builtins_seed_key_override
     from unify.workflow_manager.builtins_catalog import (
+        BUILTINS_WORKFLOWS_CONTENT_CONTEXT,
         BUILTINS_WORKFLOWS_CONTEXT,
         seed_builtin_workflows,
     )
@@ -436,6 +439,17 @@ async def test_catalog_seeds_the_builtins_shelf_and_short_circuits(
             str((lg.entries or {}).get("slug")): dict(lg.entries or {}) for lg in logs
         }
 
+    def artifacts():
+        logs = unisdk.get_logs(
+            project=project,
+            context=BUILTINS_WORKFLOWS_CONTENT_CONTEXT,
+            limit=100,
+        )
+        return {
+            str((lg.entries or {}).get("content_key")): dict(lg.entries or {})
+            for lg in logs
+        }
+
     with builtins_seed_key_override():
         assert seed_builtin_workflows(bundles=[bundle]) is True
 
@@ -447,13 +461,28 @@ async def test_catalog_seeds_the_builtins_shelf_and_short_circuits(
             {"name": "Workflow morning run", "schedule": "Every day"},
         ]
 
+        content = artifacts()
+        assert set(content) == {
+            f"{SLUG}/guidance/wf/triage",
+            f"{SLUG}/guidance/wf/tone",
+            f"{SLUG}/tasks/wf/morning",
+        }
+        triage = content[f"{SLUG}/guidance/wf/triage"]
+        assert triage["name"] == "Workflow triage procedure"
+        assert triage["body"] == "Read the inbox oldest-first."
+        morning = content[f"{SLUG}/tasks/wf/morning"]
+        assert morning["body"] == "The recurring job this workflow exists for."
+        assert morning["schedule"] == "Every day"
+
         # Unchanged catalogue: the hash short-circuits, nothing is written.
         assert seed_builtin_workflows(bundles=[bundle]) is False
 
-        # A bundle leaving the curated tree leaves the shelf.
+        # A bundle leaving the curated tree leaves the shelf whole —
+        # listing and artifacts both.
         other = WorkflowBundle(slug="other_demo", name="Other demo", surfaces={})
         assert seed_builtin_workflows(bundles=[other]) is True
         assert set(shelf()) == {"other_demo"}
+        assert artifacts() == {}
 
         # The harness re-seeds an empty catalogue for the next session.
         seed_builtin_workflows(bundles=[])

--- a/unify/workflow_manager/__init__.py
+++ b/unify/workflow_manager/__init__.py
@@ -19,6 +19,7 @@ __all__ = [
     "UnscopedSurfaceError",
     "WorkflowBundle",
     "WorkflowCatalogEntry",
+    "WorkflowContentEntry",
     "WorkflowInstallation",
     "WorkflowManager",
     "WorkflowRequirement",
@@ -47,6 +48,7 @@ _lazy_map = {
     "SCOPED_SURFACES": "unify.workflow_manager.surfaces",
     "register_default_surfaces": "unify.workflow_manager.surfaces",
     "WorkflowCatalogEntry": "unify.workflow_manager.types.catalog_entry",
+    "WorkflowContentEntry": "unify.workflow_manager.types.content_entry",
     "WorkflowInstallation": "unify.workflow_manager.types.workflow",
     "WorkflowManager": "unify.workflow_manager.workflow_manager",
 }
@@ -86,5 +88,6 @@ if TYPE_CHECKING:
         register_default_surfaces,
     )
     from .types.catalog_entry import WorkflowCatalogEntry
+    from .types.content_entry import WorkflowContentEntry
     from .types.workflow import WorkflowInstallation
     from .workflow_manager import WorkflowManager

--- a/unify/workflow_manager/builtins_catalog.py
+++ b/unify/workflow_manager/builtins_catalog.py
@@ -7,9 +7,13 @@ reading surface (Console's gallery) renders it without waking an
 assistant — a hosted assistant is an on-demand job and is usually asleep
 when someone opens Console.
 
-Everything per-assistant stays in each assistant's own contexts: the
-installation rows, params, requirement/connection state, and the planted
-content itself. Only the listing is global.
+Two contexts are published: ``Workflows/Catalog`` (one listing row per
+bundle) and ``Workflows/Content`` (one row per artifact a bundle would
+plant, substance included, so a reader can open a procedure or a task
+brief before anything is installed). Everything per-assistant stays in
+each assistant's own contexts: the installation rows, params,
+requirement/connection state, and the planted content itself — the
+global rows are the shelf, never the live copies.
 
 Seeding runs in bootstrap/admin processes (the deploy seed script, the
 self-host install, the test harness) whose key owns the Builtins project;
@@ -39,13 +43,16 @@ from ..common.log_utils import create_logs as unity_create_logs
 from ..function_manager.hash_utils import stable_hash_for_rows
 from .bundle import WorkflowBundle
 from .types.catalog_entry import WorkflowCatalogEntry
+from .types.content_entry import WorkflowContentEntry
 
 logger = logging.getLogger(__name__)
 
 BUILTINS_WORKFLOWS_CONTEXT = "Workflows/Catalog"
+BUILTINS_WORKFLOWS_CONTENT_CONTEXT = "Workflows/Content"
 BUILTINS_WORKFLOWS_META_CONTEXT = "Workflows/Meta"
 _HASH_MAP_KEY = "workflows_catalog_hash_by_unit"
-_UNIT = "workflows"
+_CATALOG_UNIT = "workflows"
+_CONTENT_UNIT = "workflows_content"
 
 
 def _ensure_catalog_storage(project: str) -> None:
@@ -54,6 +61,12 @@ def _ensure_catalog_storage(project: str) -> None:
         BUILTINS_WORKFLOWS_CONTEXT,
         description="Public catalogue of installable workflows.",
         unique_keys={"slug": "str"},
+        project=project,
+    )
+    unisdk.create_context(
+        BUILTINS_WORKFLOWS_CONTENT_CONTEXT,
+        description="The artifacts each catalogued workflow would plant.",
+        unique_keys={"content_key": "str"},
         project=project,
     )
     unisdk.create_context(
@@ -145,6 +158,7 @@ def catalog_row(bundle: WorkflowBundle) -> Dict[str, Any]:
         category=bundle.category,
         icon_id=bundle.icon_id,
         description=bundle.description,
+        about=bundle.about,
         requirements=json.dumps(
             [
                 {
@@ -160,6 +174,90 @@ def catalog_row(bundle: WorkflowBundle) -> Dict[str, Any]:
         sets=json.dumps(bundle_sets(bundle), sort_keys=True),
     )
     return strip_authoring_assistant_id(entry.model_dump(mode="json"))
+
+
+_CONTENT_BODY_FIELD = {
+    "tasks": "description",
+    "functions": "docstring",
+}
+_CONTENT_META_FIELDS = {
+    "knowledge": ("kind", "topics"),
+    "tasks": ("tags",),
+    "functions": ("argspec",),
+}
+
+
+def content_rows(bundle: WorkflowBundle) -> List[Dict[str, Any]]:
+    """One row per artifact the bundle would plant, readable substance
+    included, so a reading surface can open any of them pre-install."""
+    rows: List[Dict[str, Any]] = []
+    for surface, source in sorted(bundle.surfaces.items()):
+        body_field = _CONTENT_BODY_FIELD.get(surface, "content")
+        meta_fields = _CONTENT_META_FIELDS.get(surface, ())
+        for key, entry in sorted(source.items()):
+            fields = entry if isinstance(entry, Mapping) else {}
+            meta = {
+                name: fields[name]
+                for name in meta_fields
+                if fields.get(name) not in (None, "", [])
+            }
+            row = WorkflowContentEntry(
+                content_key=f"{bundle.slug}/{surface}/{key}",
+                slug=bundle.slug,
+                surface=surface,
+                key=key,
+                name=str(fields.get("name") or fields.get("title") or key),
+                body=str(fields.get(body_field) or ""),
+                schedule=human_schedule(fields) if surface == "tasks" else "",
+                meta=json.dumps(meta, sort_keys=True, default=str),
+            )
+            rows.append(strip_authoring_assistant_id(row.model_dump(mode="json")))
+    return rows
+
+
+def _reconcile_rows(
+    *,
+    project: str,
+    context: str,
+    rows: Dict[str, Dict[str, Any]],
+    key_field: str,
+) -> None:
+    """Converge one context onto *rows*.
+
+    Changed rows are replaced (delete + insert), the same shape the sibling
+    builtins seeders use: the Builtins writer routes deletes and inserts by
+    project, and rows here carry no state beyond what the seed derives, so
+    replacement loses nothing.
+    """
+    live_logs = unisdk.get_logs(project=project, context=context, limit=1000)
+    live = {
+        str((lg.entries or {}).get(key_field)): lg
+        for lg in live_logs
+        if (lg.entries or {}).get(key_field)
+    }
+
+    def unchanged(key: str) -> bool:
+        existing = live.get(key)
+        if existing is None:
+            return False
+        payload = rows[key]
+        return {name: (existing.entries or {}).get(name) for name in payload} == payload
+
+    doomed = [
+        lg.id for key, lg in live.items() if key not in rows or not unchanged(key)
+    ]
+    if doomed:
+        unisdk.delete_logs(project=project, context=context, logs=doomed)
+
+    inserts = [payload for key, payload in rows.items() if not unchanged(key)]
+    if inserts:
+        unity_create_logs(
+            context=context,
+            project=project,
+            entries=inserts,
+            stamp_authoring=True,
+            batched=True,
+        )
 
 
 def _default_bundles() -> Optional[List[WorkflowBundle]]:
@@ -219,75 +317,63 @@ def seed_builtin_workflows(
             _ensure_catalog_storage(project)
         return False
 
-    rows = {bundle.slug: catalog_row(bundle) for bundle in bundles}
-    hash_fields = sorted(WorkflowCatalogEntry.model_fields)
-    expected_hash = stable_hash_for_rows(
-        list(rows.values()),
-        fields=hash_fields,
-        sort_field="slug",
-    )
-    if storage_ready and current_hashes.get(_UNIT) == expected_hash:
+    catalog = {bundle.slug: catalog_row(bundle) for bundle in bundles}
+    content = {
+        row["content_key"]: row for bundle in bundles for row in content_rows(bundle)
+    }
+    units = {
+        _CATALOG_UNIT: (
+            BUILTINS_WORKFLOWS_CONTEXT,
+            "slug",
+            catalog,
+            sorted(WorkflowCatalogEntry.model_fields),
+        ),
+        _CONTENT_UNIT: (
+            BUILTINS_WORKFLOWS_CONTENT_CONTEXT,
+            "content_key",
+            content,
+            sorted(WorkflowContentEntry.model_fields),
+        ),
+    }
+
+    expected_hashes = {
+        unit: stable_hash_for_rows(
+            list(rows.values()),
+            fields=hash_fields,
+            sort_field=key_field,
+        )
+        for unit, (_, key_field, rows, hash_fields) in units.items()
+    }
+    stale_units = {
+        unit
+        for unit, expected in expected_hashes.items()
+        if current_hashes.get(unit) != expected
+    }
+    if storage_ready and not stale_units:
         logger.debug("Workflow catalogue unchanged; skipping seed")
         return False
 
     _ensure_catalog_storage(project)
 
-    live_logs = unisdk.get_logs(
-        project=project,
-        context=BUILTINS_WORKFLOWS_CONTEXT,
-        limit=1000,
-    )
-    live = {
-        str((lg.entries or {}).get("slug")): lg
-        for lg in live_logs
-        if (lg.entries or {}).get("slug")
-    }
-
-    inserts = [payload for slug, payload in rows.items() if slug not in live]
-    if inserts:
-        unity_create_logs(
-            context=BUILTINS_WORKFLOWS_CONTEXT,
+    for unit in sorted(stale_units):
+        context, key_field, rows, _ = units[unit]
+        _reconcile_rows(
             project=project,
-            entries=inserts,
-            stamp_authoring=True,
-            batched=True,
+            context=context,
+            rows=rows,
+            key_field=key_field,
         )
 
-    for slug, payload in rows.items():
-        existing = live.get(slug)
-        if existing is None:
-            continue
-        current = {key: (existing.entries or {}).get(key) for key in payload}
-        if current == payload:
-            continue
-        unisdk.update_logs(
-            project=project,
-            context=BUILTINS_WORKFLOWS_CONTEXT,
-            logs=[existing.id],
-            entries=payload,
-            overwrite=True,
-        )
-
-    stale = [lg.id for slug, lg in live.items() if slug not in rows]
-    if stale:
-        unisdk.delete_logs(
-            project=project,
-            context=BUILTINS_WORKFLOWS_CONTEXT,
-            logs=stale,
-        )
-
-    hashes = dict(current_hashes)
-    hashes[_UNIT] = expected_hash
     write_seed_hashes(
         project,
-        hashes,
+        {**current_hashes, **expected_hashes},
         meta_context=BUILTINS_WORKFLOWS_META_CONTEXT,
         key=_HASH_MAP_KEY,
     )
     logger.info(
-        "Seeded workflow catalogue project=%s rows=%d removed=%d",
+        "Seeded workflow catalogue project=%s workflows=%d artifacts=%d",
         project,
-        len(rows),
-        len(stale),
+        len(catalog),
+        len(content),
     )
     return True

--- a/unify/workflow_manager/bundle.py
+++ b/unify/workflow_manager/bundle.py
@@ -170,6 +170,13 @@ class WorkflowBundle:
     name: str
     version: str = ""
     description: str = ""
+    """One line for a card or a list row."""
+
+    about: str = ""
+    """Long-form markdown for a reader deciding whether to install: what
+    the workflow does, when it runs, what arrives, and how its settings
+    shape it. The ``description`` is the card; this is the page."""
+
     category: str = ""
     """Catalogue grouping, e.g. ``"comms"`` / ``"growth"`` / ``"ops"`` /
     ``"build"``."""

--- a/unify/workflow_manager/catalog.py
+++ b/unify/workflow_manager/catalog.py
@@ -105,6 +105,7 @@ def load_bundle(path: Path) -> WorkflowBundle:
         name=name,
         version=str(manifest.get("version", "")),
         description=str(manifest.get("description", "")),
+        about=str(manifest.get("about", "")),
         category=str(manifest.get("category", "")),
         icon_id=str(manifest.get("icon_id", "")),
         surfaces=_collect_surfaces(path),

--- a/unify/workflow_manager/types/__init__.py
+++ b/unify/workflow_manager/types/__init__.py
@@ -1,10 +1,12 @@
 from .meta import WorkflowMeta
 from .catalog_entry import WorkflowCatalogEntry
+from .content_entry import WorkflowContentEntry
 from .workflow import UNASSIGNED, WorkflowInstallation
 
 __all__ = [
     "UNASSIGNED",
     "WorkflowCatalogEntry",
+    "WorkflowContentEntry",
     "WorkflowInstallation",
     "WorkflowMeta",
 ]

--- a/unify/workflow_manager/types/catalog_entry.py
+++ b/unify/workflow_manager/types/catalog_entry.py
@@ -40,6 +40,7 @@ class WorkflowCatalogEntry(AuthoredRow):
         "category": "c",
         "icon_id": "i",
         "description": "d",
+        "about": "a",
         "requirements": "rq",
         "capabilities": "cp",
         "params_schema": "ps",
@@ -65,6 +66,14 @@ class WorkflowCatalogEntry(AuthoredRow):
     description: str = Field(
         default="",
         description="One line describing what the workflow does.",
+    )
+    about: str = Field(
+        default="",
+        description=(
+            "Long-form markdown for a reader deciding whether to install: "
+            "what the workflow does, when it runs, what arrives, and how "
+            "its settings shape it."
+        ),
     )
     requirements: str = Field(
         default="[]",

--- a/unify/workflow_manager/types/content_entry.py
+++ b/unify/workflow_manager/types/content_entry.py
@@ -1,0 +1,82 @@
+"""Pydantic model for the ``Workflows/Content`` context.
+
+One row per artifact a workflow would plant, published beside the
+catalogue in the public-read Builtins project. The catalogue row's
+``sets`` names what a bundle sets up; these rows carry the artifacts
+themselves — a procedure's text, a claim's statement, a task's brief, a
+function's docstring — so a reading surface can show any of them before
+anything is installed, without waking an assistant.
+
+Like the catalogue, everything here is derived from the bundle on disk
+and rewritten wholesale by the seed; nothing is authored in this
+context, and installed assistants never read it — their planted rows are
+the live copies.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from pydantic import Field
+
+from unify.common.authorship import AuthoredRow
+
+
+class WorkflowContentEntry(AuthoredRow):
+    """One bundled artifact, as published for reading surfaces."""
+
+    SHORTHAND_MAP: ClassVar[dict[str, str]] = {
+        "content_key": "ck",
+        "slug": "s",
+        "surface": "sf",
+        "key": "k",
+        "name": "n",
+        "body": "b",
+        "schedule": "sc",
+        "meta": "m",
+    }
+
+    content_key: str = Field(
+        description=(
+            "The row's identity: '<slug>/<surface>/<key>', e.g. "
+            "'daily_briefing/guidance/daily_briefing/compose'."
+        ),
+    )
+    slug: str = Field(description="The workflow this artifact belongs to.")
+    surface: str = Field(
+        description=(
+            "The bundle surface the artifact plants into: 'guidance', "
+            "'knowledge', 'tasks' or 'functions'."
+        ),
+    )
+    key: str = Field(
+        description="The artifact's own key within its surface.",
+    )
+    name: str = Field(description="Human-readable artifact title.")
+    body: str = Field(
+        default="",
+        description=(
+            "The artifact's readable substance: a procedure's or claim's "
+            "content, a task's brief, a function's docstring."
+        ),
+    )
+    schedule: str = Field(
+        default="",
+        description="Plain-language cadence, for tasks that have one.",
+    )
+    meta: str = Field(
+        default="{}",
+        description=(
+            "JSON object of surface-specific extras a reader may render: "
+            "a claim's kind and topics, a task's tags, a function's "
+            "argspec."
+        ),
+    )
+
+    @classmethod
+    def shorthand_map(cls) -> dict[str, str]:
+        return dict(cls.SHORTHAND_MAP)
+
+    @classmethod
+    def shorthand_inverse_map(cls) -> dict[str, str]:
+        return {v: k for k, v in cls.SHORTHAND_MAP.items()}

--- a/unify/workflow_manager/workflow_manager.py
+++ b/unify/workflow_manager/workflow_manager.py
@@ -749,6 +749,7 @@ class WorkflowManager(BaseWorkflowManager):
                 {
                     "name": bundle.name,
                     "description": bundle.description,
+                    "about": bundle.about,
                     "version": bundle.version,
                     "category": bundle.category,
                     "icon_id": bundle.icon_id,


### PR DESCRIPTION
<!--
Thanks for contributing to Unify! Please fill out the sections below.
For trivial changes (typo fixes, comment-only edits) you can shorten this template — just keep the Summary.

PRs land on `staging`, not `main`. See CONTRIBUTING.md.
-->

## Summary

<!-- 1–3 sentences: what problem does this PR solve, and why is this the right approach? -->



## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes incorrect behavior)
- [ ] Feature (non-breaking change that adds functionality)
- [ ] Refactor (no behavior change)
- [ ] Breaking change (API or data-model change — Unify has zero-backward-compat policy, but please call it out)
- [ ] Test-only (no source changes)
- [ ] Docs / chore / CI

## Areas touched

<!-- Check all that apply. Helps reviewers route. -->

- [ ] Actor / CodeAct
- [ ] ConversationManager / slow brain
- [ ] A specific state manager (Contact / Knowledge / Task / Transcript / Guidance / Function / File / Image / Web / Secret / Blacklist / Data / Memory)
- [ ] Async tool loop (`unify/common/_async_tool/`)
- [ ] Event bus / observability
- [ ] Gateway / external comms
- [ ] Tests / test infra (`tests/`, `conftest.py`, `parallel_run.sh`)
- [ ] CI / build / packaging

## Test plan

<!--
How did you verify this? Paste the command(s) you ran and the result.

The default expectation is to run the relevant directory:
  tests/parallel_run.sh tests/<module>/

For infrastructure changes that are hard to reach via tests, a quick
verification script under tests/_verify_*.py is encouraged
(see .agents/rules/surgical-verification-before-tests.md).
-->

```
tests/parallel_run.sh tests/...
```

- [ ] All relevant tests pass locally
- [ ] If this is a bug fix, I added a regression test (or explained why one isn't feasible)

## Behavior / migration notes

<!--
- Did this change a public manager API, primitive, or event payload?
- Are there schema/context changes in Orchestra that need a migration?
- Any new env vars or config flags? (Update `.env.advanced.example`.)
- If yes to any of the above, describe upgrade steps.
-->

None.

## Checklist

- [ ] PR is targeted at `staging` (not `main`)
- [ ] Followed conventional commit style (`feat(scope):`, `fix(scope):`, `refactor(scope):`, `chore(scope):`, etc.)
- [ ] No `try/except` added defensively — only around specific, recoverable errors
- [ ] No "new" / "updated" / "TODO from chat" temporal comments (see `.agents/rules/no-temporal-comments.md`)
- [ ] No test-specific shortcuts in production code (see `.agents/rules/no-test-info-in-production-code.md`)
- [ ] Updated `AGENTS.md` / `ARCHITECTURE.md` if I changed architectural conventions
