### PR TITLE
fix(conversation): only presence keeps a pod alive

### DIFF
--- a/tests/conversation_manager/core/test_inactivity_activity_source.py
+++ b/tests/conversation_manager/core/test_inactivity_activity_source.py
@@ -1,0 +1,58 @@
+"""What counts as somebody needing the assistant.
+
+An idle pod is retired by the inactivity timer, and that timer used to
+advance on *any* message off the bus — including the system's own chatter.
+One recurring internal event was enough to keep a pod alive indefinitely:
+it never idled out, so it never picked up a newly deployed image, and a
+staging pod served seven hours of requests from a five-hour-old build while
+three deploys went by.
+
+The distinction is presence, not verbosity. `loggable` asks whether an
+event is worth writing down, which is a different question: editing an
+assistant or reading the chat is somebody being there, even when neither is
+worth tracing.
+"""
+
+from unify.conversation_manager.events import (
+    AssistantUpdateEvent,
+    Event,
+    GetBusEventsResponse,
+    GetChatHistory,
+    InitializationComplete,
+    OpenSlowBrainTurn,
+    Ping,
+)
+
+
+def test_only_provably_internal_events_stop_counting_as_presence():
+    # A keepalive says the process is up, never that anyone wants anything.
+    assert Ping.counts_as_activity is False
+    # The pod telling itself it booted, and a reply to its own query.
+    assert InitializationComplete.counts_as_activity is False
+    assert GetBusEventsResponse.counts_as_activity is False
+
+
+def test_a_person_doing_something_still_keeps_the_pod_alive():
+    # These are all `loggable = False`, so gating on that flag would have
+    # treated them as noise — someone editing their assistant config, or
+    # reading the conversation, would have stopped holding the pod open.
+    for event_class in (AssistantUpdateEvent, GetChatHistory, OpenSlowBrainTurn):
+        assert event_class.loggable is False
+        assert (
+            event_class.counts_as_activity is True
+        ), f"{event_class.__name__} is somebody doing something"
+
+
+def test_the_default_is_to_count():
+    """A new event counts until someone proves it should not.
+
+    The safe direction is keeping a live pod alive: wrongly counting costs
+    an idle pod some extra minutes, wrongly discounting drops a session
+    somebody is in the middle of.
+    """
+    assert Event.counts_as_activity is True
+
+    class _NewlyAddedEvent(Event):
+        pass
+
+    assert _NewlyAddedEvent.counts_as_activity is True

--- a/unify/conversation_manager/comms_manager.py
+++ b/unify/conversation_manager/comms_manager.py
@@ -2941,20 +2941,22 @@ class CommsManager:
                     "app:comms:ping",
                     Ping(kind="keepalive").to_json(),
                 )
-
-                # Wait 30 seconds before next ping (pre-startup keepalive)
-                await asyncio.sleep(30)
-
-                # Check if we've received a startup message (indicated by assistant_id changed)
-                if SESSION_DETAILS.assistant.agent_id is not None:
-                    LOGGER.debug(
-                        f"{ICONS['subscription']} Startup received, stopping ping mechanism",
-                    )
-                    break
-
             except Exception as e:
                 LOGGER.error(f"{ICONS['subscription']} Error in ping mechanism: {e}")
-                await asyncio.sleep(30)  # Continue trying
+
+            # Wait 30 seconds before next ping (pre-startup keepalive)
+            await asyncio.sleep(30)
+
+            # Check if we've received a startup message (indicated by
+            # assistant_id changed). Outside the try on purpose: this used to
+            # sit after the publish inside it, so any exception jumped over
+            # the only exit this loop has and left a pre-startup keepalive
+            # running for the life of the pod.
+            if SESSION_DETAILS.assistant.agent_id is not None:
+                LOGGER.debug(
+                    f"{ICONS['subscription']} Startup received, stopping ping mechanism",
+                )
+                break
 
 
 async def main():

