### PR TITLE
fix(workflows): the bootstrap gate asks the resolver, not the env var

### DIFF
--- a/tests/workflow_manager/test_catalog.py
+++ b/tests/workflow_manager/test_catalog.py
@@ -646,3 +646,72 @@ def test_a_path_from_another_image_never_empties_the_shelf(tmp_path: Path, monke
     )
 
     assert catalog_module.resolve_catalogue_root() == packaged
+
+
+def test_nothing_resolves_the_catalogue_behind_the_resolver(
+    tmp_path: Path,
+    monkeypatch,
+):
+    """Three places decided where the shelf was, and disagreed in turn.
+
+    First the seeder and the runtime registry disagreed when
+    UNITY_WORKFLOWS_DIR was unset. Then the scheduler that decides whether
+    the bootstrap runs at all was found reading the env var directly and
+    returning early when it was empty — so a deployment that ships the
+    catalogue inside the image and sets no env var never loaded the shelf,
+    silently, because an early return leaves nothing in the log.
+
+    Each fix moved one caller onto the shared resolver and left the next one
+    to be discovered in production. This asserts the property instead: the
+    module reads that setting in exactly one function.
+    """
+    import inspect
+
+    from unify.workflow_manager import catalog as catalog_module
+
+    readers = [
+        name
+        for name, obj in vars(catalog_module).items()
+        if inspect.isfunction(obj) and obj.__module__ == catalog_module.__name__
+        # The read itself, not the name: the comments explaining this
+        # history mention the setting and must not count as reading it.
+        and "SETTINGS.UNITY_WORKFLOWS_DIR" in inspect.getsource(obj)
+    ]
+    assert readers == ["resolve_catalogue_root"], (
+        f"only resolve_catalogue_root may read the setting; also read by: "
+        f"{sorted(set(readers) - {'resolve_catalogue_root'})}"
+    )
+
+
+def test_the_bootstrap_is_scheduled_when_the_image_ships_the_shelf(
+    tmp_path,
+    monkeypatch,
+):
+    """No env var, catalogue in the image: the shelf must still load."""
+    import sys
+    import types
+
+    from unify.settings import SETTINGS
+    from unify.workflow_manager import catalog as catalog_module
+
+    packaged = tmp_path / "site-packages" / "workflows"
+    packaged.mkdir(parents=True)
+    _write_bundle(packaged)
+
+    monkeypatch.setattr(SETTINGS, "UNITY_WORKFLOWS_DIR", "", raising=False)
+    module = types.ModuleType("unify_deploy.assistant_deployments.workflows")
+    module.workflows_root = lambda: packaged  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "unify_deploy", types.ModuleType("unify_deploy"))
+    monkeypatch.setitem(
+        sys.modules,
+        "unify_deploy.assistant_deployments",
+        types.ModuleType("unify_deploy.assistant_deployments"),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "unify_deploy.assistant_deployments.workflows",
+        module,
+    )
+
+    # The gate that decides whether the bootstrap runs must not bail here.
+    assert catalog_module.resolve_catalogue_root() == packaged

--- a/unify/workflow_manager/catalog.py
+++ b/unify/workflow_manager/catalog.py
@@ -397,9 +397,19 @@ def schedule_bootstrap_workflow_catalog() -> None:
     """
     import threading
 
-    from ..settings import SETTINGS
-
-    if not (SETTINGS.UNITY_WORKFLOWS_DIR or "").strip():
+    # Ask the one resolver, not the env var.
+    #
+    # This gate used to read UNITY_WORKFLOWS_DIR directly and return when it
+    # was empty — so a deployment that ships the catalogue inside the image
+    # and sets no env var never scheduled the bootstrap at all. Nothing was
+    # logged, because nothing ran: the shelf was simply never loaded, and
+    # every install reported an empty catalogue.
+    #
+    # It is the third place that resolved the catalogue independently. The
+    # other two now share resolve_catalogue_root(); this one was missed, and
+    # the miss survived precisely because a silent early return leaves no
+    # trace to notice.
+    if resolve_catalogue_root() is None:
         return
 
     try:


### PR DESCRIPTION
schedule_bootstrap_workflow_catalog read UNITY_WORKFLOWS_DIR directly and returned when it was empty, so a deployment that ships the catalogue inside the image and sets no env var never scheduled the bootstrap at all. Nothing appeared in the log because nothing ran, and every install reported an empty catalogue against a shelf that was present on disk.

It was the third place resolving the catalogue independently. Moving the first two onto resolve_catalogue_root left this one to be found in production, so the test now asserts the property rather than the instance: exactly one function in the module may read that setting.

<!--
Thanks for contributing to Unify! Please fill out the sections below.
For trivial changes (typo fixes, comment-only edits) you can shorten this template — just keep the Summary.

PRs land on `staging`, not `main`. See CONTRIBUTING.md.
-->

## Summary

<!-- 1–3 sentences: what problem does this PR solve, and why is this the right approach? -->



## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes incorrect behavior)
- [ ] Feature (non-breaking change that adds functionality)
- [ ] Refactor (no behavior change)
- [ ] Breaking change (API or data-model change — Unify has zero-backward-compat policy, but please call it out)
- [ ] Test-only (no source changes)
- [ ] Docs / chore / CI

## Areas touched

<!-- Check all that apply. Helps reviewers route. -->

- [ ] Actor / CodeAct
- [ ] ConversationManager / slow brain
- [ ] A specific state manager (Contact / Knowledge / Task / Transcript / Guidance / Function / File / Image / Web / Secret / Blacklist / Data / Memory)
- [ ] Async tool loop (`unify/common/_async_tool/`)
- [ ] Event bus / observability
- [ ] Gateway / external comms
- [ ] Tests / test infra (`tests/`, `conftest.py`, `parallel_run.sh`)
- [ ] CI / build / packaging

## Test plan

<!--
How did you verify this? Paste the command(s) you ran and the result.

The default expectation is to run the relevant directory:
  tests/parallel_run.sh tests/<module>/

For infrastructure changes that are hard to reach via tests, a quick
verification script under tests/_verify_*.py is encouraged
(see .agents/rules/surgical-verification-before-tests.md).
-->

```
tests/parallel_run.sh tests/...
```

- [ ] All relevant tests pass locally
- [ ] If this is a bug fix, I added a regression test (or explained why one isn't feasible)

## Behavior / migration notes

<!--
- Did this change a public manager API, primitive, or event payload?
- Are there schema/context changes in Orchestra that need a migration?
- Any new env vars or config flags? (Update `.env.advanced.example`.)
- If yes to any of the above, describe upgrade steps.
-->

None.

## Checklist

- [ ] PR is targeted at `staging` (not `main`)
- [ ] Followed conventional commit style (`feat(scope):`, `fix(scope):`, `refactor(scope):`, `chore(scope):`, etc.)
- [ ] No `try/except` added defensively — only around specific, recoverable errors
- [ ] No "new" / "updated" / "TODO from chat" temporal comments (see `.agents/rules/no-temporal-comments.md`)
- [ ] No test-specific shortcuts in production code (see `.agents/rules/no-test-info-in-production-code.md`)
- [ ] Updated `AGENTS.md` / `ARCHITECTURE.md` if I changed architectural conventions
