### PR TITLE
Feat/workflows

### DIFF
--- a/.agents/rules/custom-source-sync.md
+++ b/.agents/rules/custom-source-sync.md
@@ -54,14 +54,19 @@ integration registry) reconcile through the shared engine in
 - Registering a surface for workflow installs while its adapter still
   queries unscoped. The `SurfaceRegistry` refuses these
   (`UnscopedSurfaceError`); routing around it reintroduces mutual prune.
+- Making canvas a synced surface. A view is TypeScript that must be
+  compiled, rendered and reviewed against the kit installed *now*, and its
+  routing token has a lifecycle the engine does not own. Bundles ship
+  canvas **source**; the install publishes through CanvasManager and the
+  uninstall deletes through its own delete.
 
 ## Deviations are declared knobs, not forks
 
 `prune=False` (secrets), `collision="yield"` (secrets),
-`find_adoptable` (data seeds, integration registry, functions/venvs
-legacy rows), `find_released` (tasks: a planted task the user has
-edited), `should_update` (tasks: skip while running), `max_workers`
-(tasks). New deviations need a named knob on the adapter and a line in
+`find_adoptable` (data seeds — deployment only, integration registry,
+functions/venvs legacy rows), `find_released` (tasks: a planted task the
+user has edited), `should_update` (tasks: skip while running),
+`max_workers` (tasks). New deviations need a named knob on the adapter and a line in
 the writeup's table.
 
 ## Handing a row to the user

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -450,14 +450,19 @@ integration registry) reconcile through the shared engine in
 - Registering a surface for workflow installs while its adapter still
   queries unscoped. The `SurfaceRegistry` refuses these
   (`UnscopedSurfaceError`); routing around it reintroduces mutual prune.
+- Making canvas a synced surface. A view is TypeScript that must be
+  compiled, rendered and reviewed against the kit installed *now*, and its
+  routing token has a lifecycle the engine does not own. Bundles ship
+  canvas **source**; the install publishes through CanvasManager and the
+  uninstall deletes through its own delete.
 
 ## Deviations are declared knobs, not forks
 
 `prune=False` (secrets), `collision="yield"` (secrets),
-`find_adoptable` (data seeds, integration registry, functions/venvs
-legacy rows), `find_released` (tasks: a planted task the user has
-edited), `should_update` (tasks: skip while running), `max_workers`
-(tasks). New deviations need a named knob on the adapter and a line in
+`find_adoptable` (data seeds — deployment only, integration registry,
+functions/venvs legacy rows), `find_released` (tasks: a planted task the
+user has edited), `should_update` (tasks: skip while running),
+`max_workers` (tasks). New deviations need a named knob on the adapter and a line in
 the writeup's table.
 
 ## Handing a row to the user

--- a/docs/writeups/custom-source-sync.md
+++ b/docs/writeups/custom-source-sync.md
@@ -122,10 +122,27 @@ loop):
 |---|---|---|
 | `prune` | `True` | secrets: `False` (never auto-delete credentials) | <!-- pragma: allowlist secret -->
 | `collision` | `"replace"` (user-added row with the same key/natural id is deleted, source row inserted) | secrets: `"yield"` (a user-owned credential wins over the deploy value) | <!-- pragma: allowlist secret -->
-| `find_adoptable` | none | data seeds (by seed value), integration registry (by slug), functions/venvs (by name — legacy rows without `custom_key`) |
+| `find_adoptable` | none | data seeds (by seed value, **deployment only**), integration registry (by slug), functions/venvs (by name — legacy rows without `custom_key`) |
 | `find_released` | none | tasks: a planted task the user has edited. Clearing `managed_by` removes the row from `live_rows`, so without this probe the key reads as *missing* and the pass plants a second copy beside the edited one. Released rows are marked `custom_released=True` rather than inferred from a null `managed_by`, because a row written before `managed_by` existed also has none — and that one the deployment still owns |
 | `should_update` | always | tasks: skip while an execution is running |
 | `max_workers` | 1 | tasks: parallel updates, serialized inserts |
+
+### Data: reconcile per table *under consideration*
+
+Every other surface reads one context, so an empty source prunes all of a
+source's rows for free. Data rows live in many tables and the table list
+comes from the source — so an empty source names no table at all, which is
+exactly what an uninstall sends. `sync_custom_data` therefore records the
+tables each source last seeded (`custom_data_contexts__<managed_by>` on the
+Data meta row) and reconciles the union of *declared* and *previously
+seeded* tables. A table dropped from a bundle, and every table a workflow
+owned before it was uninstalled, still gets its pass.
+
+The aggregate hash covers the declared schemas as well as the rows, because
+a table may legitimately declare none: a workflow ships the shape its own
+job fills. Hashing rows alone made that source indistinguishable from an
+empty one — and both from the "never synced" sentinel — so the pass
+short-circuited and the table was never created.
 
 ## Scoping: one source per pass
 

