### PR TITLE
fix(workflows): the shelf has one resolution, not two

### DIFF
--- a/tests/workflow_manager/test_catalog.py
+++ b/tests/workflow_manager/test_catalog.py
@@ -537,3 +537,36 @@ def test_making_room_for_the_catalogue_never_touches_its_rows():
     assert "create_context" in body
     for row_verb in ("delete_logs", "create_logs", "update_logs", "_reconcile_rows"):
         assert row_verb not in body
+
+
+def test_the_shelf_has_one_resolution_not_two(tmp_path: Path, monkeypatch):
+    """Console showed six workflows; every install said the shelf was empty.
+
+    The seeder fell back to the installed unify_deploy package when
+    UNITY_WORKFLOWS_DIR was unset. The runtime registry did not — it just
+    returned None. So a deployment with the package installed and no env var
+    published six workflows to the catalogue Console renders, while the
+    assistant that has to install them registered none, and every install
+    failed with "Available: nothing — the catalogue is empty" against a
+    catalogue that plainly had six rows in it.
+    """
+    import inspect
+
+    from unify.settings import SETTINGS
+    from unify.workflow_manager import builtins_catalog
+    from unify.workflow_manager.catalog import (
+        bootstrap_workflow_catalog,
+        resolve_catalogue_root,
+    )
+
+    _write_bundle(tmp_path)
+    monkeypatch.setattr(SETTINGS, "UNITY_WORKFLOWS_DIR", str(tmp_path), raising=False)
+
+    # Both reach the same tree, because both ask the same question.
+    assert resolve_catalogue_root() == tmp_path
+    assert [b.slug for b in builtins_catalog._default_bundles()] == ["daily_briefing"]
+
+    for func in (bootstrap_workflow_catalog, builtins_catalog._default_bundles):
+        assert "resolve_catalogue_root" in inspect.getsource(
+            func,
+        ), f"{func.__name__} must not resolve the catalogue root itself"

--- a/unify/workflow_manager/builtins_catalog.py
+++ b/unify/workflow_manager/builtins_catalog.py
@@ -26,7 +26,6 @@ from __future__ import annotations
 
 import json
 import logging
-from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional
 
 import unisdk
@@ -312,31 +311,13 @@ def _default_bundles() -> Optional[List[WorkflowBundle]]:
     ensures storage exists and stops, so an environment without the curated
     tree cannot empty a catalogue another environment seeded.
     """
-    from ..settings import SETTINGS
-    from .catalog import load_catalog
-
-    configured = (SETTINGS.UNITY_WORKFLOWS_DIR or "").strip()
-    if configured:
-        root = Path(configured)
-    else:
-        try:
-            from unify_deploy.assistant_deployments.workflows import workflows_root
-
-            root = workflows_root()
-        except ImportError:
-            return None
+    from .catalog import load_catalog, resolve_catalogue_root
 
     # A tree that is not there is "nothing to reconcile", never "the shelf is
     # empty". `load_catalog` answers `[]` for a missing root, and `[]` here
-    # means *delete every published workflow* — so a mispointed
-    # UNITY_WORKFLOWS_DIR, or an image built without the curated tree, would
-    # silently empty the catalogue for everyone.
-    if not root.is_dir():
-        logger.warning(
-            "Workflow catalogue root %s does not exist; leaving the published "
-            "shelf untouched rather than treating it as empty",
-            root,
-        )
+    # means *delete every published workflow*.
+    root = resolve_catalogue_root()
+    if root is None:
         return None
 
     try:

--- a/unify/workflow_manager/catalog.py
+++ b/unify/workflow_manager/catalog.py
@@ -247,6 +247,39 @@ def load_catalog(root: Path) -> List[WorkflowBundle]:
     return bundles
 
 
+def resolve_catalogue_root() -> Optional[Path]:
+    """Where this environment's curated bundles live, or None if nowhere.
+
+    One resolution, used by everything that needs the shelf. It used to be
+    written twice: the seeder fell back to the installed ``unify_deploy``
+    package when ``UNITY_WORKFLOWS_DIR`` was unset, and the runtime registry
+    returned None instead. So a deployment with the package installed and no
+    env var published six workflows to the catalogue Console renders, while
+    the assistant that has to install them registered none — the shelf was
+    visibly full and every install failed with "the catalogue is empty".
+
+    Returns None only when there is genuinely nothing to read, which callers
+    must treat as "no catalogue here", never as "the catalogue is empty".
+    """
+    from ..settings import SETTINGS
+
+    configured = (SETTINGS.UNITY_WORKFLOWS_DIR or "").strip()
+    if configured:
+        root = Path(configured)
+    else:
+        try:
+            from unify_deploy.assistant_deployments.workflows import workflows_root
+
+            root = workflows_root()
+        except ImportError:
+            return None
+
+    if not root.is_dir():
+        logger.warning("Workflow catalogue root %s does not exist", root)
+        return None
+    return root
+
+
 def bootstrap_workflow_catalog(
     root: Optional[Path] = None,
 ) -> "Optional[Any]":
@@ -263,14 +296,11 @@ def bootstrap_workflow_catalog(
     is the upkeep tick, so a version bump shipped in git reaches existing
     installations on the next session start.
     """
