### PR TITLE
fix(workflows): a path from another image never empties the shelf

### DIFF
--- a/tests/workflow_manager/test_catalog.py
+++ b/tests/workflow_manager/test_catalog.py
@@ -600,3 +600,49 @@ def test_the_install_path_sees_the_bundles_boot_loaded(tmp_path: Path, monkeypat
     from_registry = ManagerRegistry.get_workflow_manager()
     assert from_registry is booted
     assert [b.slug for b in from_registry.available_bundles()] == ["daily_briefing"]
+
+
+def test_a_path_from_another_image_never_empties_the_shelf(tmp_path: Path, monkeypatch):
+    """The one that actually broke staging for a day.
+
+    The deployment resolves the catalogue inside the comms image, where the
+    package sits at /app/unify_deploy, and stamps that absolute path into an
+    assistant Job whose own image installs it under site-packages. The
+    assistant then logged "Workflow catalogue root
+    /app/unify_deploy/assistant_deployments/workflows does not exist",
+    registered nothing, and every install reported an empty catalogue —
+    with the package two directories away the whole time.
+
+    A configured path is advice from another process. When it is not there,
+    the container's own installed copy is the fact.
+    """
+    from unify.settings import SETTINGS
+    from unify.workflow_manager import catalog as catalog_module
+
+    packaged = tmp_path / "site-packages" / "workflows"
+    packaged.mkdir(parents=True)
+    _write_bundle(packaged)
+
+    monkeypatch.setattr(
+        SETTINGS,
+        "UNITY_WORKFLOWS_DIR",
+        "/app/unify_deploy/assistant_deployments/workflows",
+        raising=False,
+    )
+
+    import sys
+    import types
+
+    module = types.ModuleType("unify_deploy.assistant_deployments.workflows")
+    module.workflows_root = lambda: packaged  # type: ignore[attr-defined]
+    parent = types.ModuleType("unify_deploy.assistant_deployments")
+    root_mod = types.ModuleType("unify_deploy")
+    monkeypatch.setitem(sys.modules, "unify_deploy", root_mod)
+    monkeypatch.setitem(sys.modules, "unify_deploy.assistant_deployments", parent)
+    monkeypatch.setitem(
+        sys.modules,
+        "unify_deploy.assistant_deployments.workflows",
+        module,
+    )
+
+    assert catalog_module.resolve_catalogue_root() == packaged

--- a/unify/workflow_manager/catalog.py
+++ b/unify/workflow_manager/catalog.py
@@ -263,17 +263,42 @@ def resolve_catalogue_root() -> Optional[Path]:
     """
     from ..settings import SETTINGS
 
-    configured = (SETTINGS.UNITY_WORKFLOWS_DIR or "").strip()
-    if configured:
-        root = Path(configured)
-    else:
+    def _packaged_root() -> Optional[Path]:
         try:
             from unify_deploy.assistant_deployments.workflows import workflows_root
 
-            root = workflows_root()
+            return workflows_root()
         except ImportError:
             return None
 
+    configured = (SETTINGS.UNITY_WORKFLOWS_DIR or "").strip()
+    if configured:
+        root = Path(configured)
+        if root.is_dir():
+            return root
+        # A configured path that is not there is advice from somewhere else,
+        # not fact about this container. The deployment resolves the
+        # catalogue inside the comms image — where the package sits at
+        # /app/unify_deploy — and stamps that absolute path into an
+        # assistant Job whose own image installs it under site-packages. The
+        # env var then names a directory that does not exist here, and
+        # trusting it left the shelf empty while the package sat two
+        # directories away.
+        packaged = _packaged_root()
+        if packaged is not None and packaged.is_dir():
+            logger.warning(
+                "Workflow catalogue root %s does not exist in this image; "
+                "using the installed package at %s instead",
+                root,
+                packaged,
+            )
+            return packaged
+        logger.warning("Workflow catalogue root %s does not exist", root)
+        return None
+
+    root = _packaged_root()
+    if root is None:
+        return None
     if not root.is_dir():
         logger.warning("Workflow catalogue root %s does not exist", root)
         return None


### PR DESCRIPTION
The assistant logged "Workflow catalogue root
/app/unify_deploy/assistant_deployments/workflows does not exist", registered nothing, and every install reported an empty catalogue — with the package installed two directories away the whole time.

_workflows_dir_for_runtime resolves the catalogue inside the comms image, where unify_deploy sits at /app, and stamps that absolute path into an assistant Job whose own image installs it under site-packages. The env var then names a directory that does not exist in the container that has to read it, and honouring it produced an empty shelf behind a full catalogue.

A configured path is advice from another process; the package this image installs is the fact. When the configured path is absent the installed copy is used, and the mismatch is logged rather than silently worked around.

The stamping itself is the deeper problem and belongs in unify-deploy: one image cannot know another's filesystem layout.

<!--
Thanks for contributing to Unify! Please fill out the sections below.
For trivial changes (typo fixes, comment-only edits) you can shorten this template — just keep the Summary.

PRs land on `staging`, not `main`. See CONTRIBUTING.md.
-->

## Summary

<!-- 1–3 sentences: what problem does this PR solve, and why is this the right approach? -->



## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes incorrect behavior)
- [ ] Feature (non-breaking change that adds functionality)
- [ ] Refactor (no behavior change)
- [ ] Breaking change (API or data-model change — Unify has zero-backward-compat policy, but please call it out)
- [ ] Test-only (no source changes)
- [ ] Docs / chore / CI

## Areas touched

<!-- Check all that apply. Helps reviewers route. -->

- [ ] Actor / CodeAct
- [ ] ConversationManager / slow brain
- [ ] A specific state manager (Contact / Knowledge / Task / Transcript / Guidance / Function / File / Image / Web / Secret / Blacklist / Data / Memory)
- [ ] Async tool loop (`unify/common/_async_tool/`)
- [ ] Event bus / observability
- [ ] Gateway / external comms
- [ ] Tests / test infra (`tests/`, `conftest.py`, `parallel_run.sh`)
- [ ] CI / build / packaging

## Test plan

<!--
How did you verify this? Paste the command(s) you ran and the result.

The default expectation is to run the relevant directory:
  tests/parallel_run.sh tests/<module>/

For infrastructure changes that are hard to reach via tests, a quick
verification script under tests/_verify_*.py is encouraged
(see .agents/rules/surgical-verification-before-tests.md).
-->

```
tests/parallel_run.sh tests/...
```

- [ ] All relevant tests pass locally
- [ ] If this is a bug fix, I added a regression test (or explained why one isn't feasible)

## Behavior / migration notes

<!--
- Did this change a public manager API, primitive, or event payload?
- Are there schema/context changes in Orchestra that need a migration?
- Any new env vars or config flags? (Update `.env.advanced.example`.)
- If yes to any of the above, describe upgrade steps.
-->

None.

## Checklist

- [ ] PR is targeted at `staging` (not `main`)
- [ ] Followed conventional commit style (`feat(scope):`, `fix(scope):`, `refactor(scope):`, `chore(scope):`, etc.)
- [ ] No `try/except` added defensively — only around specific, recoverable errors
- [ ] No "new" / "updated" / "TODO from chat" temporal comments (see `.agents/rules/no-temporal-comments.md`)
- [ ] No test-specific shortcuts in production code (see `.agents/rules/no-test-info-in-production-code.md`)
- [ ] Updated `AGENTS.md` / `ARCHITECTURE.md` if I changed architectural conventions