--- a/tests/common/test_manager_base_contract.py
+++ b/tests/common/test_manager_base_contract.py
@@ -1,0 +1,179 @@
+"""A manager's base class is its contract, and the actor must read it.
+
+The public docstrings on ``Base{Manager}`` are the LLM-facing API: the
+primitives layer turns each manager method into a tool, taking its
+description from the docstring and its arguments from the signature. That
+only works if the concrete method carries
+``@functools.wraps(Base.method, updated=())`` — which is what makes
+``inspect.getdoc`` and ``inspect.signature`` resolve to the base.
+
+Two failures this keeps dead, both of which were live when it was written:
+
+- **A bespoke ``__doc__`` copy instead of wraps.** CanvasManager attached
+  the base docstrings with a module-level loop. The prose reached the actor
+  but the *signature* did not, so a publisher-internal keyword added to the
+  concrete method leaked into the tool schema as something the model could
+  pass.
+- **An abstract base that is not abstract.** ``BaseCanvasManager`` was a
+  plain class with ``@abstractmethod`` decorators, which do nothing without
+  ``ABCMeta`` — nothing enforced that an implementation existed at all.
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import Dict, List
+
+import pytest
+
+# (alias, concrete module, concrete class, base module, base class). The
+# managers the actor reaches, plus the two catalogue managers whose tools
+# are typed JSON calls rather than primitives — the contract is the same.
+MANAGERS = [
+    ("guidance", "unify.guidance_manager.guidance_manager", "GuidanceManager"),
+    ("knowledge", "unify.knowledge_manager.knowledge_manager", "KnowledgeManager"),
+    ("tasks", "unify.task_scheduler.task_scheduler", "TaskScheduler"),
+    ("contacts", "unify.contact_manager.contact_manager", "ContactManager"),
+    ("data", "unify.data_manager.data_manager", "DataManager"),
+    ("functions", "unify.function_manager.function_manager", "FunctionManager"),
+    ("secrets", "unify.secret_manager.secret_manager", "SecretManager"),
+    ("web", "unify.web_searcher.web_searcher", "WebSearcher"),
+    ("transcripts", "unify.transcript_manager.transcript_manager", "TranscriptManager"),
+    ("ingestion", "unify.ingestion_manager.ingestion_manager", "IngestionManager"),
+    ("canvas", "unify.canvas_manager.canvas_manager", "CanvasManager"),
+    ("workflows", "unify.workflow_manager.workflow_manager", "WorkflowManager"),
+]
+
+BASES = {
+    "guidance": ("unify.guidance_manager.base", "BaseGuidanceManager"),
+    "knowledge": ("unify.knowledge_manager.base", "BaseKnowledgeManager"),
+    "tasks": ("unify.task_scheduler.base", "BaseTaskScheduler"),
+    "contacts": ("unify.contact_manager.base", "BaseContactManager"),
+    "data": ("unify.data_manager.base", "BaseDataManager"),
+    "functions": ("unify.function_manager.base", "BaseFunctionManager"),
+    "secrets": ("unify.secret_manager.base", "BaseSecretManager"),
+    "web": ("unify.web_searcher.base", "BaseWebSearcher"),
+    "transcripts": ("unify.transcript_manager.base", "BaseTranscriptManager"),
+    "ingestion": ("unify.ingestion_manager.base", "BaseIngestionManager"),
+    "canvas": ("unify.canvas_manager.base", "BaseCanvasManager"),
+    "workflows": ("unify.workflow_manager.base", "BaseWorkflowManager"),
+}
+
+# Managers whose remaining drift is known, tracked, and needs its own pass
+# because changing a base signature changes the actor's tool schema and
+# reprices every cached prompt that carries it. Listed rather than skipped
+# silently, so the debt is visible and shrinks rather than being forgotten.
+KNOWN_UNWRAPPED: Dict[str, set[str]] = {
+    "tasks": {"get_run_event", "get_run_event_children"},
+    "contacts": {"filter_contacts", "update_contact"},
+    "functions": {"add_functions", "delete_function", "execute_function"},
+}
+
+
+def _load(module: str, name: str):
+    import importlib
+
+    return getattr(importlib.import_module(module), name)
+
+
+def _raw(cls, name):
+    """The function object as written, bypassing ``functools.wraps``."""
+    for klass in cls.__mro__:
+        if name in klass.__dict__:
+            func = klass.__dict__[name]
+            if isinstance(func, (staticmethod, classmethod)):
+                func = func.__func__
+            return func
+    return None
+
+
+def _abstract_names(base) -> List[str]:
+    return sorted(getattr(base, "__abstractmethods__", set()))
+
+
+@pytest.mark.parametrize(
+    ("alias", "module", "name"),
+    MANAGERS,
+    ids=[m[0] for m in MANAGERS],
+)
+def test_the_base_is_actually_abstract(alias: str, module: str, name: str):
+    """``@abstractmethod`` on a plain class is inert: it enforces nothing
+    and populates no ``__abstractmethods__``, so a missing implementation
+    is a silent ``AttributeError`` at call time instead of a refusal at
+    construction."""
+    base = _load(*BASES[alias])
+    assert hasattr(base, "__abstractmethods__"), (
+        f"{base.__name__} declares @abstractmethod but is not an ABC; "
+        "the decorators do nothing"
+    )
+    assert _abstract_names(base), f"{base.__name__} declares no abstract methods"
+
+
+@pytest.mark.parametrize(
+    ("alias", "module", "name"),
+    MANAGERS,
+    ids=[m[0] for m in MANAGERS],
+)
+def test_public_methods_carry_the_base_contract(alias: str, module: str, name: str):
+    """Every abstract method's implementation wraps its base, so the actor
+    reads one contract — the base's — for both the prose and the
+    arguments."""
+    concrete = _load(module, name)
+    base = _load(*BASES[alias])
+    allowed = KNOWN_UNWRAPPED.get(alias, set())
+
+    unwrapped = []
+    for method in _abstract_names(base):
+        impl = _raw(concrete, method)
+        assert impl is not None, f"{name}.{method} is not implemented"
+        if getattr(impl, "__wrapped__", None) is not _raw(base, method):
+            unwrapped.append(method)
+
+    unexpected = sorted(set(unwrapped) - allowed)
+    assert not unexpected, (
+        f"{name}: {unexpected} do not wrap their base contract. Add "
+        f"@functools.wraps(Base{name}.<method>, updated=()) so the actor "
+        "reads the base docstring and the base signature."
+    )
+    # And the ledger stays honest in the other direction: a method that has
+    # since been wrapped must leave the list rather than sit there implying
+    # debt that is already paid.
+    stale = sorted(allowed - set(unwrapped))
+    assert (
+        not stale
+    ), f"{name}: {stale} now wrap their base; drop them from KNOWN_UNWRAPPED"
+
+
+def test_a_publisher_only_keyword_stays_out_of_the_actor_s_schema():
+    """The reason wraps beats copying ``__doc__``.
+
+    ``provenance`` marks a canvas published from a bundle rather than
+    authored in conversation. It is the publisher's business, not the
+    actor's, so it must be callable but invisible — which is precisely
+    what wrapping the base signature gives and what a ``__doc__`` copy
+    does not.
+    """
+    from unify.canvas_manager.canvas_manager import CanvasManager
+
+    exposed = inspect.signature(CanvasManager.create_view).parameters
+    assert "provenance" not in exposed
+    assert "tsx" in exposed and "title" in exposed
+
+    real = inspect.signature(CanvasManager.create_view, follow_wrapped=False).parameters
+    assert "provenance" in real, "still callable by the publisher"
+
+
+def test_wrapped_methods_report_the_base_docstring():
+    """What the primitives layer actually reads."""
+    from unify.canvas_manager.base import BaseCanvasManager
+    from unify.canvas_manager.canvas_manager import CanvasManager
+    from unify.ingestion_manager.base import BaseIngestionManager
+    from unify.ingestion_manager.ingestion_manager import IngestionManager
+
+    for concrete, base, method in (
+        (CanvasManager, BaseCanvasManager, "create_view"),
+        (IngestionManager, BaseIngestionManager, "submit"),
+    ):
+        doc = inspect.getdoc(getattr(concrete, method))
+        assert doc
+        assert doc == inspect.getdoc(getattr(base, method))

--- a/tests/data_manager/test_custom_data.py
+++ b/tests/data_manager/test_custom_data.py
@@ -213,5 +213,130 @@ async def test_sync_custom_data_is_idempotent(
         if (table.get("destination") or "personal") == "personal"
     }
     assert dm.sync_custom(source_tables=source) is True
-    dm._custom_data_synced = False
+    # Clear the per-source memo, not a global flag: the stored hash is what
+    # must short-circuit the second pass.
+    dm._custom_data_synced_sources.clear()
     assert dm.sync_custom(source_tables=source) is False
+
+
+@pytest.mark.requires_orchestra
+@pytest.mark.asyncio
+async def test_two_sources_seed_one_table_without_pruning_each_other(
+    data_manager_factory,
+    custom_data_dir,
+    tmp_path,
+):
+    """The reason the data surface had to be scoped before workflows could
+    reach it.
+
+    Both sources seed the same table. Unscoped, the first one's pass reads
+    every managed row in the context and prunes the other's on the way
+    past — and the other's next pass returns the favour, so the two rows
+    ping-pong forever.
+    """
+    _handle_project("DataManagerCustomSync")
+    dm = data_manager_factory()
+
+    deployment = {
+        context: table
+        for context, table in collect_custom_data(path=custom_data_dir).items()
+        if (table.get("destination") or "personal") == "personal"
+    }
+    workflow_root = tmp_path / "workflow_data"
+    workflow_root.mkdir()
+    _write_table(
+        workflow_root,
+        "CRM/ReferenceCodes",
+        fields={"code": "str", "label": "str"},
+        seed_key="code",
+        rows=[{"code": "W1", "label": "Workflow code"}],
+    )
+    workflow = collect_custom_data(path=workflow_root)
+
+    assert dm.sync_custom_data(source_tables=deployment) is True
+    assert dm.sync_custom_data(source_tables=workflow, managed_by="wf_demo") is True
+
+    codes = {
+        row["code"]: row.get("managed_by")
+        for row in dm.filter("CRM/ReferenceCodes", filter="custom_hash != None")
+    }
+    assert codes == {"A1": "deployment", "W1": "wf_demo"}
+
+    # The deployment reconciles again: its own row is unchanged and the
+    # workflow's is none of its business.
+    dm._custom_data_synced_sources.clear()
+    dm.sync_custom_data(source_tables=deployment)
+    codes = {
+        row["code"]: row.get("managed_by")
+        for row in dm.filter("CRM/ReferenceCodes", filter="custom_hash != None")
+    }
+    assert codes == {"A1": "deployment", "W1": "wf_demo"}
+
+
+@pytest.mark.requires_orchestra
+@pytest.mark.asyncio
+async def test_an_empty_source_prunes_the_tables_it_seeded_last_pass(
+    data_manager_factory,
+    tmp_path,
+):
+    """What an uninstall sends, and why the surface records its tables.
+
+    Rows live in many contexts and the context list comes from the source,
+    so an empty source names no table at all. Every other surface gets its
+    prune for free because its manager reads one context; this one has to
+    remember which tables it seeded, or a workflow's rows outlive it.
+    """
+    _handle_project("DataManagerCustomSync")
+    dm = data_manager_factory()
+
+    root = tmp_path / "wf_tables"
+    root.mkdir()
+    _write_table(
+        root,
+        "CRM/WorkflowSeeded",
+        fields={"code": "str"},
+        seed_key="code",
+        rows=[{"code": "W1"}, {"code": "W2"}],
+    )
+    source = collect_custom_data(path=root)
+
+    assert dm.sync_custom_data(source_tables=source, managed_by="wf_demo") is True
+    assert len(dm.filter("CRM/WorkflowSeeded", filter="custom_hash != None")) == 2
+
+    # Uninstall: the surface is handed nothing at all.
+    assert dm.sync_custom_data(source_tables={}, managed_by="wf_demo") is True
+    assert dm.filter("CRM/WorkflowSeeded", filter="custom_hash != None") == []
+    # The table itself stays — it is shared infrastructure, and the rows
+    # a workflow *produced* are not the bundle's to delete.
+    assert dm._table_exists("CRM/WorkflowSeeded", None)
+
+
+@pytest.mark.requires_orchestra
+@pytest.mark.asyncio
+async def test_a_table_with_no_rows_is_still_created(
+    data_manager_factory,
+    tmp_path,
+):
+    """Schemas-only is the whole point for a bundle: it ships the shape its
+    own job fills. Hashing rows alone made such a source indistinguishable
+    from an empty one, so the pass short-circuited and the table never
+    appeared."""
+    _handle_project("DataManagerCustomSync")
+    dm = data_manager_factory()
+
+    root = tmp_path / "schema_only"
+    root.mkdir()
+    _write_table(
+        root,
+        "CRM/EmptyByDesign",
+        description="Filled at run time, never by the bundle.",
+        fields={"code": "str", "label": "str"},
+        seed_key="code",
+        rows=[],
+    )
+    source = collect_custom_data(path=root)
+    assert source["CRM/EmptyByDesign"]["rows"] == []
+    assert compute_custom_data_hash(source_tables=source) != ""
+
+    assert dm.sync_custom_data(source_tables=source, managed_by="wf_demo") is True
+    assert dm._table_exists("CRM/EmptyByDesign", None)

--- a/tests/workflow_manager/test_bundle_and_fanout.py
+++ b/tests/workflow_manager/test_bundle_and_fanout.py
@@ -245,6 +245,7 @@ def test_registered_specs_match_the_real_sync_signatures():
     """
     import inspect
 
+    from unify.data_manager.data_manager import DataManager
     from unify.function_manager.function_manager import FunctionManager
     from unify.guidance_manager.guidance_manager import GuidanceManager
     from unify.knowledge_manager.knowledge_manager import KnowledgeManager
@@ -256,7 +257,12 @@ def test_registered_specs_match_the_real_sync_signatures():
         "knowledge": KnowledgeManager,
         "tasks": TaskScheduler,
         "functions": FunctionManager,
+        "data": DataManager,
     }
+    assert set(managers) == set(SCOPED_SURFACES), (
+        "a registered surface with no manager here is untested — add it "
+        "rather than letting the loop skip it"
+    )
     for surface, spec in SCOPED_SURFACES.items():
         method = getattr(managers[surface], spec.method)
         params = inspect.signature(method).parameters

