### PR TITLE
Feat/workflows

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -526,17 +526,20 @@ def pytest_sessionstart(session):
     from unify.function_manager.builtins_catalog import seed_builtin_primitives
     from unify.guidance_manager.builtins_catalog import seed_builtin_guidance
     from unify.integrations.builtins_catalog import seed_builtin_integrations
-    from unify.workflow_manager.builtins_catalog import seed_builtin_workflows
+    from unify.workflow_manager.builtins_catalog import ensure_catalog_storage
 
     with _cross_process_column_lock(builtins_project(), "builtins_seed"):
         with builtins_seed_key_override():
             seed_builtin_primitives()
             seed_builtin_guidance()
             seed_builtin_integrations()
-            # Workflows: storage only (bundles=None resolves the sibling
-            # unify-deploy tree when present; tests that need rows seed
-            # explicit bundles themselves).
-            seed_builtin_workflows(bundles=[])
+            # Workflows: storage only. The catalogue is a shared, public
+            # shelf keyed by project name alone, so it is the same rows a
+            # deployment serves — seeding desired state from here publishes
+            # whatever this checkout happens to hold, and an empty desired
+            # state deletes the shelf out from under everyone pointed at
+            # the same backend. Tests that need rows seed their own.
+            ensure_catalog_storage(builtins_project())
 
     # ------------------------------------------------------------------
     #  Configure EventBus publishing (disabled by default in tests)

--- a/tests/workflow_manager/test_catalog.py
+++ b/tests/workflow_manager/test_catalog.py
@@ -474,3 +474,66 @@ def test_a_requirement_publishes_how_it_is_resolved(tmp_path: Path):
             "required_secrets": ["GOOGLE_REFRESH_TOKEN"],
         },
     ]
+
+
+def test_a_missing_tree_never_reads_as_an_empty_shelf(tmp_path: Path, monkeypatch):
+    """The failure that emptied the staging catalogue.
+
+    ``load_catalog`` answers ``[]`` for a root that does not exist, and ``[]``
+    to the seeder means *delete every published workflow*. A mispointed
+    ``UNITY_WORKFLOWS_DIR``, or an image built without the curated tree, would
+    therefore wipe the shelf for everyone — and the wipe is indistinguishable
+    from a deliberate one.
+    """
+    from unify.settings import SETTINGS
+    from unify.workflow_manager import builtins_catalog
+
+    monkeypatch.setattr(
+        SETTINGS,
+        "UNITY_WORKFLOWS_DIR",
+        str(tmp_path / "not-here"),
+        raising=False,
+    )
+    assert builtins_catalog._default_bundles() is None
+
+
+def test_a_malformed_bundle_raises_rather_than_reading_as_no_shelf(
+    tmp_path: Path,
+    monkeypatch,
+):
+    """The other half of the same incident.
+
+    The packaged tree carried a canvas manifest with no ``view.tsx`` beside
+    it — the loader refuses that, correctly. Swallowing the error turned it
+    into "no shelf to reconcile", which the seed reports as "already up to
+    date", so an empty catalogue stayed empty with every run claiming success.
+    """
+    from unify.settings import SETTINGS
+    from unify.workflow_manager import builtins_catalog
+
+    bundle_dir = _write_bundle(tmp_path)
+    view_dir = bundle_dir / "canvas" / "orphan"
+    view_dir.mkdir(parents=True)
+    (view_dir / "view.json").write_text(json.dumps({"title": "Orphan"}) + "\n")
+
+    monkeypatch.setattr(SETTINGS, "UNITY_WORKFLOWS_DIR", str(tmp_path), raising=False)
+    with pytest.raises(ValueError, match="no view.tsx"):
+        builtins_catalog._default_bundles()
+
+
+def test_making_room_for_the_catalogue_never_touches_its_rows():
+    """The third way an empty shelf gets published: asking the wrong question.
+
+    A caller that only wants the contexts to exist has one verb for it.
+    Reaching the seeder instead means handing it desired state, and the
+    empty desired state that reads like "nothing to do" is the one input
+    that deletes every row.
+    """
+    import inspect
+
+    from unify.workflow_manager.builtins_catalog import ensure_catalog_storage
+
+    body = inspect.getsource(ensure_catalog_storage)
+    assert "create_context" in body
+    for row_verb in ("delete_logs", "create_logs", "update_logs", "_reconcile_rows"):
+        assert row_verb not in body

