### PR TITLE
fix(workflows): the shelf publishes how a requirement is resolved

### DIFF
--- a/tests/workflow_manager/test_catalog.py
+++ b/tests/workflow_manager/test_catalog.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 import pytest
 
+from unify.workflow_manager.bundle import WorkflowBundle
 from unify.workflow_manager.catalog import (
     MANIFEST_FILENAME,
     load_bundle,
@@ -426,3 +427,50 @@ def test_a_bundle_ships_table_schemas_but_never_rows(tmp_path: Path):
     )
     with pytest.raises(ValueError, match="ship seeded rows"):
         load_bundle(bundle_dir)
+
+
+def test_a_requirement_publishes_how_it_is_resolved(tmp_path: Path):
+    """A reader gets the slug *and* how to answer it.
+
+    The shelf published only the slug and the display name, so a reader had
+    nothing to go on but a gallery lookup — and a workspace is the user's own
+    account, deliberately not a catalogue app. Meeting prep's Google
+    Workspace requirement therefore rendered as "couldn't check this app",
+    about the one requirement whose answer never depended on the gallery.
+    """
+    from unify.workflow_manager.builtins_catalog import catalog_row
+    from unify.workflow_manager.bundle import WorkflowRequirement
+
+    bundle = load_bundle(_write_bundle(tmp_path))
+    published = json.loads(
+        catalog_row(
+            WorkflowBundle(
+                slug=bundle.slug,
+                name=bundle.name,
+                requirements=(
+                    WorkflowRequirement(slug="gmail", name="Gmail"),
+                    WorkflowRequirement(
+                        slug="google_workspace",
+                        name="Google Workspace",
+                        kind="workspace",
+                        required_secrets=("GOOGLE_REFRESH_TOKEN",),
+                    ),
+                ),
+            ),
+        )["requirements"],
+    )
+
+    assert published == [
+        {
+            "slug": "gmail",
+            "name": "Gmail",
+            "kind": "app",
+            "required_secrets": [],
+        },
+        {
+            "slug": "google_workspace",
+            "name": "Google Workspace",
+            "kind": "workspace",
+            "required_secrets": ["GOOGLE_REFRESH_TOKEN"],
+        },
+    ]

--- a/unify/workflow_manager/builtins_catalog.py
+++ b/unify/workflow_manager/builtins_catalog.py
@@ -164,6 +164,14 @@ def catalog_row(bundle: WorkflowBundle) -> Dict[str, Any]:
                 {
                     "slug": requirement.slug,
                     "name": requirement.name or requirement.slug,
+                    # `kind` and the declared secrets travel with the
+                    # requirement or a reader cannot resolve it. A workspace
+                    # is not in the gallery by design, so a reader that knows
+                    # only the slug looks it up, finds nothing, and reports
+                    # "couldn't check this app" about the one requirement
+                    # whose answer never depended on the gallery.
+                    "kind": requirement.kind,
+                    "required_secrets": list(requirement.required_secrets),
                 }
                 for requirement in bundle.requirements
             ],


### PR DESCRIPTION
It published a slug and a display name, which leaves a reader nothing but a gallery lookup. A workspace requirement is the user's own Google or Microsoft account — deliberately not a catalogue app — so the lookup found nothing and Meeting prep reported "couldn't check this app" about the one requirement whose answer never depended on the gallery.

`kind` and `required_secrets` now travel with the requirement, so a reader can resolve a workspace from the secret the connect flow stores without asking the gallery about something it was never going to know.

<!--
Thanks for contributing to Unify! Please fill out the sections below.
For trivial changes (typo fixes, comment-only edits) you can shorten this template — just keep the Summary.

PRs land on `staging`, not `main`. See CONTRIBUTING.md.
-->

## Summary

<!-- 1–3 sentences: what problem does this PR solve, and why is this the right approach? -->



## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes incorrect behavior)
- [ ] Feature (non-breaking change that adds functionality)
- [ ] Refactor (no behavior change)
- [ ] Breaking change (API or data-model change — Unify has zero-backward-compat policy, but please call it out)
- [ ] Test-only (no source changes)
- [ ] Docs / chore / CI

## Areas touched

<!-- Check all that apply. Helps reviewers route. -->

- [ ] Actor / CodeAct
- [ ] ConversationManager / slow brain
- [ ] A specific state manager (Contact / Knowledge / Task / Transcript / Guidance / Function / File / Image / Web / Secret / Blacklist / Data / Memory)
- [ ] Async tool loop (`unify/common/_async_tool/`)
- [ ] Event bus / observability
- [ ] Gateway / external comms
- [ ] Tests / test infra (`tests/`, `conftest.py`, `parallel_run.sh`)
- [ ] CI / build / packaging

## Test plan

<!--
How did you verify this? Paste the command(s) you ran and the result.

The default expectation is to run the relevant directory:
  tests/parallel_run.sh tests/<module>/

For infrastructure changes that are hard to reach via tests, a quick
verification script under tests/_verify_*.py is encouraged
(see .agents/rules/surgical-verification-before-tests.md).
-->

```
tests/parallel_run.sh tests/...
```

- [ ] All relevant tests pass locally
- [ ] If this is a bug fix, I added a regression test (or explained why one isn't feasible)

## Behavior / migration notes

<!--
- Did this change a public manager API, primitive, or event payload?
- Are there schema/context changes in Orchestra that need a migration?
- Any new env vars or config flags? (Update `.env.advanced.example`.)
- If yes to any of the above, describe upgrade steps.
-->

None.

## Checklist

- [ ] PR is targeted at `staging` (not `main`)
- [ ] Followed conventional commit style (`feat(scope):`, `fix(scope):`, `refactor(scope):`, `chore(scope):`, etc.)
- [ ] No `try/except` added defensively — only around specific, recoverable errors
- [ ] No "new" / "updated" / "TODO from chat" temporal comments (see `.agents/rules/no-temporal-comments.md`)
- [ ] No test-specific shortcuts in production code (see `.agents/rules/no-test-info-in-production-code.md`)
- [ ] Updated `AGENTS.md` / `ARCHITECTURE.md` if I changed architectural conventions