--- a/tests/workflow_manager/test_canvas_publish.py
+++ b/tests/workflow_manager/test_canvas_publish.py
@@ -1,0 +1,194 @@
+"""Canvas views are published, never reconciled.
+
+Decision 9 reversed: a bundle ships canvas **source**, and the install
+hands it to CanvasManager's own authoring pipeline — lint, typecheck,
+bundle, render, review — against the kit installed *now*. A pre-built
+artifact in a git bundle would pin a host runtime and break at view time,
+for the user, with nothing failing at plant time.
+
+That means canvas is deliberately outside the reconcile engine, so the
+properties the engine would have given for free have to be pinned here
+instead: identity across reinstalls, an unchanged source costing nothing,
+a failed build reported rather than swallowed, and an uninstall that goes
+through the manager's own delete so the routing token is released.
+"""
+
+from typing import Any, Dict
+
+import pytest
+
+from unify.canvas_manager.simulated import SimulatedCanvasManager
+from unify.workflow_manager.bundle import CanvasSource, WorkflowBundle
+from unify.workflow_manager.workflow_manager import WorkflowManager
+
+VALID_TSX = (
+    'import { Canvas } from "@unity/canvas-kit";\n'
+    "export default function View({ canvas }) {\n"
+    '  return <Canvas><div className="flex flex-col gap-4" /></Canvas>;\n'
+    "}\n"
+)
+
+# Colour is the one rule the canvas linter exists to enforce, because
+# authored TSX never passes through console's lint or its production build.
+OFF_PALETTE_TSX = (
+    'import { Canvas } from "@unity/canvas-kit";\n'
+    "export default function View({ canvas }) {\n"
+    '  return <Canvas><div className="bg-[#ff0000]" /></Canvas>;\n'
+    "}\n"
+)
+
+
+def _bundle(slug: str, *views: CanvasSource) -> WorkflowBundle:
+    return WorkflowBundle(slug=slug, name=slug, canvas=tuple(views))
+
+
+def _view(name: str = "ledger", tsx: str = VALID_TSX, title: str = "Ledger"):
+    return CanvasSource(
+        name=name,
+        tsx=tsx,
+        title=title,
+        description="What is outstanding.",
+        bindings=(
+            {
+                "alias": "rows",
+                "manager": "data",
+                "table": "Data/Finance/Invoices",
+                "args": {"operation": "filter", "limit": 50},
+            },
+        ),
+    )
+
+
+@pytest.fixture
+def manager(monkeypatch) -> tuple[WorkflowManager, SimulatedCanvasManager]:
+    canvas = SimulatedCanvasManager()
+    workflows = WorkflowManager.__new__(WorkflowManager)
+    monkeypatch.setattr(
+        WorkflowManager,
+        "_get_canvas_manager",
+        staticmethod(lambda: canvas),
+    )
+    return workflows, canvas
+
+
+def _rows(canvas: SimulatedCanvasManager) -> list[Dict[str, Any]]:
+    return [record.model_dump() for record in canvas.list_views(limit=50)]
+
+
+def test_installing_publishes_the_view_with_its_provenance(manager):
+    workflows, canvas = manager
+
+    report, failures = workflows._publish_canvases(
+        _bundle("invoice_chaser", _view()),
+        destination=None,
+    )
+
+    assert not failures
+    assert report["ledger"]["status"] == "published"
+    (row,) = _rows(canvas)
+    assert row["title"] == "Ledger"
+    # Written with the row, not stamped after it: a crash between the two
+    # would leave a view nobody owns and a second copy on the next install.
+    assert row["managed_by"] == "invoice_chaser"
+    assert row["custom_key"] == "invoice_chaser/ledger"
+    assert row["custom_hash"]
+
+
+def test_reinstalling_an_unchanged_view_recompiles_nothing(manager):
+    workflows, canvas = manager
+    bundle = _bundle("invoice_chaser", _view())
+
+    workflows._publish_canvases(bundle, destination=None)
+    (first,) = _rows(canvas)
+
+    report, failures = workflows._publish_canvases(bundle, destination=None)
+
+    assert not failures
+    assert report["ledger"]["status"] == "unchanged"
+    # One view, same token: a reinstall must not stack up a second copy,
+    # and the compile is the expensive part of an otherwise cheap pass.
+    (second,) = _rows(canvas)
+    assert second["token"] == first["token"]
+    assert second["updated_at"] == first["updated_at"]
+
+
+def test_a_revised_view_is_updated_in_place(manager):
+    workflows, canvas = manager
+
+    workflows._publish_canvases(_bundle("invoice_chaser", _view()), destination=None)
+    (first,) = _rows(canvas)
+
+    revised = _view(
+        tsx=VALID_TSX.replace("gap-4", "gap-6"),
+        title="Overdue ledger",
+    )
+    report, failures = workflows._publish_canvases(
+        _bundle("invoice_chaser", revised),
+        destination=None,
+    )
+
+    assert not failures
+    assert report["ledger"]["status"] == "updated"
+    (second,) = _rows(canvas)
+    # The token is the URL. Republishing under a new one would break every
+    # place the canvas has been linked from.
+    assert second["token"] == first["token"]
+    assert second["title"] == "Overdue ledger"
+    assert second["custom_hash"] != first["custom_hash"]
+
+
+def test_a_view_that_does_not_compile_is_a_reported_failure(manager):
+    """Not a silent skip: the author needs the linter's words, and the
+    installation records `partial` so a repeat install retries exactly
+    this."""
+    workflows, canvas = manager
+
+    report, failures = workflows._publish_canvases(
+        _bundle("invoice_chaser", _view(tsx=OFF_PALETTE_TSX)),
+        destination=None,
+    )
+
+    assert "ledger" not in report
+    assert "canvas:ledger" in failures
+    assert _rows(canvas) == []
+
+
+def test_uninstalling_deletes_through_the_manager(manager):
+    """Through `delete_view`, which releases the routing token and drops
+    the actions and invocations hanging off it — none of which a prune
+    adapter could do without reimplementing it."""
+    workflows, canvas = manager
+    workflows._publish_canvases(_bundle("invoice_chaser", _view()), destination=None)
+
+    removed = workflows._withdraw_canvases("invoice_chaser")
+
+    assert removed == ["invoice_chaser/ledger"]
+    assert _rows(canvas) == []
+
+
+def test_one_workflow_never_withdraws_another_s_views(manager):
+    workflows, canvas = manager
+    workflows._publish_canvases(_bundle("invoice_chaser", _view()), destination=None)
+    workflows._publish_canvases(
+        _bundle("contract_renewals", _view(name="renewals", title="Renewals")),
+        destination=None,
+    )
+    assert len(_rows(canvas)) == 2
+
+    workflows._withdraw_canvases("invoice_chaser")
+
+    surviving = _rows(canvas)
+    assert [row["custom_key"] for row in surviving] == ["contract_renewals/renewals"]
+
+
+def test_a_bundle_with_no_canvas_does_nothing_at_all(manager):
+    workflows, canvas = manager
+
+    report, failures = workflows._publish_canvases(
+        _bundle("daily_briefing"),
+        destination=None,
+    )
+
+    assert report == {}
+    assert failures == {}
+    assert _rows(canvas) == []

--- a/tests/workflow_manager/test_catalog.py
+++ b/tests/workflow_manager/test_catalog.py
@@ -310,3 +310,119 @@ def test_manifest_declares_its_provisioning_one_shot(tmp_path: Path):
     manifest = (bundle_dir / MANIFEST_FILENAME).read_text()
     (bundle_dir / MANIFEST_FILENAME).write_text(manifest + "install_task: wf/morning\n")
     assert load_bundle(bundle_dir).install_task == "wf/morning"
+
+
+# --------------------------------------------------------------------- #
+# Canvas + data: what a bundle may ship, and what it may not            #
+# --------------------------------------------------------------------- #
+def _write_canvas(bundle_dir: Path, name: str, manifest: dict, tsx: str) -> Path:
+    view_dir = bundle_dir / "canvas" / name
+    view_dir.mkdir(parents=True)
+    (view_dir / "view.json").write_text(json.dumps(manifest) + "\n")
+    (view_dir / "view.tsx").write_text(tsx)
+    return view_dir
+
+
+def test_a_bundle_ships_canvas_source_outside_the_surfaces(tmp_path: Path):
+    """A view is not a synced surface and must not become one.
+
+    It is TypeScript that has to be compiled, rendered and reviewed against
+    the kit installed *now*, and its routing token has a lifecycle the
+    reconcile engine does not own — so it loads onto its own field, where
+    the fan-out cannot reach it.
+    """
+    bundle_dir = _write_bundle(tmp_path)
+    _write_canvas(
+        bundle_dir,
+        "monthly_kpis",
+        {
+            "title": "Monthly KPIs",
+            "description": "Revenue and burn, by month.",
+            "bindings": [{"context": "Finance/Invoices"}],
+            "visibility": "private",
+        },
+        "export default function View() { return null; }\n",
+    )
+
+    bundle = load_bundle(bundle_dir)
+
+    assert "canvas" not in bundle.surfaces
+    assert [view.name for view in bundle.canvas] == ["monthly_kpis"]
+    view = bundle.canvas[0]
+    assert view.title == "Monthly KPIs"
+    assert view.bindings == ({"context": "Finance/Invoices"},)
+    assert view.tsx.startswith("export default")
+    # Identity across reinstalls, and a fingerprint that changes with the
+    # source rather than with the compiled output.
+    assert view.custom_key == "monthly_kpis"
+    first = view.content_hash()
+    assert first == load_bundle(bundle_dir).canvas[0].content_hash()
+    (bundle_dir / "canvas" / "monthly_kpis" / "view.tsx").write_text(
+        "export default 1;",
+    )
+    assert load_bundle(bundle_dir).canvas[0].content_hash() != first
+
+
+def test_a_prebuilt_canvas_is_refused(tmp_path: Path):
+    """The reason decision 9 was reversed. A compiled bundle in a git
+    bundle pins a host runtime: it is built against one kit and planted
+    into whatever host the deployment runs, so it breaks at *view* time,
+    for the user, with nothing failing at plant time."""
+    bundle_dir = _write_bundle(tmp_path)
+    view_dir = _write_canvas(
+        bundle_dir,
+        "monthly_kpis",
+        {"title": "Monthly KPIs"},
+        "export default function View() { return null; }\n",
+    )
+    (view_dir / "bundle.js").write_text("/* compiled elsewhere */")
+
+    with pytest.raises(ValueError, match="ships a built"):
+        load_bundle(bundle_dir)
+
+
+def test_a_canvas_needs_both_its_source_and_its_manifest(tmp_path: Path):
+    bundle_dir = _write_bundle(tmp_path)
+    view_dir = bundle_dir / "canvas" / "orphan"
+    view_dir.mkdir(parents=True)
+    (view_dir / "view.tsx").write_text(
+        "export default function View() { return null; }",
+    )
+
+    with pytest.raises(ValueError, match="no view.json"):
+        load_bundle(bundle_dir)
+
+
+def test_a_bundle_ships_table_schemas_but_never_rows(tmp_path: Path):
+    """A bundle is published verbatim and installed identically by
+    everyone, so rows in it are one author's data handed to every
+    installer. The table is the contract; filling it is the workflow's own
+    job at run time."""
+    bundle_dir = _write_bundle(tmp_path)
+    table_dir = bundle_dir / "data" / "Finance" / "Invoices"
+    table_dir.mkdir(parents=True)
+    (table_dir / "meta.json").write_text(
+        json.dumps(
+            {
+                "description": "Invoices this workflow reconciles.",
+                "fields": {"reference": "str", "amount": "float"},
+                "seed_key": "reference",
+            },
+        )
+        + "\n",
+    )
+
+    bundle = load_bundle(bundle_dir)
+    # Normalised into the Data namespace: a context outside it cannot be
+    # installed to a team and cannot be read by a canvas.
+    assert "Data/Finance/Invoices" in bundle.surfaces["data"]
+    assert bundle.surfaces["data"]["Data/Finance/Invoices"]["rows"] == []
+    assert bundle.surfaces["data"]["Data/Finance/Invoices"]["context"] == (
+        "Data/Finance/Invoices"
+    )
+
+    (table_dir / "rows.jsonl").write_text(
+        json.dumps({"reference": "INV-1", "amount": 10.0}) + "\n",
+    )
+    with pytest.raises(ValueError, match="ship seeded rows"):
+        load_bundle(bundle_dir)

--- a/tests/workflow_manager/test_shelf_acceptance.py
+++ b/tests/workflow_manager/test_shelf_acceptance.py
@@ -25,6 +25,7 @@ import unisdk
 
 from tests.helpers import _handle_project
 from unify.common.context_registry import ContextRegistry
+from unify.data_manager.data_manager import DataManager
 from unify.function_manager.function_manager import FunctionManager
 from unify.guidance_manager.guidance_manager import GuidanceManager
 from unify.knowledge_manager.knowledge_manager import KnowledgeManager
@@ -71,6 +72,7 @@ def live_managers():
                 "Functions/Meta",
             ),
         ),
+        (DataManager, ("Data", "Data/Meta")),
         (WorkflowManager, ("Workflows", "Workflows/Meta")),
     ):
         for name in contexts:
@@ -80,6 +82,7 @@ def live_managers():
     km = KnowledgeManager()
     ts = TaskScheduler()
     fm = FunctionManager()
+    dm = DataManager()
     wm = WorkflowManager()
     register_default_surfaces(
         wm.surfaces,
@@ -87,8 +90,9 @@ def live_managers():
         knowledge_manager=km,
         task_scheduler=ts,
         function_manager=fm,
+        data_manager=dm,
     )
-    yield gm, km, ts, fm, wm
+    yield gm, km, ts, fm, dm, wm
 
     try:
         gm.clear()
@@ -133,7 +137,7 @@ def _sample_params(bundle) -> dict:
 async def test_bundle_full_lifecycle(slug, live_managers, monkeypatch):
     from unify.workflow_manager import requirements as req_module
 
-    gm, km, ts, fm, wm = live_managers
+    gm, km, ts, fm, dm, wm = live_managers
     bundle = load_bundle(SHELF_ROOT / slug)
     wm.register_bundle(bundle)
 
@@ -160,22 +164,52 @@ async def test_bundle_full_lifecycle(slug, live_managers, monkeypatch):
     params = _sample_params(bundle)
     result = wm.install_workflow(slug=slug, params=params)
 