--- a/tests/workflow_manager/test_install_uninstall_live.py
+++ b/tests/workflow_manager/test_install_uninstall_live.py
@@ -660,5 +660,7 @@ async def test_catalog_seeds_the_builtins_shelf_and_short_circuits(
         assert set(shelf()) == {"other_demo"}
         assert artifacts() == {}
 
-        # The harness re-seeds an empty catalogue for the next session.
-        seed_builtin_workflows(bundles=[])
+        # Put this environment's real shelf back. The catalogue is shared
+        # and public — leaving the demo bundle behind, or leaving nothing
+        # behind, is a change every reader of this backend sees.
+        seed_builtin_workflows()

--- a/unify/workflow_manager/builtins_catalog.py
+++ b/unify/workflow_manager/builtins_catalog.py
@@ -55,7 +55,13 @@ _CATALOG_UNIT = "workflows"
 _CONTENT_UNIT = "workflows_content"
 
 
-def _ensure_catalog_storage(project: str) -> None:
+def ensure_catalog_storage(project: str) -> None:
+    """Create the catalogue contexts, without reading or writing a single row.
+
+    The storage-only half of seeding. A caller that only needs the contexts
+    to exist must reach this rather than the seeder, because the seeder
+    takes desired state and an empty desired state is a wipe.
+    """
     ensure_builtins_project(project)
     unisdk.create_context(
         BUILTINS_WORKFLOWS_CONTEXT,
@@ -311,13 +317,41 @@ def _default_bundles() -> Optional[List[WorkflowBundle]]:
 
     configured = (SETTINGS.UNITY_WORKFLOWS_DIR or "").strip()
     if configured:
-        return load_catalog(Path(configured))
-    try:
-        from unify_deploy.assistant_deployments.workflows import workflows_root
+        root = Path(configured)
+    else:
+        try:
+            from unify_deploy.assistant_deployments.workflows import workflows_root
 
-        return load_catalog(workflows_root())
-    except Exception:
+            root = workflows_root()
+        except ImportError:
+            return None
+
+    # A tree that is not there is "nothing to reconcile", never "the shelf is
+    # empty". `load_catalog` answers `[]` for a missing root, and `[]` here
+    # means *delete every published workflow* — so a mispointed
+    # UNITY_WORKFLOWS_DIR, or an image built without the curated tree, would
+    # silently empty the catalogue for everyone.
+    if not root.is_dir():
+        logger.warning(
+            "Workflow catalogue root %s does not exist; leaving the published "
+            "shelf untouched rather than treating it as empty",
+            root,
+        )
         return None
+
+    try:
+        return load_catalog(root)
+    except Exception:
+        # A malformed bundle must not read as "no shelf". Loud, because the
+        # seed's only other signal is "already up to date" — which is what a
+        # missing canvas source in the packaged tree reported for hours while
+        # the catalogue sat empty.
+        logger.exception(
+            "Workflow catalogue at %s failed to load; the published shelf is "
+            "left as it is and will not be updated until this is fixed",
+            root,
+        )
+        raise
 
 
 def seed_builtin_workflows(
@@ -351,7 +385,7 @@ def seed_builtin_workflows(
 
     if bundles is None:
         if not storage_ready:
-            _ensure_catalog_storage(project)
+            ensure_catalog_storage(project)
         return False
 
     catalog = {bundle.slug: catalog_row(bundle) for bundle in bundles}
@@ -390,7 +424,7 @@ def seed_builtin_workflows(
         logger.debug("Workflow catalogue unchanged; skipping seed")
         return False
 
-    _ensure_catalog_storage(project)
+    ensure_catalog_storage(project)
 
     for unit in sorted(stale_units):
         context, key_field, rows, _ = units[unit]


### PR DESCRIPTION
<!--
Thanks for contributing to Unify! Please fill out the sections below.
For trivial changes (typo fixes, comment-only edits) you can shorten this template — just keep the Summary.

PRs land on `staging`, not `main`. See CONTRIBUTING.md.
-->

## Summary

<!-- 1–3 sentences: what problem does this PR solve, and why is this the right approach? -->



## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes incorrect behavior)
- [ ] Feature (non-breaking change that adds functionality)
- [ ] Refactor (no behavior change)
- [ ] Breaking change (API or data-model change — Unify has zero-backward-compat policy, but please call it out)
- [ ] Test-only (no source changes)
- [ ] Docs / chore / CI

## Areas touched

<!-- Check all that apply. Helps reviewers route. -->

- [ ] Actor / CodeAct
- [ ] ConversationManager / slow brain
- [ ] A specific state manager (Contact / Knowledge / Task / Transcript / Guidance / Function / File / Image / Web / Secret / Blacklist / Data / Memory)
- [ ] Async tool loop (`unify/common/_async_tool/`)
- [ ] Event bus / observability
- [ ] Gateway / external comms
- [ ] Tests / test infra (`tests/`, `conftest.py`, `parallel_run.sh`)
- [ ] CI / build / packaging

## Test plan

<!--
How did you verify this? Paste the command(s) you ran and the result.

The default expectation is to run the relevant directory:
  tests/parallel_run.sh tests/<module>/

For infrastructure changes that are hard to reach via tests, a quick
verification script under tests/_verify_*.py is encouraged
(see .agents/rules/surgical-verification-before-tests.md).
-->

```
tests/parallel_run.sh tests/...
```

- [ ] All relevant tests pass locally
- [ ] If this is a bug fix, I added a regression test (or explained why one isn't feasible)

## Behavior / migration notes

<!--
- Did this change a public manager API, primitive, or event payload?
- Are there schema/context changes in Orchestra that need a migration?
- Any new env vars or config flags? (Update `.env.advanced.example`.)
- If yes to any of the above, describe upgrade steps.
-->

None.

## Checklist

- [ ] PR is targeted at `staging` (not `main`)
- [ ] Followed conventional commit style (`feat(scope):`, `fix(scope):`, `refactor(scope):`, `chore(scope):`, etc.)
- [ ] No `try/except` added defensively — only around specific, recoverable errors
- [ ] No "new" / "updated" / "TODO from chat" temporal comments (see `.agents/rules/no-temporal-comments.md`)
- [ ] No test-specific shortcuts in production code (see `.agents/rules/no-test-info-in-production-code.md`)
- [ ] Updated `AGENTS.md` / `ARCHITECTURE.md` if I changed architectural conventions