-    from ..settings import SETTINGS
-
     if root is None:
-        configured = (SETTINGS.UNITY_WORKFLOWS_DIR or "").strip()
-        if not configured:
+        root = resolve_catalogue_root()
+        if root is None:
             return None
-        root = Path(configured)
-    if not root.is_dir():
+    elif not root.is_dir():
         logger.warning("Workflow catalogue root %s does not exist", root)
         return None
 


### PR DESCRIPTION
Console rendered six workflows and every install failed with "Available: nothing — the catalogue is empty", against a catalogue that plainly had six rows in it.

The seeder and the runtime registry each resolved the curated tree themselves, and disagreed when UNITY_WORKFLOWS_DIR was unset: the seeder fell back to the installed unify_deploy package, the registry returned None. So a deployment with the package installed and no env var published six workflows to the catalogue the gallery reads, while the assistant that has to install them registered none, and the request rows recorded unknown_workflow against a full shelf.

resolve_catalogue_root is now the single answer, and a test fails if either caller starts resolving it again.

<!--
Thanks for contributing to Unify! Please fill out the sections below.
For trivial changes (typo fixes, comment-only edits) you can shorten this template — just keep the Summary.

PRs land on `staging`, not `main`. See CONTRIBUTING.md.
-->

## Summary

<!-- 1–3 sentences: what problem does this PR solve, and why is this the right approach? -->



## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes incorrect behavior)
- [ ] Feature (non-breaking change that adds functionality)
- [ ] Refactor (no behavior change)
- [ ] Breaking change (API or data-model change — Unify has zero-backward-compat policy, but please call it out)
- [ ] Test-only (no source changes)
- [ ] Docs / chore / CI

## Areas touched

<!-- Check all that apply. Helps reviewers route. -->

- [ ] Actor / CodeAct
- [ ] ConversationManager / slow brain
- [ ] A specific state manager (Contact / Knowledge / Task / Transcript / Guidance / Function / File / Image / Web / Secret / Blacklist / Data / Memory)
- [ ] Async tool loop (`unify/common/_async_tool/`)
- [ ] Event bus / observability
- [ ] Gateway / external comms
- [ ] Tests / test infra (`tests/`, `conftest.py`, `parallel_run.sh`)
- [ ] CI / build / packaging

## Test plan

<!--
How did you verify this? Paste the command(s) you ran and the result.

The default expectation is to run the relevant directory:
  tests/parallel_run.sh tests/<module>/

For infrastructure changes that are hard to reach via tests, a quick
verification script under tests/_verify_*.py is encouraged
(see .agents/rules/surgical-verification-before-tests.md).
-->

```
tests/parallel_run.sh tests/...
```

- [ ] All relevant tests pass locally
- [ ] If this is a bug fix, I added a regression test (or explained why one isn't feasible)

## Behavior / migration notes

<!--
- Did this change a public manager API, primitive, or event payload?
- Are there schema/context changes in Orchestra that need a migration?
- Any new env vars or config flags? (Update `.env.advanced.example`.)
- If yes to any of the above, describe upgrade steps.
-->

None.

## Checklist

- [ ] PR is targeted at `staging` (not `main`)
- [ ] Followed conventional commit style (`feat(scope):`, `fix(scope):`, `refactor(scope):`, `chore(scope):`, etc.)
- [ ] No `try/except` added defensively — only around specific, recoverable errors
- [ ] No "new" / "updated" / "TODO from chat" temporal comments (see `.agents/rules/no-temporal-comments.md`)
- [ ] No test-specific shortcuts in production code (see `.agents/rules/no-test-info-in-production-code.md`)
- [ ] Updated `AGENTS.md` / `ARCHITECTURE.md` if I changed architectural conventions