-    assert "failures" not in result
+    # A canvas is compiled at install, against the kit the deployment has.
+    # The harness redirects HOME, so the node toolchain is not findable
+    # here — the same reason this file resolves the shelf from the repo
+    # rather than from ``Path.home()``. Say that out loud rather than
+    # letting a toolchain-less environment read as a broken bundle; the
+    # compile itself is gated at curation time, in unify-deploy.
+    from unify.canvas_manager.ops.build_ops import toolchain_available
 
-    # Every declared requirement is a gallery app with a connect flow, so
-    # with nothing connected each one reports the route that fixes it.
-    # A bundle that named something unconnectable would land here as a
-    # different `via`, which is the authoring mistake worth catching.
-    assert result["connect_required"]["requirements"] == [
-        {
+    reported = dict(result.get("failures") or {})
+    canvas_only = {
+        name: reason for name, reason in reported.items() if name.startswith("canvas:")
+    }
+    if reported and not toolchain_available():
+        assert set(canvas_only) == set(reported), (
+            "only canvas publishing may fail without a toolchain; "
+            f"got {sorted(reported)}"
+        )
+    else:
+        assert not reported
+
+    # Each unmet requirement reports the route that fixes it, and the route
+    # follows the kind the bundle declared: a Workspace is connected in the
+    # profile's own manager and names the secret those flows store, while an
+    # app is connected in the gallery and names nothing. A bundle that got
+    # this wrong would land here as a different `via` — which is exactly the
+    # authoring mistake worth catching, since the UI offers the wrong fix.
+    def _expected(requirement) -> dict:
+        entry = {
             "slug": requirement.slug,
             "name": requirement.name or requirement.slug,
             "connected": False,
-            "via": "connection",
+            "via": "workspace" if requirement.kind == "workspace" else "connection",
         }
-        for requirement in bundle.requirements
+        if requirement.kind == "workspace":
+            entry["missing_secrets"] = list(requirement.required_secrets)
+        return entry
+
+    assert result["connect_required"]["requirements"] == [
+        _expected(requirement) for requirement in bundle.requirements
     ]
-    assert wm.get_workflow(slug=slug)["status"] == "needs_connection"
+    # `partial` outranks `needs_connection` — a surface that failed is the
+    # more urgent fact — so a bundle whose canvas could not compile here
+    # reports that instead. Both are correct; which one depends on whether
+    # anything actually failed.
+    expected_status = "partial" if reported else "needs_connection"
+    assert wm.get_workflow(slug=slug)["status"] == expected_status
 
     task_rows = _rows(ts._ctx, slug)
     assert len(task_rows) == len(bundle.surfaces.get("tasks") or {})
@@ -200,16 +234,36 @@ async def test_bundle_full_lifecycle(slug, live_managers, monkeypatch):
     )
     assert all(row["workflows"] == [slug] for row in function_rows)
 
+    # Tables the bundle declares exist, and hold nothing: a bundle ships the
+    # shape its own job fills, never the contents.
+    for context in bundle.surfaces.get("data") or {}:
+        assert dm._table_exists(context, None), f"{context} was not created"
+        assert dm.filter(context, filter="custom_hash != None") == []
+
     # ── The connections land: reinstall is the arm-on-connect path, and
     # omitting params keeps the recorded settings.
     connected = frozenset(
         str(requirement.slug).strip().lower().replace("-", "_")
         for requirement in bundle.requirements
+        if requirement.kind != "workspace"
     )
     monkeypatch.setattr(
         req_module.RequirementResolver,
         "connected_apps",
         lambda self: connected,
+    )
+    # A Workspace is not connected by a gallery row: its signal is the
+    # refresh-token secret the profile and onboarding flows store.
+    workspace_secrets = frozenset(
+        secret
+        for requirement in bundle.requirements
+        if requirement.kind == "workspace"
+        for secret in requirement.required_secrets
+    )
+    monkeypatch.setattr(
+        req_module.RequirementResolver,
+        "keyset",
+        lambda self: workspace_secrets,
     )
     result = wm.install_workflow(slug=slug)
 
@@ -217,7 +271,7 @@ async def test_bundle_full_lifecycle(slug, live_managers, monkeypatch):
     assert len(result["tasks_armed"]) == len(task_rows)
     assert all(row["enabled"] is True for row in _rows(ts._ctx, slug))
     record = wm.get_workflow(slug=slug)
-    assert record["status"] == "active"
+    assert record["status"] == ("partial" if reported else "active")
     assert record["params"] == params
 
     # The runtime read every planted task's description points at.

--- a/unify/canvas_manager/base.py
+++ b/unify/canvas_manager/base.py
@@ -10,7 +10,7 @@ IMPORTANT: Do not duplicate docstrings in concrete implementations.
 
 from __future__ import annotations
 
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional
 
 from unify.canvas_manager.types.action import CanvasAction, CanvasInvocationRecord
@@ -24,7 +24,7 @@ from unify.canvas_manager.types.view import (
 DEFAULT_VISIBILITY = "private"
 
 
-class BaseCanvasManager:
+class BaseCanvasManager(ABC):
     """
     Public contract for authoring generative user interfaces.
 

--- a/unify/canvas_manager/canvas_manager.py
+++ b/unify/canvas_manager/canvas_manager.py
@@ -14,6 +14,7 @@ viewer fails here instead, with the compiler's own diagnostics.
 
 from __future__ import annotations
 
+import functools
 import json
 import logging
 from datetime import datetime, timezone
@@ -312,6 +313,7 @@ class CanvasManager(BaseCanvasManager):
     # The public methods below inherit their documentation from
     # BaseCanvasManager; see that module for the contract.
 
+    @functools.wraps(BaseCanvasManager.create_view, updated=())
     def create_view(
         self,
         tsx: str,
@@ -324,7 +326,16 @@ class CanvasManager(BaseCanvasManager):
         destination: Optional[str] = None,
         visibility: str = DEFAULT_VISIBILITY,
         review: bool = True,
+        provenance: Optional[Dict[str, str]] = None,
     ) -> CanvasResult:
+        """Compile, review and publish one view.
+
+        *provenance* marks a view published from a source rather than
+        authored in conversation — ``custom_key``, ``custom_hash`` and
+        ``managed_by``. Written in the same insert as the row: stamping it
+        afterwards would leave a crash-window in which the view exists with
+        no owner, and the next install would publish a second copy of it.
+        """
         build, bundle = self._build(tsx)
         if not build.ok:
             return CanvasResult(title=title, build=build, error="Canvas build failed.")
@@ -418,6 +429,7 @@ class CanvasManager(BaseCanvasManager):
             build_json=build.model_dump_json(),
             created_at=now,
             updated_at=now,
+            **(provenance or {}),
         )
 
         dm = self._get_dm()
@@ -440,6 +452,7 @@ class CanvasManager(BaseCanvasManager):
             warning=warning,
         )
 
+    @functools.wraps(BaseCanvasManager.update_view, updated=())
     def update_view(
         self,
         token: str,
@@ -452,7 +465,14 @@ class CanvasManager(BaseCanvasManager):
         actions: Optional[List[CanvasAction]] = None,
         visibility: Optional[str] = None,
         review: bool = True,
+        provenance: Optional[Dict[str, str]] = None,
     ) -> CanvasResult:
+        """Revise a published view.
+
+        *provenance* re-stamps the source fingerprint in the same write as
+        the revision, so a republish that lands is never recorded as
+        up-to-date before the new source actually did.
+        """
         existing, context = self._find_row(VIEWS_TABLE, token)
         if existing is None:
             return CanvasResult(token=token, error=f"Canvas {token!r} not found.")
@@ -557,6 +577,9 @@ class CanvasManager(BaseCanvasManager):
             except ValueError as error:
                 return CanvasResult(token=token, error=str(error))
 
+        if provenance:
+            updates.update(provenance)
+
         self._get_dm().update_rows(context, updates, filter=f"token == '{token}'")
 
         if visibility is not None:
@@ -579,6 +602,7 @@ class CanvasManager(BaseCanvasManager):
             review=review_report,
         )
 
+    @functools.wraps(BaseCanvasManager.refresh_props, updated=())
     def refresh_props(self, token: str, *, props: Dict[str, Any]) -> CanvasResult:
         existing, context = self._find_row(VIEWS_TABLE, token)
         if existing is None:
@@ -623,10 +647,12 @@ class CanvasManager(BaseCanvasManager):
 
     # ── retrieval ─────────────────────────────────────────────────────────
 
+    @functools.wraps(BaseCanvasManager.get_view, updated=())
     def get_view(self, token: str) -> Optional[CanvasViewRecord]:
         row, _ = self._find_row(VIEWS_TABLE, token)
         return CanvasViewRecord.model_validate(row) if row else None
 
+    @functools.wraps(BaseCanvasManager.list_views, updated=())
     def list_views(
         self,
         *,
@@ -651,6 +677,7 @@ class CanvasManager(BaseCanvasManager):
 
         return records[:limit]
 
+    @functools.wraps(BaseCanvasManager.delete_view, updated=())
     def delete_view(self, token: str, *, destination: Optional[str] = None) -> bool:
         row, context = self._find_row(VIEWS_TABLE, token)
         if row is None:
@@ -672,6 +699,7 @@ class CanvasManager(BaseCanvasManager):
 
     # ── inspection ────────────────────────────────────────────────────────
 
+    @functools.wraps(BaseCanvasManager.preview, updated=())
     def preview(self, token: str) -> ReviewReport:
         record = self.get_view(token)
         if record is None:
@@ -692,6 +720,7 @@ class CanvasManager(BaseCanvasManager):
             intent=f"{record.title}. {record.description or ''}".strip(),
         )
 
+    @functools.wraps(BaseCanvasManager.run_invocation, updated=())
     def run_invocation(
         self,
         invocation_id: int,
@@ -945,6 +974,7 @@ class CanvasManager(BaseCanvasManager):
         with ThreadPoolExecutor(max_workers=1, thread_name_prefix="canvas-ask") as pool:
             return pool.submit(lambda: asyncio.run(actor.act(prompt))).result()
 
+    @functools.wraps(BaseCanvasManager.list_invocations, updated=())
     def list_invocations(
         self,
         token: str,
@@ -966,20 +996,3 @@ class CanvasManager(BaseCanvasManager):
 
         records.sort(key=lambda record: record.created_at or "", reverse=True)
         return records[:limit]
-
-
-# Attach the base contract's documentation to the concrete methods, so the
-# caller reads one contract regardless of which implementation is active.
-for _name in (
-    "create_view",
-    "update_view",
-    "refresh_props",
-    "get_view",
-    "list_views",
-    "delete_view",
-    "preview",
-    "run_invocation",
-    "list_invocations",
-):
-    _base_method = getattr(BaseCanvasManager, _name)
-    getattr(CanvasManager, _name).__doc__ = _base_method.__doc__

--- a/unify/canvas_manager/simulated.py
+++ b/unify/canvas_manager/simulated.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import functools
 import hashlib
 import json
+import re
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
@@ -37,6 +38,31 @@ SIMULATED_KIT_VERSION = "0.1.0-sim"
 
 def _now() -> str:
     return datetime.now(timezone.utc).isoformat()
+
+
+_EQUALITY = re.compile(r"^\s*(\w+)\s*==\s*['\"]?([^'\"]*)['\"]?\s*$")
+
+
+def _matches(record: CanvasViewRecord, expression: str) -> bool:
+    """Stand in for the backend's predicate push-down.
+
+    Two shapes, because two shapes are what callers use: an exact
+    ``field == 'value'`` — how a workflow finds the views it published, by
+    ``managed_by`` — and otherwise a substring over the text a human would
+    search. Anything richer belongs in the backend, not in a simulator
+    pretending to be one.
+    """
+    equality = _EQUALITY.match(expression)
+    if equality:
+        field, expected = equality.groups()
+        return str(getattr(record, field, "") or "") == expected
+
+    needle = expression.strip("'\" ").lower()
+    return (
+        needle in (record.title or "").lower()
+        or needle in (record.description or "").lower()
+        or needle in (record.custom_key or "").lower()
+    )
 
 
 class SimulatedCanvasManager(BaseCanvasManager):
@@ -100,6 +126,7 @@ class SimulatedCanvasManager(BaseCanvasManager):
         destination: Optional[str] = None,
         visibility: str = DEFAULT_VISIBILITY,
         review: bool = True,
+        provenance: Optional[Dict[str, str]] = None,
     ) -> CanvasResult:
         build = self._compile(tsx)
         if not build.ok:
@@ -132,6 +159,7 @@ class SimulatedCanvasManager(BaseCanvasManager):
             build_json=build.model_dump_json(),
             created_at=now,
             updated_at=now,
+            **(provenance or {}),
         )
 
         self._views[token] = record
@@ -160,6 +188,7 @@ class SimulatedCanvasManager(BaseCanvasManager):
         actions: Optional[List[CanvasAction]] = None,
         visibility: Optional[str] = None,
         review: bool = True,
+        provenance: Optional[Dict[str, str]] = None,
     ) -> CanvasResult:
         record = self._views.get(token)
         if record is None:
@@ -215,6 +244,9 @@ class SimulatedCanvasManager(BaseCanvasManager):
             except ValueError as error:
                 return CanvasResult(token=token, error=str(error))
 
+        if provenance:
+            updates.update(provenance)
+
         self._views[token] = record.model_copy(update=updates)
 
         return CanvasResult(
@@ -261,15 +293,7 @@ class SimulatedCanvasManager(BaseCanvasManager):
     ) -> List[CanvasViewRecord]:
         records = list(self._views.values())
         if filter:
-            # Substring match is enough to exercise callers; the real
-            # implementation pushes the predicate into the backend.
-            needle = filter.strip("'\" ").lower()
-            records = [
-                record
-                for record in records
-                if needle in (record.title or "").lower()
-                or needle in (record.description or "").lower()
-            ]
+            records = [record for record in records if _matches(record, filter)]
         return [
             record.model_copy(update={"tsx_source": ""}) for record in records[:limit]
         ]

--- a/unify/canvas_manager/types/view.py
+++ b/unify/canvas_manager/types/view.py
@@ -117,10 +117,20 @@ class CanvasViewRow(AuthoredRow):
     created_at: Optional[str] = None
     updated_at: Optional[str] = None
 
-    # Deployment-defined canvases: merge key and content hash, matching the
-    # convention the other managers use for source-seeded rows.
+    # Source-defined canvases: merge key, content hash and which source
+    # published it, matching the convention the other managers use for
+    # source-seeded rows.
+    #
+    # Canvas is not custom-synced — a view is compiled, rendered and
+    # reviewed against the installed kit, and its routing token has a
+    # lifecycle the reconcile engine does not own — so these are written by
+    # the publisher rather than stamped by the engine. They carry the same
+    # meaning: ``custom_key`` is identity, ``custom_hash`` says whether a
+    # republish would change anything, ``managed_by`` says who may revise
+    # or delete it.
     custom_key: Optional[str] = None
     custom_hash: Optional[str] = None
+    managed_by: Optional[str] = None
 
 
 class CanvasViewRecord(CanvasViewRow):

--- a/unify/data_manager/custom_data.py
+++ b/unify/data_manager/custom_data.py
@@ -250,19 +250,42 @@ def collect_data_from_directories(
 def compute_custom_data_hash(
     source_tables: Optional[Dict[str, Dict[str, Any]]] = None,
 ) -> str:
-    """Compute an aggregate hash of custom data rows across all tables."""
+    """Aggregate fingerprint of the tables a source declares and their rows.
+
+    Covers the schema as well as the rows, because a table may legitimately
+    declare no rows at all — a workflow ships a table for its own job to
+    fill, and the install has to create it. Hashing rows alone made such a
+    source indistinguishable from an empty one, and both from the "never
+    synced" sentinel, so the pass short-circuited and the table was never
+    created.
+    """
     tables = source_tables if source_tables is not None else {}
-    row_hashes: List[str] = []
+    parts: List[str] = []
     for context in sorted(tables.keys()):
         spec = tables[context]
+        parts.append(
+            "table:"
+            + json.dumps(
+                {
+                    "context": context,
+                    "description": spec.get("description", ""),
+                    "fields": spec.get("fields") or {},
+                    "seed_key": spec.get("seed_key", ""),
+                    "unique_keys": spec.get("unique_keys"),
+                    "auto_counting": spec.get("auto_counting"),
+                },
+                sort_keys=True,
+                default=str,
+            ),
+        )
         for row in spec.get("rows", []):
             custom_hash = row.get("custom_hash")
             custom_key = row.get("custom_key")
             if custom_hash and custom_key:
-                row_hashes.append(f"{custom_key}:{custom_hash}")
-    if not row_hashes:
+                parts.append(f"{custom_key}:{custom_hash}")
+    if not parts:
         return ""
-    combined = "|".join(row_hashes)
+    combined = "|".join(parts)
     return hashlib.sha256(combined.encode()).hexdigest()[:16]
 
 

--- a/unify/data_manager/data_manager.py
+++ b/unify/data_manager/data_manager.py
@@ -11,6 +11,7 @@ Docstrings are inherited from BaseDataManager via @functools.wraps.
 from __future__ import annotations
 
 import functools
+import json
 import logging
 from contextlib import contextmanager
 from threading import RLock
@@ -72,9 +73,12 @@ from unify.common.federated_search import (
     reduce_rows,
 )
 from unify.common.custom_sync import (
+    MANAGED_BY_DEPLOYMENT,
     CustomSyncAdapter,
     CustomSyncPartialFailure,
+    managed_rows_filter,
     reconcile_custom_rows,
+    stored_hash_field,
 )
 from unify.common.embed_utils import list_private_fields
 from unify.common.filter_utils import normalize_filter_expr
@@ -148,8 +152,12 @@ class DataManager(BaseDataManager):
         super().__init__()
         self._base_ctx = ContextRegistry.get_context(self, "Data")
         self._meta_ctx = ContextRegistry.get_context(self, DATA_META_TABLE)
-        self._custom_data_synced = False
-        self._custom_data_synced_contexts: set[str] = set()
+        # (meta_context, managed_by) pairs whose custom data sync already
+        # ran this process. Keyed by source, not a single flag: the
+        # deployment and each installed workflow reconcile disjoint row
+        # sets, and one flag would let whichever synced first suppress the
+        # others' passes entirely.
+        self._custom_data_synced_sources: set[tuple[str, str]] = set()
         self._destination_context_lock = RLock()
         self._destination_write_scoped = False
 
@@ -1471,7 +1479,12 @@ class DataManager(BaseDataManager):
         meta_context = self._meta_context_for_destination(destination)
         return meta_context, destination in (None, "personal")
 
-    def _get_stored_custom_data_hash(self) -> str:
+    def _get_stored_custom_data_hash(
+        self,
+        managed_by: str = MANAGED_BY_DEPLOYMENT,
+    ) -> str:
+        """Retrieve one source's stored custom data hash."""
+        field = stored_hash_field("custom_data_hash", managed_by)
         try:
             logs = unisdk.get_logs(
                 context=self._meta_ctx,
@@ -1479,12 +1492,19 @@ class DataManager(BaseDataManager):
                 limit=1,
             )
             if logs:
-                return logs[0].entries.get("custom_data_hash", "") or ""
+                return logs[0].entries.get(field, "") or ""
         except Exception as exc:
             logger.warning("Failed to read custom data hash: %s", exc)
         return ""
 
-    def _store_custom_data_hash(self, hash_value: str) -> None:
+    def _store_custom_data_hash(
+        self,
+        hash_value: str,
+        *,
+        managed_by: str = MANAGED_BY_DEPLOYMENT,
+    ) -> None:
+        """Store one source's custom data hash in the Meta context."""
+        field = stored_hash_field("custom_data_hash", managed_by)
         try:
             logs = unisdk.get_logs(
                 context=self._meta_ctx,
@@ -1495,17 +1515,83 @@ class DataManager(BaseDataManager):
                 unisdk.update_logs(
                     context=self._meta_ctx,
                     logs=[logs[0].id],
-                    entries={"custom_data_hash": hash_value},
+                    entries={field: hash_value},
                     overwrite=True,
                 )
             else:
                 unity_create_logs(
                     context=self._meta_ctx,
-                    entries=[{"meta_id": 1, "custom_data_hash": hash_value}],
+                    entries=[{"meta_id": 1, field: hash_value}],
                     stamp_authoring=True,
                 )
         except Exception as exc:
             logger.warning("Failed to store custom data hash: %s", exc)
+
+    def _get_stored_custom_data_contexts(
+        self,
+        managed_by: str = MANAGED_BY_DEPLOYMENT,
+    ) -> List[str]:
+        """Tables this source seeded on its last pass.
+
+        Rows live in many contexts and the context list comes from the
+        source, so an empty source names no tables — which is exactly what
+        an uninstall sends. Without this record its prune would reach
+        nothing and the workflow's rows would outlive it.
+        """
+        field = stored_hash_field("custom_data_contexts", managed_by)
+        try:
+            logs = unisdk.get_logs(
+                context=self._meta_ctx,
+                filter="meta_id == 1",
+                limit=1,
+            )
+            if not logs:
+                return []
+            raw = logs[0].entries.get(field)
+        except Exception as exc:
+            logger.warning("Failed to read custom data contexts: %s", exc)
+            return []
+        if isinstance(raw, list):
+            return [str(item) for item in raw]
+        if isinstance(raw, str) and raw.strip():
+            try:
+                parsed = json.loads(raw)
+            except ValueError:
+                return []
+            if isinstance(parsed, list):
+                return [str(item) for item in parsed]
+        return []
+
+    def _store_custom_data_contexts(
+        self,
+        contexts: List[str],
+        *,
+        managed_by: str = MANAGED_BY_DEPLOYMENT,
+    ) -> None:
+        """Record which tables this source now owns rows in."""
+        field = stored_hash_field("custom_data_contexts", managed_by)
+        value = json.dumps(sorted(contexts))
+        try:
+            logs = unisdk.get_logs(
+                context=self._meta_ctx,
+                filter="meta_id == 1",
+                limit=1,
+            )
+            if logs:
+                unisdk.update_logs(
+                    context=self._meta_ctx,
+                    logs=[logs[0].id],
+                    entries={field: value},
+                    overwrite=True,
+                )
+            else:
+                unity_create_logs(
+                    context=self._meta_ctx,
+                    entries=[{"meta_id": 1, field: value}],
+                    stamp_authoring=True,
+                )
+        except Exception as exc:
+            logger.warning("Failed to store custom data contexts: %s", exc)
 
     def _table_exists(
         self,
@@ -1642,10 +1728,20 @@ class DataManager(BaseDataManager):
         context: str,
         custom_key: str,
         destination: str | None,
+        managed_by: str = MANAGED_BY_DEPLOYMENT,
     ) -> None:
+        """Prune one managed row, scoped to the source that owns it.
+
+        Unscoped, a workflow's prune would delete the deployment's row of
+        the same key from the same table — the two sources share the
+        context and only ``managed_by`` tells them apart.
+        """
         self.delete_rows(
             context,
-            filter=f"custom_key == '{custom_key}' and custom_hash != None",
+            filter=(
+                f"custom_key == '{custom_key}' and "
+                f"{managed_rows_filter(managed_by)}"
+            ),
             destination=destination,
         )
 
@@ -1654,8 +1750,16 @@ class DataManager(BaseDataManager):
         *,
         source_tables: Optional[Dict[str, Dict[str, Any]]] = None,
         destination: str | None = None,
+        managed_by: str = MANAGED_BY_DEPLOYMENT,
     ) -> bool:
-        """Ensure deployment-defined data rows match source definitions."""
+        """Ensure source-defined data rows match their definitions.
+
+        Reconciles only the rows *managed_by* owns; rows written into the
+        same tables by other sources are neither read nor pruned. Table
+        *creation* is deliberately not scoped — a table is shared
+        infrastructure that any source may need to exist, and the first
+        one to need it creates it.
+        """
         try:
             meta_context, is_personal = self._sync_destination_contexts(destination)
         except ToolErrorException as exc:
@@ -1674,22 +1778,17 @@ class DataManager(BaseDataManager):
             expected_hash = compute_custom_data_hash(
                 source_tables=source_tables,
             )
-            current_hash = self._get_stored_custom_data_hash()
-            already_synced = (
-                self._custom_data_synced
-                if is_personal
-                else meta_context in self._custom_data_synced_contexts
-            )
+            current_hash = self._get_stored_custom_data_hash(managed_by)
+            synced_key = (meta_context, managed_by)
 
-            if already_synced and current_hash == expected_hash:
+            if synced_key in self._custom_data_synced_sources and (
+                current_hash == expected_hash
+            ):
                 return False
 
             if current_hash == expected_hash:
                 logger.debug("Custom data hash matches, skipping sync")
-                if is_personal:
-                    self._custom_data_synced = True
-                else:
-                    self._custom_data_synced_contexts.add(meta_context)
+                self._custom_data_synced_sources.add(synced_key)
                 return False
 
             logger.info(
@@ -1700,29 +1799,43 @@ class DataManager(BaseDataManager):
 
             failures: Dict[str, BaseException] = {}
 
-            for context, table_spec in source_tables.items():
+            # Every table this source has to answer for, not just the ones
+            # its current definition mentions. A table it seeded last pass
+            # and has since dropped — and every table it owned before an
+            # uninstall sent an empty source — must still get a pass, or
+            # its rows outlive the source that put them there. This is the
+            # same rule the destination loop follows: reconcile per table
+            # *under consideration*, never per table merely observed.
+            previous = self._get_stored_custom_data_contexts(managed_by)
+            for context in sorted(set(source_tables) | set(previous)):
+                table_spec = source_tables.get(context) or {}
                 rows = table_spec.get("rows", [])
-                if not rows:
-                    continue
+                declared = context in source_tables
                 seed_key = table_spec.get("seed_key")
-                if not seed_key:
+                if declared and not seed_key:
                     logger.warning(
                         "Data table %s has no seed_key, skipping",
                         context,
                     )
                     continue
 
-                if not self._table_exists(context, destination):
-                    unique_keys = table_spec.get("unique_keys")
-                    auto_counting = table_spec.get("auto_counting")
+                exists = self._table_exists(context, destination)
+                if declared and not exists:
+                    # A table with no rows is still created: a bundle may
+                    # ship the schema for its own job to fill, and the
+                    # install is what has to make the table exist.
                     self.create_table(
                         context,
                         description=table_spec.get("description"),
                         fields=table_spec.get("fields"),
-                        unique_keys=unique_keys,
-                        auto_counting=auto_counting,
+                        unique_keys=table_spec.get("unique_keys"),
+                        auto_counting=table_spec.get("auto_counting"),
                         destination=destination,
                     )
+                elif not exists:
+                    # A dropped table nobody recreated: nothing to prune,
+                    # and creating it to prune it would be absurd.
+                    continue
 
                 source_rows = {
                     str(row["custom_key"]): row for row in rows if row.get("custom_key")
@@ -1733,8 +1846,9 @@ class DataManager(BaseDataManager):
                         adapter=_DataRowSyncAdapter(
                             self,
                             context=context,
-                            seed_key=seed_key,
+                            seed_key=seed_key or "",
                             destination=destination,
+                            managed_by=managed_by,
                         ),
                     )
                 except CustomSyncPartialFailure as exc:
@@ -1745,19 +1859,28 @@ class DataManager(BaseDataManager):
             if failures:
                 raise CustomSyncPartialFailure("data", failures)
 
-            self._store_custom_data_hash(expected_hash)
-            if is_personal:
-                self._custom_data_synced = True
-            else:
-                self._custom_data_synced_contexts.add(meta_context)
+            self._store_custom_data_hash(expected_hash, managed_by=managed_by)
+            self._store_custom_data_contexts(
+                sorted(source_tables),
+                managed_by=managed_by,
+            )
+            self._custom_data_synced_sources.add(synced_key)
             return True
 
     def sync_custom(
         self,
         *,
         source_tables: Optional[Dict[str, Dict[str, Any]]] = None,
+        managed_by: str = MANAGED_BY_DEPLOYMENT,
     ) -> bool:
-        """Sync custom data from pre-collected sources across destinations."""
+        """Sync custom data from pre-collected sources across destinations.
+
+        Groups by the destination each table declares, so it never reaches
+        the engine for a destination the source does not mention. Workflow
+        installs drive ``sync_custom_data`` directly instead: an uninstall
+        passes an empty source, which resolves to zero destinations here
+        and would prune nothing.
+        """
         if source_tables is None:
             source_tables = {}
 
@@ -1772,12 +1895,19 @@ class DataManager(BaseDataManager):
             changed |= self.sync_custom_data(
                 source_tables=tables,
                 destination=destination_arg,
+                managed_by=managed_by,
             )
         return changed
 
 
 class _DataRowSyncAdapter(CustomSyncAdapter):
-    """Storage mechanics for one custom data table's row reconcile."""
+    """Storage mechanics for one custom data table's row reconcile.
+
+    Scoped to one ``managed_by``: the deployment and every installed
+    workflow may seed rows into the same table, and the reconcile loop
+    prunes every managed row whose key left the source. An unscoped read
+    would hand one source its siblings' rows and delete them.
+    """
 
     kind = "data"
 
@@ -1788,11 +1918,13 @@ class _DataRowSyncAdapter(CustomSyncAdapter):
         context: str,
         seed_key: str,
         destination: str | None,
+        managed_by: str = MANAGED_BY_DEPLOYMENT,
     ) -> None:
         self._manager = manager
         self._context = context
         self._seed_key = seed_key
         self._destination = destination
+        self.managed_by = managed_by
 
     def live_rows(self) -> List[Dict[str, Any]]:
         resolved = self._manager._resolve_context_for_write(
@@ -1801,7 +1933,7 @@ class _DataRowSyncAdapter(CustomSyncAdapter):
         )
         return filter_impl(
             resolved,
-            filter="custom_hash != None",
+            filter=managed_rows_filter(self.managed_by),
             limit=1000,
         )
 
@@ -1824,7 +1956,9 @@ class _DataRowSyncAdapter(CustomSyncAdapter):
     ) -> None:
         self._manager._update_custom_row(
             context=self._context,
-            row_filter=f"custom_key == {key!r} and custom_hash != None",
+            row_filter=(
+                f"custom_key == {key!r} and " f"{managed_rows_filter(self.managed_by)}"
+            ),
             row_data=fields,
             destination=self._destination,
         )
@@ -1834,6 +1968,7 @@ class _DataRowSyncAdapter(CustomSyncAdapter):
             context=self._context,
             custom_key=key,
             destination=self._destination,
+            managed_by=self.managed_by,
         )
 
     def find_adoptable(
@@ -1841,6 +1976,17 @@ class _DataRowSyncAdapter(CustomSyncAdapter):
         key: str,
         fields: Dict[str, Any],
     ) -> Optional[Dict[str, Any]]:
