### PR TITLE
fix(workflows): boot loads the shelf into the manager that installs f…

### DIFF
--- a/tests/workflow_manager/test_catalog.py
+++ b/tests/workflow_manager/test_catalog.py
@@ -570,3 +570,33 @@ def test_the_shelf_has_one_resolution_not_two(tmp_path: Path, monkeypatch):
         assert "resolve_catalogue_root" in inspect.getsource(
             func,
         ), f"{func.__name__} must not resolve the catalogue root itself"
+
+
+def test_the_install_path_sees_the_bundles_boot_loaded(tmp_path: Path, monkeypatch):
+    """The shelf is full and every install still said it was empty.
+
+    bootstrap_workflow_catalog constructed its own WorkflowManager, loaded
+    every bundle into it, and returned it — while the install path asks
+    ``ManagerRegistry.get_workflow_manager()``, which lazily built a
+    *different*, bundle-less instance. The registry getter never returns
+    None once asked, so the request handler did not report "no shelf here";
+    it reported "the catalogue is empty" against a catalogue that had just
+    been filled, and the request rows recorded unknown_workflow.
+
+    Loading bundles into an object nobody else holds is the bug, so this
+    asserts on the object the installer actually reaches.
+    """
+    from unify.manager_registry import ManagerRegistry
+    from unify.settings import SETTINGS
+    from unify.workflow_manager.catalog import bootstrap_workflow_catalog
+
+    _write_bundle(tmp_path)
+    monkeypatch.setattr(SETTINGS, "UNITY_WORKFLOWS_DIR", str(tmp_path), raising=False)
+
+    booted = bootstrap_workflow_catalog()
+    assert booted is not None
+
+    # What install_workflow resolves, not what bootstrap happened to return.
+    from_registry = ManagerRegistry.get_workflow_manager()
+    assert from_registry is booted
+    assert [b.slug for b in from_registry.available_bundles()] == ["daily_briefing"]

--- a/unify/workflow_manager/catalog.py
+++ b/unify/workflow_manager/catalog.py
@@ -306,9 +306,17 @@ def bootstrap_workflow_catalog(
 
     from ..manager_registry import ManagerRegistry
     from .surfaces import register_default_surfaces
-    from .workflow_manager import WorkflowManager
 
-    manager = WorkflowManager()
+    # The registry's instance, never a fresh one.
+    #
+    # This used to construct its own WorkflowManager, load every bundle into
+    # it, and return it — while `ManagerRegistry.get_workflow_manager()`
+    # lazily built a *different*, bundle-less one for everybody else. So the
+    # install path asked the registry, got the empty manager, and reported
+    # "the catalogue is empty" against a shelf this function had just
+    # finished filling. Registering onto the shared instance is what makes
+    # the bundles visible to the code that installs them.
+    manager = ManagerRegistry.get_workflow_manager()
     register_default_surfaces(
         manager.surfaces,
         guidance_manager=ManagerRegistry.get_guidance_manager(),


### PR DESCRIPTION
…rom it

Resolving the curated tree correctly was not enough: bootstrap constructed its own WorkflowManager, loaded every bundle into it, wired its surfaces and returned it — while the install path asks the registry, which lazily built a different, bundle-less instance for everyone else.

The registry getter never returns None once asked, so the request handler did not report "this deployment has no shelf". It reported "the catalogue is empty" against a catalogue boot had just finished filling, and every install request settled as unknown_workflow with an empty available list while Builtins/Workflows/Catalog held six rows.

Boot now registers onto the shared instance. The test asserts on the manager the installer resolves rather than on what bootstrap returns, which is the gap that let bundles be loaded into an object nobody held.

<!--
Thanks for contributing to Unify! Please fill out the sections below.
For trivial changes (typo fixes, comment-only edits) you can shorten this template — just keep the Summary.

PRs land on `staging`, not `main`. See CONTRIBUTING.md.
-->

## Summary

<!-- 1–3 sentences: what problem does this PR solve, and why is this the right approach? -->



## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes incorrect behavior)
- [ ] Feature (non-breaking change that adds functionality)
- [ ] Refactor (no behavior change)
- [ ] Breaking change (API or data-model change — Unify has zero-backward-compat policy, but please call it out)
- [ ] Test-only (no source changes)
- [ ] Docs / chore / CI

## Areas touched

<!-- Check all that apply. Helps reviewers route. -->

- [ ] Actor / CodeAct
- [ ] ConversationManager / slow brain
- [ ] A specific state manager (Contact / Knowledge / Task / Transcript / Guidance / Function / File / Image / Web / Secret / Blacklist / Data / Memory)
- [ ] Async tool loop (`unify/common/_async_tool/`)
- [ ] Event bus / observability
- [ ] Gateway / external comms
- [ ] Tests / test infra (`tests/`, `conftest.py`, `parallel_run.sh`)
- [ ] CI / build / packaging

## Test plan

<!--
How did you verify this? Paste the command(s) you ran and the result.

The default expectation is to run the relevant directory:
  tests/parallel_run.sh tests/<module>/

For infrastructure changes that are hard to reach via tests, a quick
verification script under tests/_verify_*.py is encouraged
(see .agents/rules/surgical-verification-before-tests.md).
-->

```
tests/parallel_run.sh tests/...
```

- [ ] All relevant tests pass locally
- [ ] If this is a bug fix, I added a regression test (or explained why one isn't feasible)

## Behavior / migration notes

<!--
- Did this change a public manager API, primitive, or event payload?
- Are there schema/context changes in Orchestra that need a migration?
- Any new env vars or config flags? (Update `.env.advanced.example`.)
- If yes to any of the above, describe upgrade steps.
-->

None.

## Checklist

- [ ] PR is targeted at `staging` (not `main`)
- [ ] Followed conventional commit style (`feat(scope):`, `fix(scope):`, `refactor(scope):`, `chore(scope):`, etc.)
- [ ] No `try/except` added defensively — only around specific, recoverable errors
- [ ] No "new" / "updated" / "TODO from chat" temporal comments (see `.agents/rules/no-temporal-comments.md`)
- [ ] No test-specific shortcuts in production code (see `.agents/rules/no-test-info-in-production-code.md`)
- [ ] Updated `AGENTS.md` / `ARCHITECTURE.md` if I changed architectural conventions