--- a/unify/conversation_manager/conversation_manager.py
+++ b/unify/conversation_manager/conversation_manager.py
@@ -388,6 +388,7 @@ class ConversationManager(metaclass=SingletonABCMeta):
         self.inactivity_timeout = 3600  # 1 hour in seconds
         self.inactivity_check_interval = 30  # seconds
         self.last_activity_time = self.loop.time()
+        self._last_activity_source = "startup"
         self.shutdown_reason: str | None = None
         self.stop = stop
 
@@ -2800,12 +2801,22 @@ class ConversationManager(metaclass=SingletonABCMeta):
 
                 if not msg:
                     continue
-                self.last_activity_time = self.loop.time()
                 # process events
                 event = Event.from_json(msg["data"])
                 channel = msg.get("channel", "")
                 if isinstance(channel, bytes):
                     channel = channel.decode("utf-8", errors="replace")
+                # Only a message that means somebody needs the assistant
+                # keeps the pod alive. This used to advance on *any* traffic,
+                # so the system's own chatter — invisible, because those
+                # events are not loggable either — held a pod open
+                # indefinitely: it never idled out, so it never picked up a
+                # new image, and deploys could not reach it.
+                if event.__class__.counts_as_activity:
+                    self.last_activity_time = self.loop.time()
+                    self._last_activity_source = (
+                        f"{event.__class__.__name__} on {channel or '-'}"
+                    )
                 self._event_trace_seq += 1
                 event_id = f"evt-{self._event_trace_seq:06d}"
                 event_name = event.__class__.__name__