+        """Claim an unmanaged row already carrying this entry's seed value
+        rather than inserting a second copy of the same fact.
+
+        Deployment-only. The probe matches on the seed column alone, so
+        any other source using it would claim a row the deployment (or a
+        sibling workflow) hand-seeded — restamping it and ping-ponging
+        ownership on every pass. A workflow inserts instead, and its row
+        is distinguishable by ``managed_by`` from the first write.
+        """
+        if self.managed_by != MANAGED_BY_DEPLOYMENT:
+            return None
         seed_value = str(fields.get(self._seed_key, ""))
         return self._manager._find_unmanaged_row_by_seed(
             context=self._context,

--- a/unify/ingestion_manager/ingestion_manager.py
+++ b/unify/ingestion_manager/ingestion_manager.py
@@ -27,6 +27,7 @@ what happened.
 
 from __future__ import annotations
 
+import functools
 import logging
 import re
 import secrets
@@ -269,6 +270,7 @@ class IngestionManager(BaseIngestionManager):
 
     # ── submitting ────────────────────────────────────────────────────────
 
+    @functools.wraps(BaseIngestionManager.submit, updated=())
     def submit(
         self,
         source: IngestionSource,
@@ -1041,6 +1043,7 @@ class IngestionManager(BaseIngestionManager):
 
     # ── observing ─────────────────────────────────────────────────────────
 
+    @functools.wraps(BaseIngestionManager.get_status, updated=())
     def get_status(self, run_id: str) -> RunStatus:
         row, runs_context = self._find_run(run_id)
         if row is None:
@@ -1181,6 +1184,7 @@ class IngestionManager(BaseIngestionManager):
                     break
         return sorted(events, key=lambda event: event.get("at") or "")
 
+    @functools.wraps(BaseIngestionManager.get_logs, updated=())
     def get_logs(
         self,
         run_id: str,
@@ -1206,6 +1210,7 @@ class IngestionManager(BaseIngestionManager):
             for event in window
         ]
 
+    @functools.wraps(BaseIngestionManager.wait, updated=())
     def wait(self, run_id: str, *, timeout_s: Optional[float] = None) -> RunStatus:
         deadline = None if timeout_s is None else time.monotonic() + timeout_s
         # Backs off to a second so a long run does not spend the wait hammering
@@ -1220,6 +1225,7 @@ class IngestionManager(BaseIngestionManager):
             time.sleep(interval)
             interval = min(interval * 1.5, 1.0)
 
+    @functools.wraps(BaseIngestionManager.list_runs, updated=())
     def list_runs(
         self,
         *,
@@ -1257,6 +1263,7 @@ class IngestionManager(BaseIngestionManager):
 
     # ── recovering ────────────────────────────────────────────────────────
 
+    @functools.wraps(BaseIngestionManager.retry, updated=())
     def retry(self, run_id: str, *, only: RetryScope = "dlq") -> RetryResult:
         row, runs_context = self._find_run(run_id)
         if row is None:
@@ -1357,12 +1364,15 @@ class IngestionManager(BaseIngestionManager):
             )
         return url
 
+    @functools.wraps(BaseIngestionManager.cancel, updated=())
     def cancel(self, run_id: str) -> bool:
         return self._transition(run_id, "cancelled", "Cancelled by request.")
 
+    @functools.wraps(BaseIngestionManager.pause, updated=())
     def pause(self, run_id: str) -> bool:
         return self._transition(run_id, "paused", "Paused by request.")
 
+    @functools.wraps(BaseIngestionManager.resume, updated=())
     def resume(self, run_id: str) -> bool:
         row, runs_context = self._find_run(run_id)
         if row is None or row.get("state") != "paused":

--- a/unify/workflow_manager/bundle.py
+++ b/unify/workflow_manager/bundle.py
@@ -121,6 +121,55 @@ class Surface:
 
 
 @dataclass(frozen=True)
+class CanvasSource:
+    """One view a bundle ships, as the author wrote it.
+
+    ``name`` is the directory it came from and, with the slug, its stable
+    identity across reinstalls — the published row carries
+    ``<slug>/<name>`` as its ``custom_key`` so a repeat install revises the
+    view it published last time instead of stacking up a second one.
+    """
+
+    name: str
+    tsx: str
+    title: str
+    description: str = ""
+    bindings: tuple[Dict[str, Any], ...] = ()
+    props: Dict[str, Any] = field(default_factory=dict)
+    actions: tuple[Dict[str, Any], ...] = ()
+    visibility: str = "private"
+
+    @property
+    def custom_key(self) -> str:
+        return self.name
+
+    def content_hash(self) -> str:
+        """Fingerprint of everything a republish would change.
+
+        Compiled output is deliberately excluded: the same source against a
+        newer kit is a different bundle, and that is the kit's business to
+        decide at build time, not a reason to consider the source changed.
+        """
+        import hashlib
+        import json as _json
+
+        payload = _json.dumps(
+            {
+                "tsx": self.tsx,
+                "title": self.title,
+                "description": self.description,
+                "bindings": list(self.bindings),
+                "props": self.props,
+                "actions": list(self.actions),
+                "visibility": self.visibility,
+            },
+            sort_keys=True,
+            default=str,
+        )
+        return hashlib.sha256(payload.encode()).hexdigest()[:16]
+
+
+@dataclass(frozen=True)
 class WorkflowRequirement:
     """One integration a workflow needs connected before its jobs may run.
 
@@ -221,6 +270,23 @@ class WorkflowBundle:
     """Assistant capabilities the workflow needs beyond connected apps,
     e.g. ``"computer"`` or ``"filesystem"``. Declared for the catalogue;
     not gated at install."""
+
+    canvas: tuple["CanvasSource", ...] = ()
+    """Views this bundle ships as **source**, deliberately outside
+    :attr:`surfaces`.
+
+    A canvas is not custom-synced and never will be. It is real TypeScript
+    that has to be linted, typechecked, bundled, rendered and reviewed
+    against the canvas kit installed *now*, and its routing token has a
+    lifecycle the reconcile engine has no business owning. Shipping a
+    pre-built bundle instead would pin a host runtime: the host serves
+    versioned runtimes, so a view compiled against one kit and planted into
+    another breaks at *view* time, for the user, with nothing failing at
+    plant time to warn anyone.
+
+    So the install hands this to CanvasManager's own authoring pipeline and
+    uninstall deletes through its own delete, which already releases the
+    token."""
 
     def __post_init__(self) -> None:
         if not self.slug:

--- a/unify/workflow_manager/catalog.py
+++ b/unify/workflow_manager/catalog.py
@@ -23,13 +23,14 @@ catalogue.
 
 from __future__ import annotations
 
+import json
 import logging
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import yaml
 
-from .bundle import WorkflowBundle, WorkflowRequirement
+from .bundle import CanvasSource, WorkflowBundle, WorkflowRequirement
 
 logger = logging.getLogger(__name__)
 
@@ -63,6 +64,7 @@ def _parse_requirements(raw: Any, *, slug: str) -> tuple[WorkflowRequirement, ..
 def _collect_surfaces(path: Path) -> Dict[str, Dict[str, Dict[str, Any]]]:
     """Collect every content directory present, using the deployment
     collectors so hashes and field shapes match the reconcile's."""
+    from ..data_manager.custom_data import collect_custom_data
     from ..function_manager.custom_functions import collect_custom_functions
     from ..guidance_manager.custom_guidance import collect_custom_guidance
     from ..knowledge_manager.custom_knowledge import collect_custom_knowledge
@@ -73,8 +75,116 @@ def _collect_surfaces(path: Path) -> Dict[str, Dict[str, Dict[str, Any]]]:
         "knowledge": collect_custom_knowledge(path=path / "knowledge"),
         "tasks": collect_custom_tasks(path=path / "tasks"),
         "functions": collect_custom_functions(directory=path / "functions"),
+        # Tables a bundle declares, schemas only: a workflow ships the shape
+        # its own job fills, never the contents. Seeded rows in a bundle
+        # would be one deployment's data published to everyone.
+        "data": _bundle_tables(collect_custom_data(path=path / "data"), path=path),
     }
     return {name: source for name, source in collected.items() if source}
+
+
+def _bundle_tables(
+    tables: Dict[str, Dict[str, Any]],
+    *,
+    path: Path,
+) -> Dict[str, Dict[str, Any]]:
+    """Normalise a bundle's declared tables, and refuse seeded rows.
+
+    Two rules, both made structural rather than left to be remembered.
+
+    **Schemas only.** A bundle is published verbatim to the public-read
+    Builtins project and installed identically by everyone, so rows in it
+    are one author's data handed to every installer. The table is the
+    contract; filling it is the workflow's own job at run time.
+
+    **Data-owned contexts.** ``data/Finance/Invoices`` becomes
+    ``Data/Finance/Invoices``. A context outside the Data namespace cannot
+    be installed to a team — the write refuses the destination — and cannot
+    be read by a canvas, whose policy declares ``Data`` and nothing else.
+    Both failures land a long way from the author, so the prefix is applied
+    here instead.
+    """
+    seeded = sorted(context for context, spec in tables.items() if spec.get("rows"))
+    if seeded:
+        raise ValueError(
+            f"{path.name}: data tables {', '.join(seeded)} ship seeded rows. "
+            "A bundle declares table schemas only — the workflow's own job "
+            "fills them. Delete the rows.jsonl.",
+        )
+
+    normalised: Dict[str, Dict[str, Any]] = {}
+    for context, spec in tables.items():
+        owned = context if context.startswith("Data/") else f"Data/{context}"
+        normalised[owned] = {**spec, "context": owned}
+    return normalised
+
+
+CANVAS_SOURCE_FILENAME = "view.tsx"
+CANVAS_MANIFEST_FILENAME = "view.json"
+
+
+def _collect_canvas(path: Path) -> tuple[CanvasSource, ...]:
+    """Load the views a bundle ships, as source.
+
+    Deliberately not a collected "surface": these never reach the reconcile
+    engine. A directory needs both ``view.tsx`` and ``view.json`` — source
+    with no manifest has no title to publish under and no bindings to read,
+    and a manifest with no source has nothing to compile, so either alone
+    is an authoring mistake worth naming rather than skipping.
+    """
+    root = path / "canvas"
+    if not root.is_dir():
+        return ()
+
+    views: List[CanvasSource] = []
+    for entry in sorted(root.iterdir()):
+        if not entry.is_dir():
+            continue
+        tsx_path = entry / CANVAS_SOURCE_FILENAME
+        manifest_path = entry / CANVAS_MANIFEST_FILENAME
+        if not tsx_path.is_file() and not manifest_path.is_file():
+            continue
+        if not tsx_path.is_file():
+            raise ValueError(
+                f"{path.name}: canvas {entry.name!r} has no {CANVAS_SOURCE_FILENAME}.",
+            )
+        if not manifest_path.is_file():
+            raise ValueError(
+                f"{path.name}: canvas {entry.name!r} has no "
+                f"{CANVAS_MANIFEST_FILENAME}; a view needs a title to publish "
+                "under and its bindings declared.",
+            )
+        manifest = json.loads(manifest_path.read_text()) or {}
+        title = str(manifest.get("title") or "").strip()
+        if not title:
+            raise ValueError(
+                f"{path.name}: canvas {entry.name!r} declares no title.",
+            )
+        # A pre-built bundle in a bundle pins a host runtime — it compiles
+        # against one kit and is planted into whatever host the deployment
+        # runs, so it breaks at view time with nothing failing at plant
+        # time. Refuse it where it is written rather than at someone's
+        # install.
+        for built in ("bundle.js", "bundle.mjs", "view.js"):
+            if (entry / built).exists():
+                raise ValueError(
+                    f"{path.name}: canvas {entry.name!r} ships a built "
+                    f"{built}. Bundles ship source; the install compiles it "
+                    "against the kit that is actually installed.",
+                )
+        views.append(
+            CanvasSource(
+                name=entry.name,
+                tsx=tsx_path.read_text(),
+                title=title,
+                description=str(manifest.get("description") or ""),
+                bindings=tuple(manifest.get("bindings") or ()),
+                props=dict(manifest.get("props") or {}),
+                actions=tuple(manifest.get("actions") or ()),
+                visibility=str(manifest.get("visibility") or "private"),
+            ),
+        )
+    return tuple(views)
 
 
 def load_bundle(path: Path) -> WorkflowBundle:
@@ -117,6 +227,7 @@ def load_bundle(path: Path) -> WorkflowBundle:
         ),
         install_task=str(manifest.get("install_task", "")),
         capabilities=tuple(manifest.get("capabilities") or ()),
