### PR TITLE
Staging

### DIFF
--- a/scripts/seed_builtins_catalog.py
+++ b/scripts/seed_builtins_catalog.py
@@ -963,6 +963,7 @@ def main(argv: list[str] | None = None) -> int:
     from unify.function_manager.builtins_catalog import seed_builtin_primitives
     from unify.guidance_manager.builtins_catalog import seed_builtin_guidance
     from unify.integrations.builtins_catalog import seed_builtin_integrations
+    from unify.workflow_manager.builtins_catalog import seed_builtin_workflows
 
     project = builtins_project()
     logging.info(
@@ -972,6 +973,7 @@ def main(argv: list[str] | None = None) -> int:
     )
     primitives_changed = seed_builtin_primitives()
     guidance_changed = seed_builtin_guidance()
+    workflows_changed = seed_builtin_workflows()
     if args.skip_integrations:
         integrations_changed = False
     elif args.integration_bootstrap_manifest:
@@ -994,6 +996,7 @@ def main(argv: list[str] | None = None) -> int:
     for name, changed in (
         ("primitives", primitives_changed),
         ("guidance", guidance_changed),
+        ("workflows", workflows_changed),
         ("integrations", integrations_changed),
     ):
         state = "updated" if changed else "already up to date"

--- a/tests/comms/test_ms_teams_bot_route_resolution.py
+++ b/tests/comms/test_ms_teams_bot_route_resolution.py
@@ -64,9 +64,15 @@ def _stub_transport(monkeypatch) -> list[dict]:
     return sends
 
 