@@ -2939,7 +2950,8 @@ class ConversationManager(metaclass=SingletonABCMeta):
                     )
                 self._session_logger.info(
                     "inactivity_check",
-                    f"Idle check: pubsub_idle={pubsub_idle:.1f}s, "
+                    f"Idle check: last_activity={self._last_activity_source}, "
+                    f"pubsub_idle={pubsub_idle:.1f}s, "
                     f"eventbus_idle={eventbus_idle:.1f}s, "
                     f"min_idle={idle_seconds:.1f}s, "
                     f"effective_idle={effective_idle_seconds:.1f}s, "

--- a/unify/conversation_manager/events.py
+++ b/unify/conversation_manager/events.py
@@ -66,6 +66,20 @@ class Event:
 
     _registry: ClassVar[dict[str, "Event"]] = {}
     loggable: ClassVar[bool] = True
+    # Whether receiving this event means somebody needs the assistant.
+    #
+    # The inactivity timer is what retires an idle pod, and it used to
+    # advance on *any* message off the bus — including the system's own
+    # chatter. One recurring internal event was enough to keep a pod alive
+    # indefinitely: it never idled out, so it never picked up a new image,
+    # and a deploy could not reach it.
+    #
+    # Deliberately not `loggable`: that flag asks whether an event is worth
+    # writing down, which is a different question. Editing an assistant or
+    # reading the chat is presence even when it is not worth tracing.
+    # Defaults to True so a new event counts until someone proves it should
+    # not — the safe direction is keeping a live pod alive.
+    counts_as_activity: ClassVar[bool] = True
     content_logged: ClassVar[bool] = False
     prominent: ClassVar[bool] = False
     topic: ClassVar[str | None] = None
@@ -1576,6 +1590,8 @@ class InitializationComplete(Event):
     """Published when ConversationManager has fully initialized all managers."""
 
     loggable: ClassVar[bool] = False
+    # The pod telling itself it finished booting.
+    counts_as_activity: ClassVar[bool] = False
 
 
 @dataclass
@@ -1595,6 +1611,9 @@ class AssistantUpdateEvent(_SessionConfigBase):
 @dataclass
 class Ping(Event):
     loggable: ClassVar[bool] = False
+    # A keepalive by name and purpose; it says the process is up, never
+    # that anyone wants anything.
+    counts_as_activity: ClassVar[bool] = False
     kind: str
 
 
@@ -1639,6 +1658,8 @@ class GetChatHistory(_TruncatedReprMixin, Event):
 @dataclass(repr=False)
 class GetBusEventsResponse(_TruncatedReprMixin, Event):
     loggable: ClassVar[bool] = False
+    # A reply to a query this process asked itself.
+    counts_as_activity: ClassVar[bool] = False
     events: list[dict[str, Any]]
 
     def _repr_truncated(self) -> str:


### PR DESCRIPTION
The inactivity timer advanced on any message off the bus, including the system's own chatter, and those events are not loggable either — so a recurring internal event held a pod open indefinitely while writing nothing anywhere. A staging pod served seven hours from a five-hour-old image across three deploys, because a pod that never idles out never restarts.

Presence is now an explicit flag rather than a borrowed one. `loggable` asks whether an event is worth writing down, which is a different question: editing an assistant or reading the chat is somebody being there even when neither is worth tracing, and gating on it would have dropped sessions mid-configuration. `counts_as_activity` defaults to True, and only a keepalive, a boot notification and a self-query reply opt out — wrongly counting costs an idle pod minutes, wrongly discounting drops a live session.

The idle check now names the event class and channel that last touched the clock. It printed four numbers and omitted the only one that identified the cause.

Also moves the ping loop's exit out of its try. Any exception between the publish and the check jumped over the only way that loop ends.

<!--
Thanks for contributing to Unify! Please fill out the sections below.
For trivial changes (typo fixes, comment-only edits) you can shorten this template — just keep the Summary.

PRs land on `staging`, not `main`. See CONTRIBUTING.md.
-->

## Summary

<!-- 1–3 sentences: what problem does this PR solve, and why is this the right approach? -->



## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes incorrect behavior)
- [ ] Feature (non-breaking change that adds functionality)
- [ ] Refactor (no behavior change)
- [ ] Breaking change (API or data-model change — Unify has zero-backward-compat policy, but please call it out)
- [ ] Test-only (no source changes)
- [ ] Docs / chore / CI

## Areas touched

<!-- Check all that apply. Helps reviewers route. -->

- [ ] Actor / CodeAct
- [ ] ConversationManager / slow brain
- [ ] A specific state manager (Contact / Knowledge / Task / Transcript / Guidance / Function / File / Image / Web / Secret / Blacklist / Data / Memory)
- [ ] Async tool loop (`unify/common/_async_tool/`)
- [ ] Event bus / observability
- [ ] Gateway / external comms
- [ ] Tests / test infra (`tests/`, `conftest.py`, `parallel_run.sh`)
- [ ] CI / build / packaging

## Test plan

<!--
How did you verify this? Paste the command(s) you ran and the result.

The default expectation is to run the relevant directory:
  tests/parallel_run.sh tests/<module>/

For infrastructure changes that are hard to reach via tests, a quick
verification script under tests/_verify_*.py is encouraged
(see .agents/rules/surgical-verification-before-tests.md).
-->

```
tests/parallel_run.sh tests/...
```

- [ ] All relevant tests pass locally
- [ ] If this is a bug fix, I added a regression test (or explained why one isn't feasible)

## Behavior / migration notes

<!--
- Did this change a public manager API, primitive, or event payload?
- Are there schema/context changes in Orchestra that need a migration?
- Any new env vars or config flags? (Update `.env.advanced.example`.)
- If yes to any of the above, describe upgrade steps.
-->

None.

## Checklist

- [ ] PR is targeted at `staging` (not `main`)
- [ ] Followed conventional commit style (`feat(scope):`, `fix(scope):`, `refactor(scope):`, `chore(scope):`, etc.)
- [ ] No `try/except` added defensively — only around specific, recoverable errors
- [ ] No "new" / "updated" / "TODO from chat" temporal comments (see `.agents/rules/no-temporal-comments.md`)
- [ ] No test-specific shortcuts in production code (see `.agents/rules/no-test-info-in-production-code.md`)
- [ ] Updated `AGENTS.md` / `ARCHITECTURE.md` if I changed architectural conventions