+        canvas=_collect_canvas(path),
     )
 
 
@@ -174,6 +285,7 @@ def bootstrap_workflow_catalog(
         knowledge_manager=ManagerRegistry.get_knowledge_manager(),
         task_scheduler=ManagerRegistry.get_task_scheduler(),
         function_manager=ManagerRegistry.get_function_manager(),
+        data_manager=ManagerRegistry.get_data_manager(),
     )
 
     for entry in sorted(root.iterdir()):

--- a/unify/workflow_manager/surfaces.py
+++ b/unify/workflow_manager/surfaces.py
@@ -23,6 +23,7 @@ from typing import TYPE_CHECKING, Any, Mapping
 from .bundle import SurfaceRegistry
 
 if TYPE_CHECKING:  # pragma: no cover
+    from ..data_manager.data_manager import DataManager
     from ..function_manager.function_manager import FunctionManager
     from ..guidance_manager.guidance_manager import GuidanceManager
     from ..knowledge_manager.knowledge_manager import KnowledgeManager
@@ -52,6 +53,12 @@ SCOPED_SURFACES: Mapping[str, SurfaceSpec] = {
     # grouping wrappers on the managers above) and orders venvs before
     # functions so venv_name resolution holds.
     "functions": SurfaceSpec("sync_custom", "source_functions", shared=True),
+    # DataManager.sync_custom_data reconciles per table *under
+    # consideration*, taking the tables a source seeded last pass from its
+    # own meta record — so an uninstall's empty source still prunes, which
+    # the single-context surfaces get for free from their manager reading
+    # one context.
+    "data": SurfaceSpec("sync_custom_data", "source_tables"),
 }
 """Surface name -> the manager method a workflow install drives.
 
@@ -60,11 +67,7 @@ Make the adapter change first; this mapping is the consequence, not the
 mechanism.
 """
 