-def _stub_exchange(monkeypatch, metadata: dict | None) -> None:
-    """Stand in for the durable Transcripts exchange lookup."""
+def _stub_exchange(
+    monkeypatch,
+    metadata: dict | None,
+    *,
+    message_metadata: dict | None = None,
+) -> None:
+    """Stand in for the durable Transcripts lookups (messages + exchange)."""
     transcript_manager = SimpleNamespace(
+        latest_message_metadata_by_conversation=lambda key: message_metadata or {},
         resolve_exchange_id_by_metadata=lambda key, value: (
             91 if metadata is not None else None
         ),
@@ -138,6 +144,80 @@ async def test_resolves_from_durable_exchange_when_ids_omitted(monkeypatch):
     assert result == {"status": "ok"}
     assert sends[0]["tenant_id"] == "tenant-stored"
     assert sends[0]["conversation_id"] == "conv-stored"
+
+
+@pytest.mark.anyio
+async def test_resolves_from_message_history_when_exchange_predates_routing(
+    monkeypatch,
+):
+    """The reported failure: plenty of inbound Teams history, but an exchange
+    created before routing was captured. Messages carry it; the exchange
+    does not."""
+    comms = _make_comms(monkeypatch)
+    sends = _stub_transport(monkeypatch)
+    _stub_exchange(
+        monkeypatch,
+        {"conversation_key": "ms_teams_bot_message:dm:1"},
+        message_metadata={
+            "tenant_id": "tenant-from-message",
+            "conversation_id": "conv-from-message",
+        },
+    )
+    _stub_route(monkeypatch, None)
+
+    result = await comms.send_ms_teams_bot_message(
+        contact_id=TEST_CONTACT_ID,
+        content="the report is ready",
+    )
+
+    assert result == {"status": "ok"}
+    assert sends[0]["tenant_id"] == "tenant-from-message"
+    assert sends[0]["conversation_id"] == "conv-from-message"
+
+
+@pytest.mark.anyio
+async def test_message_history_outranks_stale_exchange(monkeypatch):
+    """Messages are the fresher record — an exchange keeps whatever was
+    written when the thread began."""
+    comms = _make_comms(monkeypatch)
+    sends = _stub_transport(monkeypatch)
+    _stub_exchange(
+        monkeypatch,
+        {"tenant_id": "tenant-old", "conversation_id": "conv-old"},
+        message_metadata={
+            "tenant_id": "tenant-new",
+            "conversation_id": "conv-new",
+        },
+    )
+    _stub_route(monkeypatch, None)
+
+    await comms.send_ms_teams_bot_message(
+        contact_id=TEST_CONTACT_ID,
+        content="ping",
+    )
+
+    assert sends[0]["conversation_id"] == "conv-new"
+
+
+@pytest.mark.anyio
+async def test_partial_message_metadata_falls_through_to_exchange(monkeypatch):
+    """Half a routing pair is unusable — keep looking rather than fail."""
+    comms = _make_comms(monkeypatch)
+    sends = _stub_transport(monkeypatch)
+    _stub_exchange(
+        monkeypatch,
+        {"tenant_id": "tenant-exchange", "conversation_id": "conv-exchange"},
+        message_metadata={"conversation_id": "conv-orphan"},
+    )
+    _stub_route(monkeypatch, None)
+
+    await comms.send_ms_teams_bot_message(
+        contact_id=TEST_CONTACT_ID,
+        content="ping",
+    )
+
+    assert sends[0]["tenant_id"] == "tenant-exchange"
+    assert sends[0]["conversation_id"] == "conv-exchange"
 
 
 @pytest.mark.anyio

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -526,12 +526,17 @@ def pytest_sessionstart(session):
     from unify.function_manager.builtins_catalog import seed_builtin_primitives
     from unify.guidance_manager.builtins_catalog import seed_builtin_guidance
     from unify.integrations.builtins_catalog import seed_builtin_integrations
+    from unify.workflow_manager.builtins_catalog import seed_builtin_workflows
 
     with _cross_process_column_lock(builtins_project(), "builtins_seed"):
         with builtins_seed_key_override():
             seed_builtin_primitives()
             seed_builtin_guidance()
             seed_builtin_integrations()
+            # Workflows: storage only (bundles=None resolves the sibling
+            # unify-deploy tree when present; tests that need rows seed
+            # explicit bundles themselves).
+            seed_builtin_workflows(bundles=[])
 
     # ------------------------------------------------------------------
     #  Configure EventBus publishing (disabled by default in tests)

--- a/tests/conversation_manager/core/test_exchange_routing_backfill.py
+++ b/tests/conversation_manager/core/test_exchange_routing_backfill.py
@@ -1,0 +1,131 @@
+"""Long-lived conversations repair their own routing identity.
+
+Exchange metadata is written once, when the exchange is created, and a
+Teams or Slack thread outlives that moment by months. A conversation that
+began before routing identifiers were recorded would otherwise never
+acquire them, leaving outbound replies unable to find it for as long as
+the thread lives — no amount of new traffic would help. The backfill
+closes that gap from the next message in either direction.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from unify.conversation_manager.cm_types import Medium
+from unify.conversation_manager.domains import managers_utils
+
+
+@pytest.fixture(autouse=True)
+def _clear_backfill_cache():
+    managers_utils._routing_backfilled_exchanges.clear()
+    yield
+    managers_utils._routing_backfilled_exchanges.clear()
+
+
+def _event(**overrides):
+    base = {
+        "tenant_id": "tenant-a",
+        "conversation_id": "conv-a",
+        "channel_id": "",
+        "team_id": "",
+        "thread_id": "",
+        "guild_id": "",
+        "group_id": "",
+        "thread_ts": "",
+        "event_ts": "",
+    }
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def _cm(stored: dict):
+    updates: list[tuple[int, dict]] = []
+    transcript_manager = SimpleNamespace(
+        get_exchange_metadata=lambda exchange_id: SimpleNamespace(metadata=stored),
+        update_exchange_metadata=lambda exchange_id, metadata: updates.append(
+            (exchange_id, metadata),
+        ),
+    )
+    return SimpleNamespace(transcript_manager=transcript_manager), updates
+
+
+def test_backfills_routing_onto_an_exchange_that_lacks_it():
+    cm, updates = _cm({"conversation_key": "ms_teams_bot_message:dm:1"})
+
+    managers_utils._backfill_exchange_routing(
+        cm,
+        exchange_id=77,
+        event=_event(),
+        medium=Medium.MS_TEAMS_BOT_MESSAGE,
+        conversation_key="ms_teams_bot_message:dm:1",
+    )
+
+    assert updates
+    exchange_id, written = updates[0]
+    assert exchange_id == 77
+    assert written["tenant_id"] == "tenant-a"
+    assert written["conversation_id"] == "conv-a"
+
+
+def test_leaves_an_already_complete_exchange_alone():
+    cm, updates = _cm(
+        {
+            "conversation_key": "ms_teams_bot_message:dm:1",
+            "tenant_id": "tenant-a",
+            "conversation_id": "conv-a",
+        },
+    )
+
+    managers_utils._backfill_exchange_routing(
+        cm,
+        exchange_id=77,
+        event=_event(),
+        medium=Medium.MS_TEAMS_BOT_MESSAGE,
+        conversation_key="ms_teams_bot_message:dm:1",
+    )
+
+    assert updates == []
+
+
+def test_repairs_once_per_exchange_per_process():
+    """Every message in a busy thread would otherwise re-read the row."""
+    cm, updates = _cm({})
+
+    for _ in range(3):
+        managers_utils._backfill_exchange_routing(
+            cm,
+            exchange_id=77,
+            event=_event(),
+            medium=Medium.MS_TEAMS_BOT_MESSAGE,
+            conversation_key="ms_teams_bot_message:dm:1",
+        )
+
+    assert len(updates) == 1
+
+
+def test_an_unreadable_exchange_does_not_break_logging():
+    """A repair is opportunistic; losing it must not cost the message."""
+
+    def _raise(exchange_id):
+        raise RuntimeError("exchange row is gone")
+
+    updates: list[tuple[int, dict]] = []
+    cm = SimpleNamespace(
+        transcript_manager=SimpleNamespace(
+            get_exchange_metadata=_raise,
+            update_exchange_metadata=lambda exchange_id, metadata: updates.append(
+                (exchange_id, metadata),
+            ),
+        ),
+    )
+
+    managers_utils._backfill_exchange_routing(
+        cm,
+        exchange_id=77,
+        event=_event(),
+        medium=Medium.MS_TEAMS_BOT_MESSAGE,
+        conversation_key="ms_teams_bot_message:dm:1",
+    )
+
+    assert updates == []

--- a/tests/workflow_manager/test_catalog.py
+++ b/tests/workflow_manager/test_catalog.py
@@ -194,9 +194,8 @@ def test_human_schedule_reads_as_plain_language():
     """Reading surfaces show a workflow's cadence before it is installed,
     and that phrasing is the part a user actually weighs. Derived once
     here so every surface says it identically."""
-    from unify.workflow_manager.workflow_manager import WorkflowManager
+    from unify.workflow_manager.builtins_catalog import human_schedule as schedule
 
-    schedule = WorkflowManager._human_schedule
     weekdays = {
         "repeat": [
             {
@@ -233,10 +232,10 @@ def test_human_schedule_reads_as_plain_language():
 
 def test_bundle_sets_names_what_each_surface_receives(tmp_path: Path):
     """The 'what this installs' list a reader shows before installing."""
-    from unify.workflow_manager.workflow_manager import WorkflowManager
+    from unify.workflow_manager.builtins_catalog import bundle_sets
 
     bundle = load_bundle(_write_bundle(tmp_path))
-    sets = WorkflowManager._bundle_sets(bundle)
+    sets = bundle_sets(bundle)
 
     assert sets["guidance"] == [{"name": "Triage"}]
     assert sets["tasks"] == [{"name": "Morning run", "schedule": "Every day"}]

--- a/tests/workflow_manager/test_catalog.py
+++ b/tests/workflow_manager/test_catalog.py
@@ -24,6 +24,10 @@ version: "1.2.0"
 category: comms
 icon_id: briefing
 description: Your calendar and the unread that matters, before stand-up.
+about: |
+  Every weekday morning the briefing reads your calendar and inbox.
+
+  It arrives as one chat message before stand-up.
 requirements:
   - slug: gmail
     name: Gmail
@@ -78,6 +82,8 @@ def test_load_bundle_reads_identity_and_content(tmp_path: Path):
     assert bundle.version == "1.2.0"
     assert bundle.category == "comms"
     assert bundle.icon_id == "briefing"
+    assert bundle.about.startswith("Every weekday morning")
+    assert "\n\n" in bundle.about
     assert bundle.capabilities == ("filesystem",)
     assert bundle.params_schema["mailbox"]["required"] is True
 
@@ -239,3 +245,31 @@ def test_bundle_sets_names_what_each_surface_receives(tmp_path: Path):
 
     assert sets["guidance"] == [{"name": "Triage"}]
     assert sets["tasks"] == [{"name": "Morning run", "schedule": "Every day"}]
+
+
+def test_content_rows_carry_each_artifact_whole(tmp_path: Path):
+    """The listing names what a workflow sets up; the content rows beside
+    it carry the artifacts' substance, so a reader can open any of them
+    before anything is installed."""
+    from unify.workflow_manager.builtins_catalog import content_rows
+
+    bundle = load_bundle(_write_bundle(tmp_path))
+    rows = {row["content_key"]: row for row in content_rows(bundle)}
+
+    assert set(rows) == {
+        "daily_briefing/guidance/wf/triage",
+        "daily_briefing/tasks/wf/morning",
+    }
+
+    triage = rows["daily_briefing/guidance/wf/triage"]
+    assert triage["slug"] == "daily_briefing"
+    assert triage["surface"] == "guidance"
+    assert triage["key"] == "wf/triage"
+    assert triage["name"] == "Triage"
+    assert triage["body"] == "Oldest first."
+    assert triage["schedule"] == ""
+
+    morning = rows["daily_briefing/tasks/wf/morning"]
+    assert morning["name"] == "Morning run"
+    assert morning["body"] == "The recurring job."
+    assert morning["schedule"] == "Every day"

--- a/tests/workflow_manager/test_daily_briefing_acceptance.py
+++ b/tests/workflow_manager/test_daily_briefing_acceptance.py
@@ -32,9 +32,12 @@ def _bundle_dir() -> Path:
     configured = (os.environ.get("UNITY_WORKFLOWS_DIR") or "").strip()
     if configured:
         return Path(configured) / SLUG
-    return (
-        Path.home() / "unify-deploy/unify_deploy/assistant_deployments/workflows" / SLUG
-    )
+    # Resolve the sibling checkout from this repo's location, never from
+    # Path.home(): the test harness points HOME at a scratch dir, so a
+    # home-relative probe skips this test on every machine that uses the
+    # runner — silently, forever.
+    siblings = Path(__file__).resolve().parents[2].parent
+    return siblings / "unify-deploy/unify_deploy/assistant_deployments/workflows" / SLUG
 
 
 pytestmark = pytest.mark.skipif(

--- a/tests/workflow_manager/test_install_uninstall_live.py
+++ b/tests/workflow_manager/test_install_uninstall_live.py
@@ -412,14 +412,17 @@ async def test_catalog_seeds_the_builtins_shelf_and_short_circuits(
     """The shelf a reading surface renders lives in the public-read
     Builtins project — platform data, one copy for everyone, exactly like
     the integrations app catalogue — while everything per-assistant stays
-    in the assistant's own contexts. The seed must also be cheap on every
-    run between deploys: an unchanged catalogue reads one meta row and
-    writes nothing.
+    in the assistant's own contexts. The listing rows carry names; the
+    content rows beside them carry the artifacts' substance, so a reader
+    can open a procedure or a task brief before anything is installed.
+    The seed must also be cheap on every run between deploys: an
+    unchanged catalogue reads one meta row and writes nothing.
     """
     import json as _json
 
     from unify.common.builtins import builtins_project, builtins_seed_key_override
     from unify.workflow_manager.builtins_catalog import (
+        BUILTINS_WORKFLOWS_CONTENT_CONTEXT,
         BUILTINS_WORKFLOWS_CONTEXT,
         seed_builtin_workflows,
     )
@@ -436,6 +439,17 @@ async def test_catalog_seeds_the_builtins_shelf_and_short_circuits(
             str((lg.entries or {}).get("slug")): dict(lg.entries or {}) for lg in logs
         }
 
+    def artifacts():
+        logs = unisdk.get_logs(
+            project=project,
+            context=BUILTINS_WORKFLOWS_CONTENT_CONTEXT,
+            limit=100,
+        )
+        return {
+            str((lg.entries or {}).get("content_key")): dict(lg.entries or {})
+            for lg in logs
+        }
+
     with builtins_seed_key_override():
         assert seed_builtin_workflows(bundles=[bundle]) is True
 
@@ -447,13 +461,28 @@ async def test_catalog_seeds_the_builtins_shelf_and_short_circuits(
             {"name": "Workflow morning run", "schedule": "Every day"},
         ]
 
+        content = artifacts()
+        assert set(content) == {
+            f"{SLUG}/guidance/wf/triage",
+            f"{SLUG}/guidance/wf/tone",
+            f"{SLUG}/tasks/wf/morning",
+        }
+        triage = content[f"{SLUG}/guidance/wf/triage"]
+        assert triage["name"] == "Workflow triage procedure"
+        assert triage["body"] == "Read the inbox oldest-first."
+        morning = content[f"{SLUG}/tasks/wf/morning"]
+        assert morning["body"] == "The recurring job this workflow exists for."
+        assert morning["schedule"] == "Every day"
+
         # Unchanged catalogue: the hash short-circuits, nothing is written.
         assert seed_builtin_workflows(bundles=[bundle]) is False
 
-        # A bundle leaving the curated tree leaves the shelf.
+        # A bundle leaving the curated tree leaves the shelf whole —
+        # listing and artifacts both.
         other = WorkflowBundle(slug="other_demo", name="Other demo", surfaces={})
         assert seed_builtin_workflows(bundles=[other]) is True
         assert set(shelf()) == {"other_demo"}
+        assert artifacts() == {}
 
         # The harness re-seeds an empty catalogue for the next session.
         seed_builtin_workflows(bundles=[])

--- a/tests/workflow_manager/test_install_uninstall_live.py
+++ b/tests/workflow_manager/test_install_uninstall_live.py
@@ -405,57 +405,55 @@ async def test_bootstrap_fills_the_shelf_and_reconciles_installed(
 
 @_handle_project
 @pytest.mark.asyncio
-async def test_catalog_publishes_for_reading_surfaces_and_short_circuits(
+async def test_catalog_seeds_the_builtins_shelf_and_short_circuits(
     live_managers,
     bundle,
 ):
-    """The shelf a reading surface renders without waking the assistant.
-
-    A hosted assistant is usually asleep when someone opens Console, so
-    the catalogue is mirrored into rows rather than served from the
-    assistant's memory. The publish must also be cheap on every boot
-    between deploys, which is almost all of them: an unchanged catalogue
-    costs one meta read and writes nothing.
+    """The shelf a reading surface renders lives in the public-read
+    Builtins project — platform data, one copy for everyone, exactly like
+    the integrations app catalogue — while everything per-assistant stays
+    in the assistant's own contexts. The seed must also be cheap on every
+    run between deploys: an unchanged catalogue reads one meta row and
+    writes nothing.
     """
     import json as _json
 
-    gm, ts, wm = live_managers
-    wm.register_bundle(bundle)
-
-    first = wm.publish_catalog()
-    assert first["published"] == [SLUG]
-    assert first["removed"] == []
-
-    rows = unisdk.get_logs(context=wm._catalog_ctx)
-    (row,) = [dict(lg.entries or {}) for lg in rows]
-    assert row["slug"] == SLUG
-    assert row["name"] == "Live demo workflow"
-    assert _json.loads(row["surfaces"]) == ["guidance", "tasks"]
-
-    # "What this installs", derived so a reader can show it pre-install.
-    sets = _json.loads(row["sets"])
-    assert sets["guidance"] == [{"name": "Workflow triage procedure"}] or (
-        {"name": "Workflow tone procedure"} in sets["guidance"]
+    from unify.common.builtins import builtins_project, builtins_seed_key_override
+    from unify.workflow_manager.builtins_catalog import (
+        BUILTINS_WORKFLOWS_CONTEXT,
+        seed_builtin_workflows,
     )
-    assert sets["tasks"] == [
-        {"name": "Workflow morning run", "schedule": "Every day"},
-    ]
 
-    # Unchanged catalogue: no writes at all.
-    again = wm.publish_catalog()
-    assert again == {"unchanged": True, "published": [], "removed": []}
+    project = builtins_project()
 
-    # A bundle leaving the catalogue leaves the shelf too.
-    wm._catalogue.clear()
-    wm.register_bundle(
-        WorkflowBundle(slug="other_demo", name="Other demo", surfaces={}),
-    )
-    third = wm.publish_catalog()
-    assert third["published"] == ["other_demo"]
-    assert third["removed"] == [SLUG]
+    def shelf():
+        logs = unisdk.get_logs(
+            project=project,
+            context=BUILTINS_WORKFLOWS_CONTEXT,
+            limit=100,
+        )
+        return {
+            str((lg.entries or {}).get("slug")): dict(lg.entries or {}) for lg in logs
+        }
 
-    slugs = {
-        str((lg.entries or {}).get("slug"))
-        for lg in unisdk.get_logs(context=wm._catalog_ctx)
-    }
-    assert slugs == {"other_demo"}
+    with builtins_seed_key_override():
+        assert seed_builtin_workflows(bundles=[bundle]) is True
+
+        row = shelf()[SLUG]
+        assert row["name"] == "Live demo workflow"
+        assert _json.loads(row["surfaces"]) == ["guidance", "tasks"]
+        sets = _json.loads(row["sets"])
+        assert sets["tasks"] == [
+            {"name": "Workflow morning run", "schedule": "Every day"},
+        ]
+
+        # Unchanged catalogue: the hash short-circuits, nothing is written.
+        assert seed_builtin_workflows(bundles=[bundle]) is False
+
+        # A bundle leaving the curated tree leaves the shelf.
+        other = WorkflowBundle(slug="other_demo", name="Other demo", surfaces={})
+        assert seed_builtin_workflows(bundles=[other]) is True
+        assert set(shelf()) == {"other_demo"}
+
+        # The harness re-seeds an empty catalogue for the next session.
+        seed_builtin_workflows(bundles=[])

--- a/unify/canvas_manager/ops/review_ops.py
+++ b/unify/canvas_manager/ops/review_ops.py
@@ -36,6 +36,7 @@ import socketserver
 import subprocess
 import tempfile
 import threading
+import time
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -288,6 +289,36 @@ def _parent_html(
 </script></body>"""
 
 
+def _wait_for_theme(page: Any, child: Any, *, dark: bool) -> None:
+    """Block until the child frame has applied the theme it was sent.
+
+    Polled from here rather than with ``wait_for_function`` because the frame
+    is the real thing: opaque origin, ``script-src <origin> blob: <hash>``,
+    and deliberately no ``unsafe-eval`` — the runtime imports bundles as
+    blobs precisely so eval is never needed. Playwright's in-page predicate
+    poller evals the predicate string in that document, which the CSP
+    refuses, so the whole render reported "did not render" with a CSP error
+    the moment the gate began rendering for real.
+
+    Reading the class over CDP one tick at a time is CSP-exempt and asserts
+    the same condition. Relaxing the frame's CSP to suit the harness would
+    trade a real security property for a test convenience.
+    """
+    deadline = time.monotonic() + _RENDER_TIMEOUT_MS / 1000
+    while True:
+        applied = bool(
+            child.evaluate("document.documentElement.classList.contains('dark')"),
+        )
+        if applied is dark:
+            return
+        if time.monotonic() >= deadline:
+            raise TimeoutError(
+                f"child frame did not apply the {'dark' if dark else 'light'} "
+                f"theme within {_RENDER_TIMEOUT_MS}ms",
+            )
+        page.wait_for_timeout(50)
+
+
 def _render(
     *,
     host: Path,
@@ -376,11 +407,7 @@ def _render(
                     page.evaluate("theme => window.__setTheme(theme)", theme)
                     # Waiting on the class the child actually applied keeps this
                     # deterministic; a fixed delay would race a slow message.
-                    child.wait_for_function(
-                        "dark => document.documentElement.classList.contains('dark') === dark",
-                        arg=theme == "dark",
-                        timeout=_RENDER_TIMEOUT_MS,
-                    )
+                    _wait_for_theme(page, child, dark=theme == "dark")
                     shot = out_dir / f"canvas-{token}-{theme}.png"
                     element.screenshot(path=str(shot))
                     shots.append(str(shot))

--- a/unify/comms/capabilities.py
+++ b/unify/comms/capabilities.py
@@ -50,6 +50,14 @@ def _channel_lines() -> list[str]:
             "another channel.",
         )
     lines.append("- Unify platform messages: `send_unify_message`.")
+    lines.append(
+        "Send by calling the tool. Do not try to confirm a channel will work "
+        "by searching transcripts, logs or contact records first — routing "
+        "identifiers are resolved inside the send tools, so a search that "
+        "comes up empty is not evidence the send would fail, and refusing on "
+        "it drops a message that would have gone through. The tool's return "
+        "value is the source of truth for whether anything was delivered.",
+    )
     return lines
 
 

--- a/unify/comms/primitives.py
+++ b/unify/comms/primitives.py
@@ -742,12 +742,17 @@ class CommsPrimitives:
         return None
 
     def _stored_ms_teams_bot_route(self, contact_id: int) -> tuple[str, str] | None:
-        """Teams routing recovered from the durable conversation exchange.
+        """Teams routing recovered from durable transcript history.
 
         The live renderer surfaces these ids on an inbound message, which is
         the only way they normally reach a reply. A headless run has no
-        rendered thread, so it reads them back off the Transcripts exchange
-        the conversation is grouped under instead.
+        rendered thread, so it reads them back out of what was written down.
+
+        Messages first, exchange second. Exchange metadata is written once,
+        when the conversation's exchange is created, so a thread that began
+        before routing was recorded has none — which is the common case for
+        any conversation older than the feature. Per-message routing has no
+        such gap.
         """
         key = conversation_keys.conversation_key(
             Medium.MS_TEAMS_BOT_MESSAGE,
@@ -756,18 +761,29 @@ class CommsPrimitives:
         if not key:
             return None
         transcript_manager = ManagerRegistry.get_transcript_manager()
+
+        sources = [
+            lambda: transcript_manager.latest_message_metadata_by_conversation(key),
+            lambda: self._exchange_metadata_for_conversation(transcript_manager, key),
+        ]
+        for source in sources:
+            metadata = source() or {}
+            tenant_id = str(metadata.get("tenant_id") or "")
+            conversation_id = str(metadata.get("conversation_id") or "")
+            if tenant_id and conversation_id:
+                return tenant_id, conversation_id
+        return None
+
+    @staticmethod
+    def _exchange_metadata_for_conversation(transcript_manager, key: str) -> dict:
+        """Exchange metadata for a conversation key, or ``{}`` if absent."""
         exchange_id = transcript_manager.resolve_exchange_id_by_metadata(
             conversation_keys.CONVERSATION_KEY_FIELD,
             key,
         )
         if exchange_id is None:
-            return None
-        metadata = transcript_manager.get_exchange_metadata(exchange_id).metadata or {}
-        tenant_id = str(metadata.get("tenant_id") or "")
-        conversation_id = str(metadata.get("conversation_id") or "")
-        if tenant_id and conversation_id:
-            return tenant_id, conversation_id
-        return None
+            return {}
+        return transcript_manager.get_exchange_metadata(exchange_id).metadata or {}
 
     async def _routed_ms_teams_bot_conversation(
         self,
@@ -1993,6 +2009,15 @@ class CommsPrimitives:
         shared bot token are resolved server-side; the assistant never handles
         bot credentials. The send pins the conversation to this assistant so
         later replies route back to it.
+
+        **Do not verify the conversation before calling this.** Searching
+        transcripts, logs or contact records for a ``tenant_id`` /
+        ``conversation_id`` pair does not work and will make you refuse a
+        send that would have succeeded: the identifiers live in places those
+        searches do not reach, and resolving them is this tool's job. Call it
+        with ``contact_id`` and the message, and treat what it returns as the
+        answer — a success means the message was delivered, and only an error
+        means it was not.
 
         The Teams bot **cannot open a conversation** — it can only speak
         inside a chat or thread the person has already messaged it in. So if

--- a/unify/conversation_manager/domains/managers_utils.py
+++ b/unify/conversation_manager/domains/managers_utils.py
@@ -1187,6 +1187,55 @@ def _conversation_exchange_metadata(
     return metadata
 
 
+# Exchanges already checked for missing routing this process. The backfill is
+# a no-op after the first repair, so re-reading the row on every subsequent
+# message in the conversation would be pure overhead.
+_routing_backfilled_exchanges: set[int] = set()
+
+
+def _backfill_exchange_routing(
+    cm: "ConversationManager",
+    *,
+    exchange_id: int,
+    event: "Event",
+    medium: "Medium",
+    conversation_key: str,
+) -> None:
+    """Add missing routing identity to an exchange that predates its capture.
+
+    Exchange metadata is written once, when the exchange is created, and
+    conversations are long-lived: a thread started before routing was
+    recorded would never acquire it, leaving outbound replies unable to
+    find the conversation for as long as the thread lives. Repair it from
+    the first message that arrives carrying the identifiers, in either
+    direction, so the gap closes on its own rather than needing a backfill.
+    """
+    if exchange_id in _routing_backfilled_exchanges:
+        return
+    _routing_backfilled_exchanges.add(exchange_id)
+
+    desired = _conversation_exchange_metadata(event, medium, conversation_key)
+    routing = {k: v for k, v in desired.items() if k != "medium"}
+    try:
+        stored = cm.transcript_manager.get_exchange_metadata(exchange_id).metadata or {}
+    except Exception:  # noqa: BLE001 — a missing/unreadable row is not fatal
+        LOGGER.debug(
+            f"{ICONS['managers_worker']} [ManagersWorker] Could not read exchange "
+            f"{exchange_id} metadata for routing backfill.",
+        )
+        return
+
+    missing = {k: v for k, v in routing.items() if not stored.get(k)}
+    if not missing:
+        return
+    # Merges rather than replaces, so only the gap needs sending.
+    cm.transcript_manager.update_exchange_metadata(exchange_id, missing)
+    LOGGER.debug(
+        f"{ICONS['managers_worker']} [ManagersWorker] Backfilled routing "
+        f"{sorted(missing)} onto exchange {exchange_id}.",
+    )
+
+
 def _recover_exchange_id(
     cm: "ConversationManager",
     medium: "Medium",
@@ -1462,23 +1511,32 @@ async def log_message(
     # channels (group channels, email) reuse for the whole thread — both with no
     # inactivity window. Durable mediums (DMs and email) additionally recover their
     # exchange from Exchanges metadata on a cold (post-restart) cache.
+    # Derived whenever the medium groups, not only when the exchange is
+    # unknown: it is also stamped onto the message row as the join key that
+    # makes routing recoverable per message, and an already-resolved exchange
+    # is the common case.
     conversation_key: str | None = None
-    if exchange_id == UNASSIGNED and (
-        medium in _DM_MEDIA or medium in _PROVIDER_THREAD_MEDIA
-    ):
+    if medium in _DM_MEDIA or medium in _PROVIDER_THREAD_MEDIA:
         conversation_key = _derive_conversation_key(
             event,
             medium,
             contact_id,
         )
-        if conversation_key is not None:
-            cached = cm._conversation_exchange_ids.get(conversation_key)
-            if cached is not None:
-                exchange_id = cached
-            elif medium in _DURABLE_MEDIA:
-                recovered = _recover_exchange_id(cm, medium, conversation_key)
-                if recovered is not None:
-                    exchange_id = recovered
+    # An exchange handed to us by a live call session or carried on the event
+    # is not this conversation's own thread, so it must neither be bound to
+    # the conversation key nor repaired as though it were.
+    exchange_preset = exchange_id != UNASSIGNED
+    exchange_grouped = False
+    if not exchange_preset and conversation_key is not None:
+        cached = cm._conversation_exchange_ids.get(conversation_key)
+        if cached is not None:
+            exchange_id = cached
+            exchange_grouped = True
+        elif medium in _DURABLE_MEDIA:
+            recovered = _recover_exchange_id(cm, medium, conversation_key)
+            if recovered is not None:
+                exchange_id = recovered
+                exchange_grouped = True
 
     # A spoken line's audible start, when the voice agent observed one. The
     # event's own timestamp marks the commit that follows the line, so using it
@@ -1541,6 +1599,38 @@ async def log_message(
                     metadata["team_id"] = event.team_id
                 if event.group_id is not None:
                     metadata["group_id"] = event.group_id
+                metadata = metadata or None
+            elif isinstance(
+                event,
+                (
+                    MsTeamsBotMessageReceived,
+                    MsTeamsBotMessageSent,
+                    MsTeamsBotChannelMessageReceived,
+                    MsTeamsBotChannelMessageSent,
+                ),
+            ):
+                # An outbound Teams bot reply routes on
+                # (tenant_id, conversation_id), and the Bot Framework will not
+                # let us open a conversation to recover them. Recording them on
+                # every message — not only in the exchange metadata written
+                # once at exchange creation — is what lets a later run that saw
+                # no inbound activity still reply into the same conversation.
+                # ``conversation_key`` is stored alongside as the join key, so
+                # the lookup is an exact server-side match rather than a scan.
+                metadata = {}
+                for attr in (
+                    "tenant_id",
+                    "conversation_id",
+                    "channel_id",
+                    "team_id",
+                    "thread_id",
+                ):
+                    if value := getattr(event, attr, "") or "":
+                        metadata[attr] = value
+                if metadata and conversation_key is not None:
+                    metadata[conversation_keys.CONVERSATION_KEY_FIELD] = (
+                        conversation_key
+                    )
                 metadata = metadata or None
             elif isinstance(
                 event,
@@ -1672,6 +1762,14 @@ async def log_message(
                         f"{ICONS['managers_worker']} [ManagersWorker] Cached pre-hire exchange_id: {exchange_id}",
                     )
             else:
+                if exchange_grouped and conversation_key is not None:
+                    _backfill_exchange_routing(
+                        cm,
+                        exchange_id=exchange_id,
+                        event=event,
+                        medium=medium,
+                        conversation_key=conversation_key,
+                    )
                 msg_data = {
                     "medium": medium,
                     "sender_id": sender_id,
@@ -1753,7 +1851,7 @@ async def log_message(
         ):
             cm.call_manager.teams_meet_exchange_id = exchange_id
             cm.call_manager.call_exchange_destination = primary_destination
-        elif conversation_key is not None:
+        elif conversation_key is not None and not exchange_preset:
             # Record the exchange so the next message in this conversation reuses it.
             cm._conversation_exchange_ids[conversation_key] = exchange_id
 

--- a/unify/transcript_manager/transcript_manager.py
+++ b/unify/transcript_manager/transcript_manager.py
@@ -1264,6 +1264,41 @@ class TranscriptManager(BaseTranscriptManager):
         except (TypeError, ValueError):
             return None
 
+    def latest_message_metadata_by_conversation(
+        self,
+        conversation_key: str,
+    ) -> dict:
+        """Metadata of the newest message stored under a conversation key.
+
+        Routing identifiers are recorded on every message of a grouped
+        conversation, not only on the exchange row written when the thread
+        began. Reading the newest message is therefore the resilient way to
+        recover them: it survives an exchange created before routing was
+        captured, and it reflects the most recent values if a provider ever
+        re-keys the conversation.
+
+        Returns ``{}`` when nothing matches, which callers should read as
+        "no conversation on record" rather than as an error.
+        """
+        needle = str(conversation_key or "").strip()
+        if not needle:
+            return {}
+        escaped = needle.replace("\\", "\\\\").replace('"', '\\"')
+        for context in self._read_transcript_contexts():
+            rows = unisdk.get_logs(
+                context=context,
+                filter=f'metadata.conversation_key == "{escaped}"',
+                sorting={"timestamp": "descending"},
+                limit=1,
+            )
+            if not rows:
+                continue
+            entries = getattr(rows[0], "entries", {}) or {}
+            metadata = entries.get("metadata") or {}
+            if isinstance(metadata, dict) and metadata:
+                return dict(metadata)
+        return {}
+
     def resolve_message_id_by_chat_message_id(
         self,
         chat_message_id: int,

--- a/unify/workflow_manager/__init__.py
+++ b/unify/workflow_manager/__init__.py
@@ -23,6 +23,7 @@ __all__ = [
     "WorkflowManager",
     "WorkflowRequirement",
     "bootstrap_workflow_catalog",
+    "seed_builtin_workflows",
     "load_bundle",
     "load_catalog",
     "register_default_surfaces",
@@ -38,6 +39,7 @@ _lazy_map = {
     "WorkflowBundle": "unify.workflow_manager.bundle",
     "WorkflowRequirement": "unify.workflow_manager.bundle",
     "bootstrap_workflow_catalog": "unify.workflow_manager.catalog",
+    "seed_builtin_workflows": "unify.workflow_manager.builtins_catalog",
     "load_bundle": "unify.workflow_manager.catalog",
     "load_catalog": "unify.workflow_manager.catalog",
     "schedule_bootstrap_workflow_catalog": "unify.workflow_manager.catalog",
@@ -71,6 +73,7 @@ if TYPE_CHECKING:
         WorkflowBundle,
         WorkflowRequirement,
     )
+    from .builtins_catalog import seed_builtin_workflows
     from .catalog import (
         bootstrap_workflow_catalog,
         load_bundle,

--- a/unify/workflow_manager/__init__.py
+++ b/unify/workflow_manager/__init__.py
@@ -19,6 +19,7 @@ __all__ = [
     "UnscopedSurfaceError",
     "WorkflowBundle",
     "WorkflowCatalogEntry",
+    "WorkflowContentEntry",
     "WorkflowInstallation",
     "WorkflowManager",
     "WorkflowRequirement",
@@ -47,6 +48,7 @@ _lazy_map = {
     "SCOPED_SURFACES": "unify.workflow_manager.surfaces",
     "register_default_surfaces": "unify.workflow_manager.surfaces",
     "WorkflowCatalogEntry": "unify.workflow_manager.types.catalog_entry",
+    "WorkflowContentEntry": "unify.workflow_manager.types.content_entry",
     "WorkflowInstallation": "unify.workflow_manager.types.workflow",
     "WorkflowManager": "unify.workflow_manager.workflow_manager",
 }
@@ -86,5 +88,6 @@ if TYPE_CHECKING:
         register_default_surfaces,
     )
     from .types.catalog_entry import WorkflowCatalogEntry
+    from .types.content_entry import WorkflowContentEntry
     from .types.workflow import WorkflowInstallation
     from .workflow_manager import WorkflowManager

--- a/unify/workflow_manager/builtins_catalog.py
+++ b/unify/workflow_manager/builtins_catalog.py
@@ -1,0 +1,293 @@
+"""Public-read Builtins catalogue for the workflow shelf.
+
+The shelf listing is platform data, not tenant data: one hand-curated
+collection, identical for every assistant, exactly like the integrations
+app catalogue. It lives as rows in the public-read Builtins project so a
+reading surface (Console's gallery) renders it without waking an
+assistant — a hosted assistant is an on-demand job and is usually asleep
+when someone opens Console.
+
+Everything per-assistant stays in each assistant's own contexts: the
+installation rows, params, requirement/connection state, and the planted
+content itself. Only the listing is global.
+
+Seeding runs in bootstrap/admin processes (the deploy seed script, the
+self-host install, the test harness) whose key owns the Builtins project;
+assistants never write here. It is hash-guarded, so repeated runs are
+cheap and idempotent — the same contract as the primitives, guidance and
+integrations catalogues beside it.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Optional
+
+import unisdk
+from unisdk.utils.http import RequestError
+
+from ..common.authorship import strip_authoring_assistant_id
+from ..common.builtins import (
+    builtins_project,
+    ensure_builtins_project,
+    read_seed_hashes,
+    write_seed_hashes,
+)
+from ..common.log_utils import create_logs as unity_create_logs
+from ..function_manager.hash_utils import stable_hash_for_rows
+from .bundle import WorkflowBundle
+from .types.catalog_entry import WorkflowCatalogEntry
+
+logger = logging.getLogger(__name__)
+
+BUILTINS_WORKFLOWS_CONTEXT = "Workflows/Catalog"
+BUILTINS_WORKFLOWS_META_CONTEXT = "Workflows/Meta"
+_HASH_MAP_KEY = "workflows_catalog_hash_by_unit"
+_UNIT = "workflows"
+
+
+def _ensure_catalog_storage(project: str) -> None:
+    ensure_builtins_project(project)
+    unisdk.create_context(
+        BUILTINS_WORKFLOWS_CONTEXT,
+        description="Public catalogue of installable workflows.",
+        unique_keys={"slug": "str"},
+        project=project,
+    )
+    unisdk.create_context(
+        BUILTINS_WORKFLOWS_META_CONTEXT,
+        description="Seeding state for the workflow catalogue.",
+        unique_keys={"meta_id": "int"},
+        project=project,
+    )
+
+
+def human_schedule(entry: Mapping[str, Any]) -> str:
+    """A plain-language cadence for one task entry, or "" if it has none.
+
+    Reading surfaces show a workflow's recurring jobs before it is
+    installed, and "every weekday at 08:30" is the part a user actually
+    weighs. Derived here rather than in the reader so every surface says
+    it the same way.
+    """
+    repeat = entry.get("repeat") or []
+    if isinstance(repeat, str):
+        try:
+            repeat = json.loads(repeat)
+        except ValueError:
+            return ""
+    if not repeat:
+        return "Once, at install" if not entry.get("trigger") else "On a trigger"
+
+    first = repeat[0] if isinstance(repeat[0], Mapping) else {}
+    frequency = str(first.get("frequency") or "").lower()
+    weekdays = [str(d).upper() for d in (first.get("weekdays") or [])]
+    at = str(first.get("time_of_day") or "")[:5]
+
+    if frequency == "weekly" and weekdays:
+        if set(weekdays) == {"MO", "TU", "WE", "TH", "FR"}:
+            cadence = "Every weekday"
+        else:
+            order = ["MO", "TU", "WE", "TH", "FR", "SA", "SU"]
+            names = {
+                "MO": "Mon",
+                "TU": "Tue",
+                "WE": "Wed",
+                "TH": "Thu",
+                "FR": "Fri",
+                "SA": "Sat",
+                "SU": "Sun",
+            }
+            ordered = [names[d] for d in order if d in weekdays]
+            cadence = "Every " + ", ".join(ordered)
+    elif frequency:
+        cadence = {
+            "minutely": "Every minute",
+            "hourly": "Every hour",
+            "daily": "Every day",
+            "weekly": "Every week",
+            "monthly": "Every month",
+            "yearly": "Every year",
+        }.get(frequency, f"Every {frequency}")
+    else:
+        return ""
+
+    return f"{cadence} at {at}" if at else cadence
+
+
+def bundle_sets(bundle: WorkflowBundle) -> Dict[str, Any]:
+    """What a bundle sets up, per surface, for a reader to show."""
+    sets: Dict[str, Any] = {}
+    for surface, source in bundle.surfaces.items():
+        items = []
+        for key, entry in sorted(source.items()):
+            fields = entry if isinstance(entry, Mapping) else {}
+            item: Dict[str, Any] = {
+                "name": str(fields.get("name") or fields.get("title") or key),
+            }
+            if surface == "tasks":
+                schedule = human_schedule(fields)
+                if schedule:
+                    item["schedule"] = schedule
+            items.append(item)
+        sets[surface] = items
+    return sets
+
+
+def catalog_row(bundle: WorkflowBundle) -> Dict[str, Any]:
+    """One catalogue row's fields, derived wholly from the bundle."""
+    entry = WorkflowCatalogEntry(
+        slug=bundle.slug,
+        name=bundle.name,
+        version=bundle.version,
+        category=bundle.category,
+        icon_id=bundle.icon_id,
+        description=bundle.description,
+        requirements=json.dumps(
+            [
+                {
+                    "slug": requirement.slug,
+                    "name": requirement.name or requirement.slug,
+                }
+                for requirement in bundle.requirements
+            ],
+        ),
+        capabilities=json.dumps(list(bundle.capabilities)),
+        params_schema=json.dumps(bundle.params_schema, sort_keys=True),
+        surfaces=json.dumps(bundle.surface_names()),
+        sets=json.dumps(bundle_sets(bundle), sort_keys=True),
+    )
+    return strip_authoring_assistant_id(entry.model_dump(mode="json"))
+
+
+def _default_bundles() -> Optional[List[WorkflowBundle]]:
+    """The curated bundles this environment ships, or None when it has none.
+
+    Resolution order matches the runtime's: an explicit
+    ``UNITY_WORKFLOWS_DIR``, then the installed ``unify_deploy`` package.
+    ``None`` (as opposed to ``[]``) means "nothing to reconcile" — the seed
+    ensures storage exists and stops, so an environment without the curated
+    tree cannot empty a catalogue another environment seeded.
+    """
+    from ..settings import SETTINGS
+    from .catalog import load_catalog
+
+    configured = (SETTINGS.UNITY_WORKFLOWS_DIR or "").strip()
+    if configured:
+        return load_catalog(Path(configured))
+    try:
+        from unify_deploy.assistant_deployments.workflows import workflows_root
+
+        return load_catalog(workflows_root())
+    except Exception:
+        return None
+
+
+def seed_builtin_workflows(
+    *,
+    bundles: Optional[List[WorkflowBundle]] = None,
+    project: str | None = None,
+) -> bool:
+    """Seed the public workflow catalogue. Returns True when rows changed.
+
+    Omitting *bundles* resolves them from this environment's curated tree;
+    an environment with no tree only guarantees storage exists. Passing
+    ``bundles=[]`` explicitly empties the catalogue.
+    """
+    project = project or builtins_project()
+
+    if bundles is None:
+        bundles = _default_bundles()
+
+    # Read-only probe first: a pre-seeded, unchanged catalogue must be
+    # verifiable by any principal without owner-guarded writes.
+    try:
+        current_hashes = read_seed_hashes(
+            project,
+            meta_context=BUILTINS_WORKFLOWS_META_CONTEXT,
+            key=_HASH_MAP_KEY,
+        )
+        storage_ready = True
+    except RequestError:
+        storage_ready = False
+        current_hashes = {}
+
+    if bundles is None:
+        if not storage_ready:
+            _ensure_catalog_storage(project)
+        return False
+
+    rows = {bundle.slug: catalog_row(bundle) for bundle in bundles}
+    hash_fields = sorted(WorkflowCatalogEntry.model_fields)
+    expected_hash = stable_hash_for_rows(
+        list(rows.values()),
+        fields=hash_fields,
+        sort_field="slug",
+    )
+    if storage_ready and current_hashes.get(_UNIT) == expected_hash:
+        logger.debug("Workflow catalogue unchanged; skipping seed")
+        return False
+
+    _ensure_catalog_storage(project)
+
+    live_logs = unisdk.get_logs(
+        project=project,
+        context=BUILTINS_WORKFLOWS_CONTEXT,
+        limit=1000,
+    )
+    live = {
+        str((lg.entries or {}).get("slug")): lg
+        for lg in live_logs
+        if (lg.entries or {}).get("slug")
+    }
+
+    inserts = [payload for slug, payload in rows.items() if slug not in live]
+    if inserts:
+        unity_create_logs(
+            context=BUILTINS_WORKFLOWS_CONTEXT,
+            project=project,
+            entries=inserts,
+            stamp_authoring=True,
+            batched=True,
+        )
+
+    for slug, payload in rows.items():
+        existing = live.get(slug)
+        if existing is None:
+            continue
+        current = {key: (existing.entries or {}).get(key) for key in payload}
+        if current == payload:
+            continue
+        unisdk.update_logs(
+            project=project,
+            context=BUILTINS_WORKFLOWS_CONTEXT,
+            logs=[existing.id],
+            entries=payload,
+            overwrite=True,
+        )
+
+    stale = [lg.id for slug, lg in live.items() if slug not in rows]
+    if stale:
+        unisdk.delete_logs(
+            project=project,
+            context=BUILTINS_WORKFLOWS_CONTEXT,
+            logs=stale,
+        )
+
+    hashes = dict(current_hashes)
+    hashes[_UNIT] = expected_hash
+    write_seed_hashes(
+        project,
+        hashes,
+        meta_context=BUILTINS_WORKFLOWS_META_CONTEXT,
+        key=_HASH_MAP_KEY,
+    )
+    logger.info(
+        "Seeded workflow catalogue project=%s rows=%d removed=%d",
+        project,
+        len(rows),
+        len(stale),
+    )
+    return True

--- a/unify/workflow_manager/builtins_catalog.py
+++ b/unify/workflow_manager/builtins_catalog.py
@@ -7,9 +7,13 @@ reading surface (Console's gallery) renders it without waking an
 assistant — a hosted assistant is an on-demand job and is usually asleep
 when someone opens Console.
 
-Everything per-assistant stays in each assistant's own contexts: the
-installation rows, params, requirement/connection state, and the planted
-content itself. Only the listing is global.
+Two contexts are published: ``Workflows/Catalog`` (one listing row per
+bundle) and ``Workflows/Content`` (one row per artifact a bundle would
+plant, substance included, so a reader can open a procedure or a task
+brief before anything is installed). Everything per-assistant stays in
+each assistant's own contexts: the installation rows, params,
+requirement/connection state, and the planted content itself — the
+global rows are the shelf, never the live copies.
 
 Seeding runs in bootstrap/admin processes (the deploy seed script, the
 self-host install, the test harness) whose key owns the Builtins project;
@@ -39,13 +43,16 @@ from ..common.log_utils import create_logs as unity_create_logs
 from ..function_manager.hash_utils import stable_hash_for_rows
 from .bundle import WorkflowBundle
 from .types.catalog_entry import WorkflowCatalogEntry
+from .types.content_entry import WorkflowContentEntry
 
 logger = logging.getLogger(__name__)
 
 BUILTINS_WORKFLOWS_CONTEXT = "Workflows/Catalog"
+BUILTINS_WORKFLOWS_CONTENT_CONTEXT = "Workflows/Content"
 BUILTINS_WORKFLOWS_META_CONTEXT = "Workflows/Meta"
 _HASH_MAP_KEY = "workflows_catalog_hash_by_unit"
-_UNIT = "workflows"
+_CATALOG_UNIT = "workflows"
+_CONTENT_UNIT = "workflows_content"
 
 
 def _ensure_catalog_storage(project: str) -> None:
@@ -54,6 +61,12 @@ def _ensure_catalog_storage(project: str) -> None:
         BUILTINS_WORKFLOWS_CONTEXT,
         description="Public catalogue of installable workflows.",
         unique_keys={"slug": "str"},
+        project=project,
+    )
+    unisdk.create_context(
+        BUILTINS_WORKFLOWS_CONTENT_CONTEXT,
+        description="The artifacts each catalogued workflow would plant.",
+        unique_keys={"content_key": "str"},
         project=project,
     )
     unisdk.create_context(
@@ -145,6 +158,7 @@ def catalog_row(bundle: WorkflowBundle) -> Dict[str, Any]:
         category=bundle.category,
         icon_id=bundle.icon_id,
         description=bundle.description,
+        about=bundle.about,
         requirements=json.dumps(
             [
                 {
@@ -160,6 +174,90 @@ def catalog_row(bundle: WorkflowBundle) -> Dict[str, Any]:
         sets=json.dumps(bundle_sets(bundle), sort_keys=True),
     )
     return strip_authoring_assistant_id(entry.model_dump(mode="json"))
+
+
+_CONTENT_BODY_FIELD = {
+    "tasks": "description",
+    "functions": "docstring",
+}
+_CONTENT_META_FIELDS = {
+    "knowledge": ("kind", "topics"),
+    "tasks": ("tags",),
+    "functions": ("argspec",),
+}
+
+
+def content_rows(bundle: WorkflowBundle) -> List[Dict[str, Any]]:
+    """One row per artifact the bundle would plant, readable substance
+    included, so a reading surface can open any of them pre-install."""
+    rows: List[Dict[str, Any]] = []
+    for surface, source in sorted(bundle.surfaces.items()):
+        body_field = _CONTENT_BODY_FIELD.get(surface, "content")
+        meta_fields = _CONTENT_META_FIELDS.get(surface, ())
+        for key, entry in sorted(source.items()):
+            fields = entry if isinstance(entry, Mapping) else {}
+            meta = {
+                name: fields[name]
+                for name in meta_fields
+                if fields.get(name) not in (None, "", [])
+            }
+            row = WorkflowContentEntry(
+                content_key=f"{bundle.slug}/{surface}/{key}",
+                slug=bundle.slug,
+                surface=surface,
+                key=key,
+                name=str(fields.get("name") or fields.get("title") or key),
+                body=str(fields.get(body_field) or ""),
+                schedule=human_schedule(fields) if surface == "tasks" else "",
+                meta=json.dumps(meta, sort_keys=True, default=str),
+            )
+            rows.append(strip_authoring_assistant_id(row.model_dump(mode="json")))
+    return rows
+
+
+def _reconcile_rows(
+    *,
+    project: str,
+    context: str,
+    rows: Dict[str, Dict[str, Any]],
+    key_field: str,
+) -> None:
+    """Converge one context onto *rows*.
+
+    Changed rows are replaced (delete + insert), the same shape the sibling
+    builtins seeders use: the Builtins writer routes deletes and inserts by
+    project, and rows here carry no state beyond what the seed derives, so
+    replacement loses nothing.
+    """
+    live_logs = unisdk.get_logs(project=project, context=context, limit=1000)
+    live = {
+        str((lg.entries or {}).get(key_field)): lg
+        for lg in live_logs
+        if (lg.entries or {}).get(key_field)
+    }
+
+    def unchanged(key: str) -> bool:
+        existing = live.get(key)
+        if existing is None:
+            return False
+        payload = rows[key]
+        return {name: (existing.entries or {}).get(name) for name in payload} == payload
+
+    doomed = [
+        lg.id for key, lg in live.items() if key not in rows or not unchanged(key)
+    ]
+    if doomed:
+        unisdk.delete_logs(project=project, context=context, logs=doomed)
+
+    inserts = [payload for key, payload in rows.items() if not unchanged(key)]
+    if inserts:
+        unity_create_logs(
+            context=context,
+            project=project,
+            entries=inserts,
+            stamp_authoring=True,
+            batched=True,
+        )
 
 
 def _default_bundles() -> Optional[List[WorkflowBundle]]:
@@ -219,75 +317,63 @@ def seed_builtin_workflows(
             _ensure_catalog_storage(project)
         return False
 
-    rows = {bundle.slug: catalog_row(bundle) for bundle in bundles}
-    hash_fields = sorted(WorkflowCatalogEntry.model_fields)
-    expected_hash = stable_hash_for_rows(
-        list(rows.values()),
-        fields=hash_fields,
-        sort_field="slug",
-    )
-    if storage_ready and current_hashes.get(_UNIT) == expected_hash:
+    catalog = {bundle.slug: catalog_row(bundle) for bundle in bundles}
+    content = {
+        row["content_key"]: row for bundle in bundles for row in content_rows(bundle)
+    }
+    units = {
+        _CATALOG_UNIT: (
+            BUILTINS_WORKFLOWS_CONTEXT,
+            "slug",
+            catalog,
+            sorted(WorkflowCatalogEntry.model_fields),
+        ),
+        _CONTENT_UNIT: (
+            BUILTINS_WORKFLOWS_CONTENT_CONTEXT,
+            "content_key",
+            content,
+            sorted(WorkflowContentEntry.model_fields),
+        ),
+    }
+
+    expected_hashes = {
+        unit: stable_hash_for_rows(
+            list(rows.values()),
+            fields=hash_fields,
+            sort_field=key_field,
+        )
+        for unit, (_, key_field, rows, hash_fields) in units.items()
+    }
+    stale_units = {
+        unit
+        for unit, expected in expected_hashes.items()
+        if current_hashes.get(unit) != expected
+    }
+    if storage_ready and not stale_units:
         logger.debug("Workflow catalogue unchanged; skipping seed")
         return False
 
     _ensure_catalog_storage(project)
 
-    live_logs = unisdk.get_logs(
-        project=project,
-        context=BUILTINS_WORKFLOWS_CONTEXT,
-        limit=1000,
-    )
-    live = {
-        str((lg.entries or {}).get("slug")): lg
-        for lg in live_logs
-        if (lg.entries or {}).get("slug")
-    }
-
-    inserts = [payload for slug, payload in rows.items() if slug not in live]
-    if inserts:
-        unity_create_logs(
-            context=BUILTINS_WORKFLOWS_CONTEXT,
+    for unit in sorted(stale_units):
+        context, key_field, rows, _ = units[unit]
+        _reconcile_rows(
             project=project,
-            entries=inserts,
-            stamp_authoring=True,
-            batched=True,
+            context=context,
+            rows=rows,
+            key_field=key_field,
         )
 
-    for slug, payload in rows.items():
-        existing = live.get(slug)
-        if existing is None:
-            continue
-        current = {key: (existing.entries or {}).get(key) for key in payload}
-        if current == payload:
-            continue
-        unisdk.update_logs(
-            project=project,
-            context=BUILTINS_WORKFLOWS_CONTEXT,
-            logs=[existing.id],
-            entries=payload,
-            overwrite=True,
-        )
-
-    stale = [lg.id for slug, lg in live.items() if slug not in rows]
-    if stale:
-        unisdk.delete_logs(
-            project=project,
-            context=BUILTINS_WORKFLOWS_CONTEXT,
-            logs=stale,
-        )
-
-    hashes = dict(current_hashes)
-    hashes[_UNIT] = expected_hash
     write_seed_hashes(
         project,
-        hashes,
+        {**current_hashes, **expected_hashes},
         meta_context=BUILTINS_WORKFLOWS_META_CONTEXT,
         key=_HASH_MAP_KEY,
     )
     logger.info(
-        "Seeded workflow catalogue project=%s rows=%d removed=%d",
+        "Seeded workflow catalogue project=%s workflows=%d artifacts=%d",
         project,
-        len(rows),
-        len(stale),
+        len(catalog),
+        len(content),
     )
     return True

--- a/unify/workflow_manager/bundle.py
+++ b/unify/workflow_manager/bundle.py
@@ -170,6 +170,13 @@ class WorkflowBundle:
     name: str
     version: str = ""
     description: str = ""
+    """One line for a card or a list row."""
+
+    about: str = ""
+    """Long-form markdown for a reader deciding whether to install: what
+    the workflow does, when it runs, what arrives, and how its settings
+    shape it. The ``description`` is the card; this is the page."""
+
     category: str = ""
     """Catalogue grouping, e.g. ``"comms"`` / ``"growth"`` / ``"ops"`` /
     ``"build"``."""

--- a/unify/workflow_manager/catalog.py
+++ b/unify/workflow_manager/catalog.py
@@ -105,6 +105,7 @@ def load_bundle(path: Path) -> WorkflowBundle:
         name=name,
         version=str(manifest.get("version", "")),
         description=str(manifest.get("description", "")),
+        about=str(manifest.get("about", "")),
         category=str(manifest.get("category", "")),
         icon_id=str(manifest.get("icon_id", "")),
         surfaces=_collect_surfaces(path),

--- a/unify/workflow_manager/catalog.py
+++ b/unify/workflow_manager/catalog.py
@@ -181,9 +181,10 @@ def bootstrap_workflow_catalog(
         except Exception:
             logger.exception("Skipping malformed workflow bundle at %s", entry)
 
-    # Publish before reconciling: the shelf is what a reading surface needs
-    # first, and it must not wait on installs that may be slow or partial.
-    manager.publish_catalog()
+    # The shelf itself is NOT published here: the catalogue listing is
+    # platform data in the public-read Builtins project, seeded by admin
+    # processes (see builtins_catalog.seed_builtin_workflows). An assistant
+    # key cannot write Builtins and must not try.
 
     try:
         report = manager.reconcile_installed()

--- a/unify/workflow_manager/types/__init__.py
+++ b/unify/workflow_manager/types/__init__.py
@@ -1,10 +1,12 @@
 from .meta import WorkflowMeta
 from .catalog_entry import WorkflowCatalogEntry
+from .content_entry import WorkflowContentEntry
 from .workflow import UNASSIGNED, WorkflowInstallation
 
 __all__ = [
     "UNASSIGNED",
     "WorkflowCatalogEntry",
+    "WorkflowContentEntry",
     "WorkflowInstallation",
     "WorkflowMeta",
 ]

--- a/unify/workflow_manager/types/catalog_entry.py
+++ b/unify/workflow_manager/types/catalog_entry.py
@@ -40,6 +40,7 @@ class WorkflowCatalogEntry(AuthoredRow):
         "category": "c",
         "icon_id": "i",
         "description": "d",
+        "about": "a",
         "requirements": "rq",
         "capabilities": "cp",
         "params_schema": "ps",
@@ -65,6 +66,14 @@ class WorkflowCatalogEntry(AuthoredRow):
     description: str = Field(
         default="",
         description="One line describing what the workflow does.",
+    )
+    about: str = Field(
+        default="",
+        description=(
+            "Long-form markdown for a reader deciding whether to install: "
+            "what the workflow does, when it runs, what arrives, and how "
+            "its settings shape it."
+        ),
     )
     requirements: str = Field(
         default="[]",

--- a/unify/workflow_manager/types/content_entry.py
+++ b/unify/workflow_manager/types/content_entry.py
@@ -1,0 +1,82 @@
+"""Pydantic model for the ``Workflows/Content`` context.
+
+One row per artifact a workflow would plant, published beside the
+catalogue in the public-read Builtins project. The catalogue row's
+``sets`` names what a bundle sets up; these rows carry the artifacts
+themselves — a procedure's text, a claim's statement, a task's brief, a
+function's docstring — so a reading surface can show any of them before
+anything is installed, without waking an assistant.
+
+Like the catalogue, everything here is derived from the bundle on disk
+and rewritten wholesale by the seed; nothing is authored in this
+context, and installed assistants never read it — their planted rows are
+the live copies.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from pydantic import Field
+
+from unify.common.authorship import AuthoredRow
+
+
+class WorkflowContentEntry(AuthoredRow):
+    """One bundled artifact, as published for reading surfaces."""
+
+    SHORTHAND_MAP: ClassVar[dict[str, str]] = {
+        "content_key": "ck",
+        "slug": "s",
+        "surface": "sf",
+        "key": "k",
+        "name": "n",
+        "body": "b",
+        "schedule": "sc",
+        "meta": "m",
+    }
+
+    content_key: str = Field(
+        description=(
+            "The row's identity: '<slug>/<surface>/<key>', e.g. "
+            "'daily_briefing/guidance/daily_briefing/compose'."
+        ),
+    )
+    slug: str = Field(description="The workflow this artifact belongs to.")
+    surface: str = Field(
+        description=(
+            "The bundle surface the artifact plants into: 'guidance', "
+            "'knowledge', 'tasks' or 'functions'."
+        ),
+    )
+    key: str = Field(
+        description="The artifact's own key within its surface.",
+    )
+    name: str = Field(description="Human-readable artifact title.")
+    body: str = Field(
+        default="",
+        description=(
+            "The artifact's readable substance: a procedure's or claim's "
+            "content, a task's brief, a function's docstring."
+        ),
+    )
+    schedule: str = Field(
+        default="",
+        description="Plain-language cadence, for tasks that have one.",
+    )
+    meta: str = Field(
+        default="{}",
+        description=(
+            "JSON object of surface-specific extras a reader may render: "
+            "a claim's kind and topics, a task's tags, a function's "
+            "argspec."
+        ),
+    )
+
+    @classmethod
+    def shorthand_map(cls) -> dict[str, str]:
+        return dict(cls.SHORTHAND_MAP)
+
+    @classmethod
+    def shorthand_inverse_map(cls) -> dict[str, str]:
+        return {v: k for k, v in cls.SHORTHAND_MAP.items()}

--- a/unify/workflow_manager/workflow_manager.py
+++ b/unify/workflow_manager/workflow_manager.py
@@ -749,6 +749,7 @@ class WorkflowManager(BaseWorkflowManager):
                 {
                     "name": bundle.name,
                     "description": bundle.description,
+                    "about": bundle.about,
                     "version": bundle.version,
                     "category": bundle.category,
                     "icon_id": bundle.icon_id,

--- a/unify/workflow_manager/workflow_manager.py
+++ b/unify/workflow_manager/workflow_manager.py
@@ -16,7 +16,6 @@ which is what makes update and uninstall possible at all.
 from __future__ import annotations
 
 import functools
-import hashlib
 import json
 import logging
 import threading
@@ -35,7 +34,6 @@ from ..common.tool_outcome import ToolErrorException
 from .base import BaseWorkflowManager
 from .bundle import WORKFLOW_LIBRARY, SurfaceRegistry, WorkflowBundle
 from .requirements import RequirementResolver
-from .types.catalog_entry import WorkflowCatalogEntry
 from .types.meta import WorkflowMeta
 from .types.workflow import UNASSIGNED, WorkflowInstallation
 
@@ -43,7 +41,6 @@ logger = logging.getLogger(__name__)
 
 WORKFLOW_TABLE = "Workflows"
 WORKFLOW_META_TABLE = "Workflows/Meta"
-WORKFLOW_CATALOG_TABLE = "Workflows/Catalog"
 
 
 class WorkflowManager(BaseWorkflowManager):
@@ -64,22 +61,12 @@ class WorkflowManager(BaseWorkflowManager):
                 fields=model_to_fields(WorkflowMeta),
                 unique_keys={"meta_id": "int"},
             ),
-            TableContext(
-                name=WORKFLOW_CATALOG_TABLE,
-                description=(
-                    "Installable workflows published for reading surfaces. "
-                    "Derived from the bundles on disk; never authored here."
-                ),
-                fields=model_to_fields(WorkflowCatalogEntry),
-                unique_keys={"slug": "str"},
-            ),
         ]
 
     def __init__(self) -> None:
         super().__init__()
         self._ctx = ContextRegistry.get_context(self, WORKFLOW_TABLE)
         self._meta_ctx = ContextRegistry.get_context(self, WORKFLOW_META_TABLE)
-        self._catalog_ctx = ContextRegistry.get_context(self, WORKFLOW_CATALOG_TABLE)
         self._surfaces = SurfaceRegistry()
         self._catalogue: Dict[str, WorkflowBundle] = {}
         self._lock = threading.RLock()
@@ -745,233 +732,6 @@ class WorkflowManager(BaseWorkflowManager):
                 sorted(failures),
             )
         return result
-
-    # ------------------------------------------------------------------ #
-    # Publishing the catalogue for reading surfaces                      #
-    # ------------------------------------------------------------------ #
-    @staticmethod
-    def _human_schedule(entry: Mapping[str, Any]) -> str:
-        """A plain-language cadence for one task entry, or "" if it has none.
-
-        Reading surfaces show a workflow's recurring jobs before it is
-        installed, and "every weekday at 08:30" is the part a user actually
-        weighs. Derived here rather than in the reader so every surface
-        says it the same way.
-        """
-        repeat = entry.get("repeat") or []
-        if isinstance(repeat, str):
-            try:
-                repeat = json.loads(repeat)
-            except ValueError:
-                return ""
-        if not repeat:
-            return "Once, at install" if not entry.get("trigger") else "On a trigger"
-
-        first = repeat[0] if isinstance(repeat[0], Mapping) else {}
-        frequency = str(first.get("frequency") or "").lower()
-        weekdays = [str(d).upper() for d in (first.get("weekdays") or [])]
-        at = str(first.get("time_of_day") or "")[:5]
-
-        if frequency == "weekly" and weekdays:
-            weekday_set = {"MO", "TU", "WE", "TH", "FR"}
-            if set(weekdays) == weekday_set:
-                cadence = "Every weekday"
-            else:
-                order = ["MO", "TU", "WE", "TH", "FR", "SA", "SU"]
-                names = {
-                    "MO": "Mon",
-                    "TU": "Tue",
-                    "WE": "Wed",
-                    "TH": "Thu",
-                    "FR": "Fri",
-                    "SA": "Sat",
-                    "SU": "Sun",
-                }
-                ordered = [names[d] for d in order if d in weekdays]
-                cadence = "Every " + ", ".join(ordered)
-        elif frequency:
-            cadence = {
-                "minutely": "Every minute",
-                "hourly": "Every hour",
-                "daily": "Every day",
-                "weekly": "Every week",
-                "monthly": "Every month",
-                "yearly": "Every year",
-            }.get(frequency, f"Every {frequency}")
-        else:
-            return ""
-
-        return f"{cadence} at {at}" if at else cadence
-
-    @classmethod
-    def _bundle_sets(cls, bundle: WorkflowBundle) -> Dict[str, Any]:
-        """What a bundle sets up, per surface, for a reader to show."""
-        sets: Dict[str, Any] = {}
-        for surface, source in bundle.surfaces.items():
-            items = []
-            for key, entry in sorted(source.items()):
-                fields = entry if isinstance(entry, Mapping) else {}
-                item: Dict[str, Any] = {
-                    "name": str(fields.get("name") or fields.get("title") or key),
-                }
-                if surface == "tasks":
-                    schedule = cls._human_schedule(fields)
-                    if schedule:
-                        item["schedule"] = schedule
-                items.append(item)
-            sets[surface] = items
-        return sets
-
-    def _catalog_entry(self, bundle: WorkflowBundle) -> Dict[str, Any]:
-        """One catalogue row's fields, derived wholly from the bundle."""
-        entry = WorkflowCatalogEntry(
-            slug=bundle.slug,
-            name=bundle.name,
-            version=bundle.version,
-            category=bundle.category,
-            icon_id=bundle.icon_id,
-            description=bundle.description,
-            requirements=json.dumps(
-                [
-                    {
-                        "slug": requirement.slug,
-                        "name": requirement.name or requirement.slug,
-                    }
-                    for requirement in bundle.requirements
-                ],
-            ),
-            capabilities=json.dumps(list(bundle.capabilities)),
-            params_schema=json.dumps(bundle.params_schema, sort_keys=True),
-            surfaces=json.dumps(bundle.surface_names()),
-            sets=json.dumps(self._bundle_sets(bundle), sort_keys=True),
-        )
-        return strip_authoring_assistant_id(entry.model_dump(mode="json"))
-
-    def _get_stored_catalog_hash(self) -> str:
-        try:
-            logs = unisdk.get_logs(
-                context=self._meta_ctx,
-                filter="meta_id == 1",
-                limit=1,
-            )
-            if logs:
-                return str((logs[0].entries or {}).get("custom_workflow_hash", ""))
-        except Exception:
-            logger.debug("Could not read the workflow catalogue hash", exc_info=True)
-        return ""
-
-    def _store_catalog_hash(self, hash_value: str) -> None:
-        try:
-            logs = unisdk.get_logs(
-                context=self._meta_ctx,
-                filter="meta_id == 1",
-                limit=1,
-            )
-            if logs:
-                unisdk.update_logs(
-                    context=self._meta_ctx,
-                    logs=[logs[0].id],
-                    entries={"custom_workflow_hash": hash_value},
-                    overwrite=True,
-                )
-            else:
-                unity_create_logs(
-                    context=self._meta_ctx,
-                    entries=[{"meta_id": 1, "custom_workflow_hash": hash_value}],
-                    stamp_authoring=True,
-                )
-        except Exception:
-            logger.debug("Could not store the workflow catalogue hash", exc_info=True)
-
-    def publish_catalog(self) -> Dict[str, Any]:
-        """Mirror the in-memory catalogue into ``Workflows/Catalog``.
-
-        Reading surfaces then see the shelf without waking the assistant,
-        which matters because a hosted assistant is usually asleep when
-        someone opens Console.
-
-        Cheap by construction, in three steps:
-
-        1. **Hash short-circuit.** The published shape is fingerprinted and
-           compared with the stored aggregate. A boot whose catalogue has
-           not changed costs one meta read and nothing else — which is
-           every boot between deploys, i.e. almost all of them.
-        2. **One batched insert** for rows that are new, rather than a call
-           per bundle.
-        3. **Per-row updates only for rows that actually changed**, since
-           Orchestra applies one entries payload to every id in a call and
-           each row's content differs. Deletes batch into one call.
-
-        Nothing is authored in that context, so there is no user edit to
-        preserve and no merge to get wrong.
-
-        Best-effort by design: a publish failure must not stop an assistant
-        booting or block installs, because the in-memory catalogue is the
-        authority either way. Failures are logged and the next boot retries
-        (the hash is stored only on success, so a failed pass does not pin
-        itself as up to date).
-        """
-        bundles = self.available_bundles()
-        entries = {bundle.slug: self._catalog_entry(bundle) for bundle in bundles}
-        expected_hash = hashlib.sha256(
-            json.dumps(entries, sort_keys=True).encode(),
-        ).hexdigest()
-
-        if entries and self._get_stored_catalog_hash() == expected_hash:
-            logger.debug("Workflow catalogue unchanged; skipping publish")
-            return {"unchanged": True, "published": [], "removed": []}
-
-        published: List[str] = []
-        removed: List[str] = []
-        try:
-            live_logs = unisdk.get_logs(
-                context=self._catalog_ctx,
-                exclude_fields=list_private_fields(self._catalog_ctx),
-            )
-            live = {
-                str((lg.entries or {}).get("slug")): lg
-                for lg in live_logs
-                if (lg.entries or {}).get("slug")
-            }
-
-            inserts = [payload for slug, payload in entries.items() if slug not in live]
-            if inserts:
-                unity_create_logs(
-                    context=self._catalog_ctx,
-                    entries=inserts,
-                    stamp_authoring=True,
-                    batched=True,
-                )
-                published.extend(payload["slug"] for payload in inserts)
-
-            for slug, payload in entries.items():
-                existing = live.get(slug)
-                if existing is None:
-                    continue
-                current = {key: (existing.entries or {}).get(key) for key in payload}
-                if current == payload:
-                    continue
-                unisdk.update_logs(
-                    context=self._catalog_ctx,
-                    logs=[existing.id],
-                    entries=payload,
-                    overwrite=True,
-                )
-                published.append(slug)
-
-            stale = [lg.id for slug, lg in live.items() if slug not in entries]
-            if stale:
-                unisdk.delete_logs(context=self._catalog_ctx, logs=stale)
-                removed.extend(slug for slug in live if slug not in entries)
-        except Exception:
-            logger.exception(
-                "Could not publish the workflow catalogue; the shelf may read "
-                "stale until the next boot",
-            )
-            return {"published": sorted(published), "removed": sorted(removed)}
-
-        self._store_catalog_hash(expected_hash)
-        return {"published": sorted(published), "removed": sorted(removed)}
 
     @functools.wraps(BaseWorkflowManager.get_workflow, updated=())
     def get_workflow(self, *, slug: str) -> Dict[str, Any]:


### PR DESCRIPTION
<!--
Thanks for contributing to Unify! Please fill out the sections below.
For trivial changes (typo fixes, comment-only edits) you can shorten this template — just keep the Summary.

PRs land on `staging`, not `main`. See CONTRIBUTING.md.
-->

## Summary

<!-- 1–3 sentences: what problem does this PR solve, and why is this the right approach? -->



## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes incorrect behavior)
- [ ] Feature (non-breaking change that adds functionality)
- [ ] Refactor (no behavior change)
- [ ] Breaking change (API or data-model change — Unify has zero-backward-compat policy, but please call it out)
- [ ] Test-only (no source changes)
- [ ] Docs / chore / CI

## Areas touched

<!-- Check all that apply. Helps reviewers route. -->

- [ ] Actor / CodeAct
- [ ] ConversationManager / slow brain
- [ ] A specific state manager (Contact / Knowledge / Task / Transcript / Guidance / Function / File / Image / Web / Secret / Blacklist / Data / Memory)
- [ ] Async tool loop (`unify/common/_async_tool/`)
- [ ] Event bus / observability
- [ ] Gateway / external comms
- [ ] Tests / test infra (`tests/`, `conftest.py`, `parallel_run.sh`)
- [ ] CI / build / packaging

## Test plan

<!--
How did you verify this? Paste the command(s) you ran and the result.

The default expectation is to run the relevant directory:
  tests/parallel_run.sh tests/<module>/

For infrastructure changes that are hard to reach via tests, a quick
verification script under tests/_verify_*.py is encouraged
(see .agents/rules/surgical-verification-before-tests.md).
-->

```
tests/parallel_run.sh tests/...
```

- [ ] All relevant tests pass locally
- [ ] If this is a bug fix, I added a regression test (or explained why one isn't feasible)

## Behavior / migration notes

<!--
- Did this change a public manager API, primitive, or event payload?
- Are there schema/context changes in Orchestra that need a migration?
- Any new env vars or config flags? (Update `.env.advanced.example`.)
- If yes to any of the above, describe upgrade steps.
-->

None.

## Checklist

- [ ] PR is targeted at `staging` (not `main`)
- [ ] Followed conventional commit style (`feat(scope):`, `fix(scope):`, `refactor(scope):`, `chore(scope):`, etc.)
- [ ] No `try/except` added defensively — only around specific, recoverable errors
- [ ] No "new" / "updated" / "TODO from chat" temporal comments (see `.agents/rules/no-temporal-comments.md`)
- [ ] No test-specific shortcuts in production code (see `.agents/rules/no-test-info-in-production-code.md`)
- [ ] Updated `AGENTS.md` / `ARCHITECTURE.md` if I changed architectural conventions