-PENDING_SCOPING: tuple[str, ...] = (
-    "data",
-    "canvas",
-    "venvs",
-)
+PENDING_SCOPING: tuple[str, ...] = ("venvs",)
 """Surfaces workflows will reach once their adapters are scoped, listed so
 the gap is visible rather than merely absent.
 
@@ -77,6 +80,14 @@ blacklist are populated at runtime by a workflow's own functions, never
 pre-seeded from a bundle; secrets and integrations enter a bundle as
 declared requirements, never as content; dashboards are deprecated in
 favour of canvas.
+
+``canvas`` is absent for a different reason and will not appear here. A
+view is real TypeScript that has to be linted, typechecked, bundled,
+rendered and published against the kit installed *now*, and its routing
+token has a lifecycle the reconcile engine has no business owning. A
+bundle ships canvas **source**; the install-time provisioning pass hands
+it to CanvasManager's own authoring pipeline and uninstall deletes
+through the manager's own delete, which already releases the token.
 """
 
 
@@ -87,6 +98,7 @@ def register_default_surfaces(
     knowledge_manager: "KnowledgeManager | None" = None,
     task_scheduler: "TaskScheduler | None" = None,
     function_manager: "FunctionManager | None" = None,
+    data_manager: "DataManager | None" = None,
 ) -> SurfaceRegistry:
     """Wire every managed-scoped manager that was supplied.
 
@@ -99,6 +111,7 @@ def register_default_surfaces(
         "knowledge": knowledge_manager,
         "tasks": task_scheduler,
         "functions": function_manager,
+        "data": data_manager,
     }
     for name, manager in managers.items():
         if manager is None:

--- a/unify/workflow_manager/workflow_manager.py
+++ b/unify/workflow_manager/workflow_manager.py
@@ -667,6 +667,16 @@ class WorkflowManager(BaseWorkflowManager):
                 enabled=not unmet,
             )
 
+            # Views are published after the surfaces land, because a view
+            # binds to tables the data surface just created. A publish that
+            # fails joins the surface failures: the installation stays and
+            # reports `partial`, so a repeat install retries exactly it.
+            canvases, canvas_failures = self._publish_canvases(
+                bundle,
+                destination=destination,
+            )
+            failures.update(canvas_failures)
+
             record = WorkflowInstallation(
                 workflow_id=(
                     existing.get("workflow_id", UNASSIGNED) if existing else UNASSIGNED
@@ -686,6 +696,8 @@ class WorkflowManager(BaseWorkflowManager):
             "installed": record.model_dump(mode="json"),
             "planted": planted,
         }
+        if canvases:
+            result["canvases"] = canvases
         if unmet:
             result["tasks_held"] = armed
             result["connect_required"] = {
@@ -752,6 +764,148 @@ class WorkflowManager(BaseWorkflowManager):
         if orphaned:
             result["orphaned"] = orphaned
         return result
+
+    # ------------------------------------------------------------------ #
+    # Canvas views (published, never reconciled)                         #
+    # ------------------------------------------------------------------ #
+    @staticmethod
+    def _get_canvas_manager():
+        from ..manager_registry import ManagerRegistry
+
+        return ManagerRegistry.get_canvas_manager()
+
+    def _published_canvases(
+        self,
+        slug: str,
+    ) -> Dict[str, Dict[str, Any]]:
+        """Views this workflow has published, keyed by their ``custom_key``."""
+        try:
+            records = self._get_canvas_manager().list_views(
+                filter=f"managed_by == '{slug}'",
+                limit=200,
+            )
+        except Exception:
+            logger.exception("Could not read published canvases for %r", slug)
+            return {}
+        return {
+            str(record.custom_key): record.model_dump()
+            for record in records
+            if record.custom_key
+        }
+
+    def _publish_canvases(
+        self,
+        bundle: WorkflowBundle,
+        *,
+        destination: Optional[str],
+    ) -> tuple[Dict[str, Any], Dict[str, BaseException]]:
+        """Compile and publish the views a bundle ships.
+
+        Deliberately outside the surface fan-out. A view is TypeScript that
+        has to be linted, typechecked, bundled, rendered and reviewed
+        against the kit installed *now* — the reason a bundle ships source
+        and not a built artifact — and its routing token has a lifecycle
+        the reconcile engine has no business owning.
+
+        Idempotent by ``custom_key``: a repeat install revises the view it
+        published last time, and one whose source is unchanged is left
+        alone rather than recompiled, because the compile is the expensive
+        part of an otherwise cheap reconcile.
+        """
+        if not bundle.canvas:
+            return {}, {}
+
+        manager = self._get_canvas_manager()
+        published = self._published_canvases(bundle.slug)
+        report: Dict[str, Any] = {}
+        failures: Dict[str, BaseException] = {}
+
+        for source in bundle.canvas:
+            key = f"{bundle.slug}/{source.custom_key}"
+            content_hash = source.content_hash()
+            existing = published.get(key)
+            provenance = {
+                "custom_key": key,
+                "custom_hash": content_hash,
+                "managed_by": bundle.slug,
+            }
+            try:
+                if existing and existing.get("custom_hash") == content_hash:
+                    report[source.name] = {
+                        "token": existing.get("token"),
+                        "status": "unchanged",
+                    }
+                    continue
+                if existing:
+                    result = manager.update_view(
+                        str(existing["token"]),
+                        tsx=source.tsx,
+                        title=source.title,
+                        description=source.description,
+                        bindings=list(source.bindings),
+                        props=dict(source.props),
+                        actions=list(source.actions),
+                        visibility=source.visibility,
+                        provenance=provenance,
+                    )
+                else:
+                    result = manager.create_view(
+                        source.tsx,
+                        title=source.title,
+                        description=source.description,
+                        bindings=list(source.bindings),
+                        props=dict(source.props),
+                        actions=list(source.actions),
+                        destination=destination,
+                        visibility=source.visibility,
+                        provenance=provenance,
+                    )
+            except Exception as exc:
+                failures[f"canvas:{source.name}"] = exc
+                logger.exception(
+                    "Publishing canvas %r for workflow %r failed",
+                    source.name,
+                    bundle.slug,
+                )
+                continue
+
+            if result.error:
+                # A view that does not compile or does not mount is a
+                # failure with a message worth relaying — the author needs
+                # the compiler's words, not "install failed".
+                failures[f"canvas:{source.name}"] = RuntimeError(result.error)
+                continue
+            report[source.name] = {
+                "token": result.token,
+                "url": result.url,
+                "status": "updated" if existing else "published",
+            }
+
+        return report, failures
+
+    def _withdraw_canvases(self, slug: str) -> List[str]:
+        """Delete the views this workflow published.
+
+        Through the manager's own delete, which releases the routing token
+        and drops the actions and invocations hanging off it — none of
+        which a prune adapter could do without reimplementing it.
+        """
+        removed: List[str] = []
+        manager = self._get_canvas_manager()
+        for key, row in self._published_canvases(slug).items():
+            token = str(row.get("token") or "")
+            if not token:
+                continue
+            try:
+                manager.delete_view(token)
+                removed.append(key)
+            except Exception:
+                logger.exception(
+                    "Could not delete canvas %r while uninstalling %r",
+                    key,
+                    slug,
+                )
+        return removed
 
     def _trigger_install_task(
         self,
@@ -1159,6 +1313,11 @@ class WorkflowManager(BaseWorkflowManager):
                 surface_names=pruned_surfaces,
                 empty=True,
             )
+            # Views go whatever `keep_data` says: a canvas is the bundle's
+            # own content, not work the workflow produced, and leaving one
+            # behind would leave a live URL rendering against tables that
+            # may no longer be filled.
+            withdrawn = self._withdraw_canvases(slug)
             kept = sorted(set(recorded) - set(pruned_surfaces))
             # The installation row goes only after every surface actually
             # cleared. On failure it stays — it holds the recorded surfaces,
@@ -1167,6 +1326,8 @@ class WorkflowManager(BaseWorkflowManager):
                 self._delete_installation(slug, context=context)
 
         result: Dict[str, Any] = {"slug": slug, "removed": removed}
+        if withdrawn:
+            result["canvases_removed"] = withdrawn
         if kept:
             result["kept"] = kept
         if failures:


### PR DESCRIPTION
<!--
Thanks for contributing to Unify! Please fill out the sections below.
For trivial changes (typo fixes, comment-only edits) you can shorten this template — just keep the Summary.

PRs land on `staging`, not `main`. See CONTRIBUTING.md.
-->

## Summary

<!-- 1–3 sentences: what problem does this PR solve, and why is this the right approach? -->



## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes incorrect behavior)
- [ ] Feature (non-breaking change that adds functionality)
- [ ] Refactor (no behavior change)
- [ ] Breaking change (API or data-model change — Unify has zero-backward-compat policy, but please call it out)
- [ ] Test-only (no source changes)
- [ ] Docs / chore / CI

## Areas touched

<!-- Check all that apply. Helps reviewers route. -->

- [ ] Actor / CodeAct
- [ ] ConversationManager / slow brain
- [ ] A specific state manager (Contact / Knowledge / Task / Transcript / Guidance / Function / File / Image / Web / Secret / Blacklist / Data / Memory)
- [ ] Async tool loop (`unify/common/_async_tool/`)
- [ ] Event bus / observability
- [ ] Gateway / external comms
- [ ] Tests / test infra (`tests/`, `conftest.py`, `parallel_run.sh`)
- [ ] CI / build / packaging

## Test plan

<!--
How did you verify this? Paste the command(s) you ran and the result.

The default expectation is to run the relevant directory:
  tests/parallel_run.sh tests/<module>/

For infrastructure changes that are hard to reach via tests, a quick
verification script under tests/_verify_*.py is encouraged
(see .agents/rules/surgical-verification-before-tests.md).
-->

```
tests/parallel_run.sh tests/...
```

- [ ] All relevant tests pass locally
- [ ] If this is a bug fix, I added a regression test (or explained why one isn't feasible)

## Behavior / migration notes

<!--
- Did this change a public manager API, primitive, or event payload?
- Are there schema/context changes in Orchestra that need a migration?
- Any new env vars or config flags? (Update `.env.advanced.example`.)
- If yes to any of the above, describe upgrade steps.
-->

None.

## Checklist

- [ ] PR is targeted at `staging` (not `main`)
- [ ] Followed conventional commit style (`feat(scope):`, `fix(scope):`, `refactor(scope):`, `chore(scope):`, etc.)
- [ ] No `try/except` added defensively — only around specific, recoverable errors
- [ ] No "new" / "updated" / "TODO from chat" temporal comments (see `.agents/rules/no-temporal-comments.md`)
- [ ] No test-specific shortcuts in production code (see `.agents/rules/no-test-info-in-production-code.md`)
- [ ] Updated `AGENTS.md` / `ARCHITECTURE.md` if I changed architectural conventions
