### PR TITLE
feat(workflows): a workflow runs on request, and takes the app you have

### DIFF
--- a/tests/workflow_manager/test_catalog.py
+++ b/tests/workflow_manager/test_catalog.py
@@ -299,20 +299,6 @@ def test_content_rows_publish_what_the_artifacts_own_page_shows(tmp_path: Path):
     assert guidance_meta == {}
 
 
-def test_manifest_declares_its_provisioning_one_shot(tmp_path: Path):
-    """The long thing a workflow needs done before its recurring job means
-    anything — a mailbox backfill, a CRM import. Named rather than inferred so
-    a bundle can ship several tasks and be explicit about which is setup."""
-    bundle_dir = _write_bundle(tmp_path)
-
-    # Absent means the workflow needs no provisioning, not an error.
-    assert load_bundle(bundle_dir).install_task == ""
-
-    manifest = (bundle_dir / MANIFEST_FILENAME).read_text()
-    (bundle_dir / MANIFEST_FILENAME).write_text(manifest + "install_task: wf/morning\n")
-    assert load_bundle(bundle_dir).install_task == "wf/morning"
-
-
 # --------------------------------------------------------------------- #
 # Canvas + data: what a bundle may ship, and what it may not            #
 # --------------------------------------------------------------------- #
@@ -465,15 +451,85 @@ def test_a_requirement_publishes_how_it_is_resolved(tmp_path: Path):
             "slug": "gmail",
             "name": "Gmail",
             "kind": "app",
+            "alternatives": [],
             "required_secrets": [],
         },
         {
             "slug": "google_workspace",
             "name": "Google Workspace",
             "kind": "workspace",
+            "alternatives": [],
             "required_secrets": ["GOOGLE_REFRESH_TOKEN"],
         },
     ]
+
+
+def test_a_requirement_publishes_every_app_that_would_satisfy_it(tmp_path: Path):
+    """A choice the bundle offers has to survive publication.
+
+    The requirement is met by any one of its apps, so a reader that saw only
+    the first would offer a Slack connect to someone on Discord for a
+    workflow that serves them identically.
+    """
+    from unify.workflow_manager.builtins_catalog import catalog_row
+    from unify.workflow_manager.bundle import RequirementOption, WorkflowRequirement
+
+    bundle = load_bundle(_write_bundle(tmp_path))
+    published = json.loads(
+        catalog_row(
+            WorkflowBundle(
+                slug=bundle.slug,
+                name=bundle.name,
+                requirements=(
+                    WorkflowRequirement(
+                        slug="slack",
+                        name="Slack",
+                        alternatives=(
+                            RequirementOption("discord", "Discord"),
+                            # Name omitted on purpose: the slug stands in, so
+                            # a chip is never blank.
+                            RequirementOption("microsoft_teams"),
+                        ),
+                    ),
+                ),
+            ),
+        )["requirements"],
+    )
+
+    assert published[0]["alternatives"] == [
+        {"slug": "discord", "name": "Discord"},
+        {"slug": "microsoft_teams", "name": "microsoft_teams"},
+    ]
+
+
+def test_alternatives_are_read_from_the_manifest(tmp_path: Path):
+    """Declared as slugs or as mappings, in recommendation order."""
+    bundle_dir = _write_bundle(tmp_path)
+    manifest = _MANIFEST.replace(
+        """requirements:
+  - slug: gmail
+    name: Gmail
+    required_secrets: [GMAIL_TOKEN]
+  - notion
+""",
+        """requirements:
+  - slug: slack
+    name: Slack
+    alternatives:
+      - slug: discord
+        name: Discord
+      - microsoft_teams
+""",
+    )
+    (bundle_dir / MANIFEST_FILENAME).write_text(manifest)
+
+    requirement = load_bundle(bundle_dir).requirements[0]
+    assert [option.slug for option in requirement.options] == [
+        "slack",
+        "discord",
+        "microsoft_teams",
+    ]
+    assert requirement.options[2].display_name == "microsoft_teams"
 
 
 def test_a_missing_tree_never_reads_as_an_empty_shelf(tmp_path: Path, monkeypatch):

--- a/tests/workflow_manager/test_install_uninstall_live.py
+++ b/tests/workflow_manager/test_install_uninstall_live.py
@@ -267,7 +267,18 @@ async def test_install_arms_tasks_and_holds_them_while_disconnected(
     assert result["connect_required"]["requirements"][0]["slug"] == "gmail"
     (task_row,) = _rows(ts._ctx, SLUG)
     assert task_row["enabled"] is False
-    assert wm.get_workflow(slug=SLUG)["status"] == "needs_connection"
+    held = wm.get_workflow(slug=SLUG)
+    assert held["status"] == "needs_connection"
+    # The planted job is named on the record, held rather than hidden: this
+    # is what "run it now" resolves to, and a caller has to be able to see
+    # both the id and that starting it would be refused.
+    assert held["jobs"] == [
+        {
+            "task_id": int(task_row["task_id"]),
+            "name": task_row["name"],
+            "enabled": False,
+        },
+    ]
 
     # The connection lands: the repeat install is the arm-on-connect path.
     monkeypatch.setattr(
@@ -281,7 +292,15 @@ async def test_install_arms_tasks_and_holds_them_while_disconnected(
     assert len(result["tasks_armed"]) == 1
     (task_row,) = _rows(ts._ctx, SLUG)
     assert task_row["enabled"] is True
-    assert wm.get_workflow(slug=SLUG)["status"] == "active"
+    armed = wm.get_workflow(slug=SLUG)
+    assert armed["status"] == "active"
+    assert armed["jobs"] == [
+        {
+            "task_id": int(task_row["task_id"]),
+            "name": task_row["name"],
+            "enabled": True,
+        },
+    ]
 
     wm.uninstall_workflow(slug=SLUG)
     assert _rows(ts._ctx, SLUG) == []

--- a/tests/workflow_manager/test_shelf_acceptance.py
+++ b/tests/workflow_manager/test_shelf_acceptance.py
@@ -199,6 +199,20 @@ async def test_bundle_full_lifecycle(slug, live_managers, monkeypatch):
         }
         if requirement.kind == "workspace":
             entry["missing_secrets"] = list(requirement.required_secrets)
+        # A requirement the bundle lets the user satisfy more than one way
+        # reports every option with its own state, because the reader offers
+        # all of them: naming only the first would send someone who uses
+        # Discord to connect Slack.
+        if len(requirement.options) > 1:
+            entry["options"] = [
+                {
+                    "slug": option.slug,
+                    "name": option.display_name,
+                    "connected": False,
+                    "via": "connection",
+                }
+                for option in requirement.options
+            ]
         return entry
 
     assert result["connect_required"]["requirements"] == [

--- a/unify/actor/prompt_builders.py
+++ b/unify/actor/prompt_builders.py
@@ -170,10 +170,19 @@ _WORKFLOW_SHELF = textwrap.dedent("""
 
     **After install, everything is ordinary.** Planted procedures are
     found by the same guidance search as any other; planted tasks are
-    ordinary tasks, run and steered through the usual task tools. There
-    is no workflow-level "run": running means triggering the workflow's
-    own task. Uninstalling removes what the workflow planted and stops
-    its jobs — name them before confirming.
+    ordinary tasks, run and steered through the usual task tools.
+    Uninstalling removes what the workflow planted and stops its jobs —
+    name them before confirming.
+
+    **Running one is always explicit.** Installing plants and arms; it
+    never runs. When the user asks for a workflow's work now — "run my
+    briefing", "do the review sweep" — take the `task_id` from that
+    installation's `jobs` (in `WorkflowManager_get_workflow`, or the
+    installed entries of `WorkflowManager_list_workflows`) and start it
+    with `primitives.tasks.execute`. There is no workflow-level run,
+    because a workflow has no runtime: the task it planted does. A job
+    reporting `enabled: false` is held on a missing connection, and
+    starting it is refused — say which app to connect instead.
 """)
 
 

--- a/unify/task_scheduler/task_scheduler.py
+++ b/unify/task_scheduler/task_scheduler.py
@@ -2024,6 +2024,43 @@ class TaskScheduler(BaseTaskScheduler):
                 )
         return last_result
 
+    def list_custom_tasks(
+        self,
+        *,
+        managed_by: str,
+        destination: str | None = None,
+    ) -> List[Dict[str, Any]]:
+        """The task definitions one source planted, with their ids.
+
+        The counterpart to :meth:`set_custom_tasks_enabled`: the installer
+        that plants and arms a source's tasks also has to be able to name
+        them, so a caller can start one on demand. Resolved here rather
+        than by the caller, because the context a destination maps to is
+        this manager's to decide.
+        """
+        tasks_context, _meta_context, _is_personal = self._sync_destination_contexts(
+            destination,
+        )
+        store = self._store_for_task_context(tasks_context)
+        rows = store.get_rows(filter=managed_rows_filter(managed_by), limit=1000)
+        planted: List[Dict[str, Any]] = []
+        for row in rows:
+            entries = dict(row.entries or {})
+            task_id = entries.get("task_id")
+            if task_id is None:
+                continue
+            planted.append(
+                {
+                    "task_id": int(task_id),
+                    "name": entries.get("name", ""),
+                    # False while the source holds them on a missing
+                    # connection: the definition exists and nothing will
+                    # start it, an explicit run included.
+                    "enabled": entries.get("enabled") is not False,
+                },
+            )
+        return sorted(planted, key=lambda task: task["task_id"])
+
     def set_custom_tasks_enabled(
         self,
         *,

--- a/unify/workflow_manager/base.py
+++ b/unify/workflow_manager/base.py
@@ -104,7 +104,11 @@ class BaseWorkflowManager(BaseStateManager, metaclass=SingletonABCMeta):
         -------
         A dict with ``workflows`` (a list of entries, each carrying at
         least ``slug``, ``name``, ``description``, and ``installed``) and
-        ``total``.
+        ``total``. An installed entry also carries ``jobs``: the tasks that
+        installation planted, with their ``task_id``, name and whether they
+        are armed. Those ids are how a workflow is run on demand — a
+        workflow has no run of its own, so running one means starting one
+        of its tasks with the ordinary task tools.
         """
         raise NotImplementedError
 
@@ -144,6 +148,10 @@ class BaseWorkflowManager(BaseStateManager, metaclass=SingletonABCMeta):
         destination:
             ``None`` for personal, or ``team:<id>`` to install for a whole
             team. A team install plants content for every member.
+
+        Installing never runs anything. It plants content and arms the
+        schedule; the first run happens at the job's next occurrence, or
+        when someone explicitly asks for one.
 
         Returns
         -------
@@ -272,7 +280,9 @@ class BaseWorkflowManager(BaseStateManager, metaclass=SingletonABCMeta):
 
         Returns
         -------
-        The workflow record, or a not-found result if no such bundle exists.
+        The workflow record, or a not-found result if no such bundle
+        exists. An installed one carries ``jobs``: the tasks it planted,
+        with the ``task_id`` needed to run one on demand.
         """
         raise NotImplementedError
 

--- a/unify/workflow_manager/builtins_catalog.py
+++ b/unify/workflow_manager/builtins_catalog.py
@@ -176,6 +176,14 @@ def catalog_row(bundle: WorkflowBundle) -> Dict[str, Any]:
                     # "couldn't check this app" about the one requirement
                     # whose answer never depended on the gallery.
                     "kind": requirement.kind,
+                    # Every app that would satisfy it, recommended first.
+                    # A reader that only saw the first one would offer a
+                    # Slack connect to a Discord user for a workflow that
+                    # serves them identically.
+                    "alternatives": [
+                        {"slug": option.slug, "name": option.display_name}
+                        for option in requirement.alternatives
+                    ],
                     "required_secrets": list(requirement.required_secrets),
                 }
                 for requirement in bundle.requirements

--- a/unify/workflow_manager/bundle.py
+++ b/unify/workflow_manager/bundle.py
@@ -90,6 +90,12 @@ class Surface:
     ``enabled`` and ``destination`` keywords. ``None`` for surfaces whose
     content is inert until read (guidance, knowledge, functions)."""
 
+    lister: Callable[..., Any] | None = None
+    """Reports one source's planted rows on the surfaces where a caller
+    needs their ids — tasks, which are what "run this workflow now"
+    resolves to. Called with ``managed_by`` and ``destination``. ``None``
+    for surfaces whose rows are only ever read where they live."""
+
     def arm(self, *, managed_by: str, enabled: bool, destination: str | None) -> Any:
         if self.armer is None:
             return None
@@ -98,6 +104,11 @@ class Surface:
             enabled=enabled,
             destination=destination,
         )
+
+    def planted(self, *, managed_by: str, destination: str | None) -> Any:
+        if self.lister is None:
+            return None
+        return self.lister(managed_by=managed_by, destination=destination)
 
     def sync(
         self,
@@ -170,6 +181,18 @@ class CanvasSource:
 
 
 @dataclass(frozen=True)
+class RequirementOption:
+    """One app that would satisfy a requirement."""
+
+    slug: str
+    name: str = ""
+
+    @property
+    def display_name(self) -> str:
+        return self.name or self.slug
+
+
+@dataclass(frozen=True)
 class WorkflowRequirement:
     """One integration a workflow needs connected before its jobs may run.
 
@@ -207,6 +230,21 @@ class WorkflowRequirement:
     it as an app is what led to a name-matching table deciding that anything
     starting with "GMAIL" or "GOOGLE" wanted a pasted refresh token."""
 
+    alternatives: tuple[RequirementOption, ...] = ()
+    """Other apps that would satisfy this same requirement, any one of
+    them instead of :attr:`slug`.
+
+    A workflow needs a *capability* — somewhere to post, a calendar to
+    read — and the app providing it is the user's choice, not the
+    bundle's. Declaring Slack and stopping there excludes everyone on
+    Discord or Teams from a workflow that would serve them identically.
+
+    Order is the recommendation: :attr:`slug` first, then these. The
+    requirement is met as soon as any one of them is connected, and a
+    reader offers the whole set so the user connects the one they
+    already use. Keep the list short and genuinely interchangeable —
+    alternatives the planted procedures can all actually drive."""
+
     required_secrets: tuple[str, ...] = ()
     """Secret names whose presence marks this requirement connected, for
     apps no other authority can answer for — a BYOD OAuth provider with
@@ -217,6 +255,11 @@ class WorkflowRequirement:
     two places to update when the package changes. Empty with no other
     authority reads as met, so a bundle cannot hold its jobs hostage to a
     signal nothing can check."""
+
+    @property
+    def options(self) -> tuple[RequirementOption, ...]:
+        """Every app that satisfies this requirement, recommended first."""
+        return (RequirementOption(self.slug, self.name), *self.alternatives)
 
 
 @dataclass
@@ -251,20 +294,6 @@ class WorkflowBundle:
     requirements: tuple[WorkflowRequirement, ...] = ()
     """Integrations that must be connected before this workflow's jobs
     are armed. Checked at install and on every reconcile."""
-
-    install_task: str = ""
-    """``custom_key`` of a task in this bundle to run **once**, after content
-    lands on a first install.
-
-    The provisioning one-shot: a mailbox backfill, a CRM import — the long
-    thing a workflow needs done before its recurring job is meaningful. Named
-    rather than inferred so a bundle can ship several tasks and be explicit
-    about which one is setup. Empty means the workflow needs no provisioning.
-
-    Deliberately an ordinary task rather than new machinery: durability,
-    resumability, steering and observability come from TaskScheduler, and the
-    workflow/task boundary stays intact — a workflow still has no runtime, it
-    just asked for a task to be run."""
 
     capabilities: tuple[str, ...] = ()
     """Assistant capabilities the workflow needs beyond connected apps,
@@ -321,6 +350,7 @@ class SurfaceRegistry:
         source_scoped: bool,
         shared: bool = False,
         armer: Callable[..., Any] | None = None,
+        lister: Callable[..., Any] | None = None,
     ) -> None:
         if not source_scoped:
             raise UnscopedSurfaceError(name)
@@ -330,6 +360,7 @@ class SurfaceRegistry:
             source_kwarg=source_kwarg,
             shared=shared,
             armer=armer,
+            lister=lister,
         )
 
     def get(self, name: str) -> Surface:

--- a/unify/workflow_manager/catalog.py
+++ b/unify/workflow_manager/catalog.py
@@ -30,7 +30,12 @@ from typing import Any, Dict, List, Optional
 
 import yaml
 
-from .bundle import CanvasSource, WorkflowBundle, WorkflowRequirement
+from .bundle import (
+    CanvasSource,
+    RequirementOption,
+    WorkflowBundle,
+    WorkflowRequirement,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -55,10 +60,37 @@ def _parse_requirements(raw: Any, *, slug: str) -> tuple[WorkflowRequirement, ..
                 slug=str(entry["slug"]),
                 name=str(entry.get("name", "")),
                 kind=str(entry.get("kind", "app")),
+                alternatives=_parse_alternatives(
+                    entry.get("alternatives"),
+                    slug=slug,
+                ),
                 required_secrets=tuple(entry.get("required_secrets") or ()),
             ),
         )
     return tuple(requirements)
+
+
+def _parse_alternatives(raw: Any, *, slug: str) -> tuple[RequirementOption, ...]:
+    """Interchangeable apps for one requirement, in recommendation order."""
+    if not raw:
+        return ()
+    options: List[RequirementOption] = []
+    for entry in raw:
+        if isinstance(entry, str):
+            options.append(RequirementOption(slug=entry))
+            continue
+        if not isinstance(entry, dict) or not entry.get("slug"):
+            raise ValueError(
+                f"Workflow {slug!r}: each alternative is a slug string or a "
+                f"mapping with at least 'slug'; got {entry!r}.",
+            )
+        options.append(
+            RequirementOption(
+                slug=str(entry["slug"]),
+                name=str(entry.get("name", "")),
+            ),
+        )
+    return tuple(options)
 
 
 def _collect_surfaces(path: Path) -> Dict[str, Dict[str, Dict[str, Any]]]:
@@ -225,7 +257,6 @@ def load_bundle(path: Path) -> WorkflowBundle:
             manifest.get("requirements"),
             slug=slug,
         ),
-        install_task=str(manifest.get("install_task", "")),
         capabilities=tuple(manifest.get("capabilities") or ()),
         canvas=_collect_canvas(path),
     )

--- a/unify/workflow_manager/requirements.py
+++ b/unify/workflow_manager/requirements.py
@@ -16,6 +16,12 @@ package, and it is connected in the onboarding and profile flows rather than
 the integrations gallery. A requirement declares ``kind: workspace`` for it,
 and the refresh-token secret those flows store is its signal.
 
+**A requirement may name several interchangeable apps.** What a workflow
+needs is a capability — somewhere to post, a calendar to read — and which app
+provides it is the user's choice. Every declared option is resolved and the
+first connected one settles the requirement; the rest travel with the answer
+so a reader can offer the app the user already has.
+
 **Absence of evidence is "not connected".** A named requirement is by
 definition something that needs connecting, so nothing having answered means
 unmet. The older default treated it as met, which armed jobs against apps
@@ -180,11 +186,52 @@ class RequirementResolver:
         caller explain an unmet requirement: a provider-backed app needs
         the gallery's connect flow, a secret-gated one needs a value
         pasted.
+
+        A requirement that offers alternatives is met by any one of them,
+        so each is resolved in recommendation order and the first
+        connected answer wins. ``options`` carries all of them with their
+        own state, which is what lets a reader offer the app the user
+        already has rather than the one the bundle happened to name first.
         """
-        slug = _normalize(requirement.slug)
+        options = getattr(requirement, "options", None) or ()
+        if len(options) > 1:
+            reports = [
+                self._resolve_app(option.slug, option.display_name, requirement)
+                for option in options
+            ]
+            satisfied = next(
+                (entry for entry in reports if entry.get("connected")),
+                None,
+            )
+            answer = dict(satisfied or reports[0])
+            answer["options"] = reports
+            # The requirement keeps the identity the bundle declared even
+            # when a different app satisfied it: that is what a reader
+            # matches its own resolution against, and what an uninstall or
+            # a re-read looks up.
+            answer["slug"] = requirement.slug
+            answer["name"] = requirement.name or requirement.slug
+            if satisfied is not None:
+                answer["satisfied_by"] = satisfied["slug"]
+            return answer
+
+        return self._resolve_app(
+            requirement.slug,
+            requirement.name or requirement.slug,
+            requirement,
+        )
+
+    def _resolve_app(
+        self,
+        app_slug: str,
+        display_name: str,
+        requirement: Any,
+    ) -> Dict[str, Any]:
+        """Resolve one app, consulting each authority in turn."""
+        slug = _normalize(app_slug)
         report: Dict[str, Any] = {
-            "slug": requirement.slug,
-            "name": requirement.name or requirement.slug,
+            "slug": app_slug,
+            "name": display_name,
         }
 
         # Workspace first, because it is not an integration at all: not in the

--- a/unify/workflow_manager/surfaces.py
+++ b/unify/workflow_manager/surfaces.py
@@ -85,9 +85,9 @@ favour of canvas.
 view is real TypeScript that has to be linted, typechecked, bundled,
 rendered and published against the kit installed *now*, and its routing
 token has a lifecycle the reconcile engine has no business owning. A
-bundle ships canvas **source**; the install-time provisioning pass hands
-it to CanvasManager's own authoring pipeline and uninstall deletes
-through the manager's own delete, which already releases the token.
+bundle ships canvas **source**; the install hands it to CanvasManager's
+own authoring pipeline and uninstall deletes through the manager's own
+delete, which already releases the token.
 """
 
 
@@ -125,6 +125,13 @@ def register_default_surfaces(
             if name == "tasks" and task_scheduler is not None
             else None
         )
+        # The same manager also answers which definitions it planted, which
+        # is how an installed workflow names the job to run on demand.
+        lister = (
+            task_scheduler.list_custom_tasks
+            if name == "tasks" and task_scheduler is not None
+            else None
+        )
         registry.register(
             name,
             getattr(manager, spec.method),
@@ -132,5 +139,6 @@ def register_default_surfaces(
             source_scoped=True,
             shared=spec.shared,
             armer=armer,
+            lister=lister,
         )
     return registry

--- a/unify/workflow_manager/workflow_manager.py
+++ b/unify/workflow_manager/workflow_manager.py
@@ -64,6 +64,26 @@ def _now() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
+def _connect_phrase(unmet: List[Dict[str, Any]]) -> str:
+    """Name what to connect, offering a choice where the bundle offers one.
+
+    A requirement with alternatives is met by any one of them, so telling
+    the user to connect the first-named app states a requirement the
+    workflow does not have.
+    """
+    parts: List[str] = []
+    for entry in unmet:
+        options = entry.get("options") or []
+        if len(options) > 1:
+            names = [
+                str(option.get("name") or option.get("slug")) for option in options
+            ]
+            parts.append("one of " + " / ".join(names))
+            continue
+        parts.append(str(entry.get("name") or entry.get("slug")))
+    return " and ".join(parts)
+
+
 class WorkflowManager(BaseWorkflowManager):
     """Catalogue of available workflow bundles and their installations."""
 
@@ -483,6 +503,39 @@ class WorkflowManager(BaseWorkflowManager):
             )
             return []
 
+    def _planted_jobs(
+        self,
+        slug: str,
+        *,
+        destination: Optional[str],
+    ) -> List[Dict[str, Any]]:
+        """The task definitions this workflow planted, with their ids.
+
+        Reported, not run: a workflow has no runtime, and running one means
+        starting the ordinary task it planted with the ordinary task tools.
+        Naming those tasks here is what makes that possible without
+        guessing — "run my briefing now" otherwise has to search the whole
+        task list for something whose name looks close enough.
+
+        Asked of the surface that planted them, exactly as arming is, so
+        the context a destination maps to stays the owning manager's to
+        decide. Best-effort: a surface that cannot answer costs the caller
+        the job list, never the workflow record it is attached to.
+        """
+        if "tasks" not in self._surfaces:
+            return []
+        try:
+            return list(
+                self._surfaces.get("tasks").planted(
+                    managed_by=slug,
+                    destination=destination,
+                )
+                or [],
+            )
+        except Exception:
+            logger.debug("Could not read planted tasks for %r", slug, exc_info=True)
+            return []
+
     @staticmethod
     def _derived_status(
         stored_status: Optional[str],
@@ -578,6 +631,14 @@ class WorkflowManager(BaseWorkflowManager):
                         # uninstall — which defaults to personal — refuses.
                         "destination": row.get("destination", "personal"),
                         "installed_at": self._destinations_of(grouped[bundle.slug]),
+                        # The tasks it planted, so "run it now" resolves to a
+                        # task id instead of a search.
+                        "jobs": self._planted_jobs(
+                            bundle.slug,
+                            destination=self._normalized_destination(
+                                row.get("destination"),
+                            ),
+                        ),
                     },
                 )
             entries.append(entry)
@@ -704,22 +765,12 @@ class WorkflowManager(BaseWorkflowManager):
                 "requirements": unmet,
                 "message": (
                     f"Workflow {slug!r} is installed but held: connect "
-                    f"{[r['slug'] for r in unmet]} to arm its jobs. "
+                    f"{_connect_phrase(unmet)} to arm its jobs. "
                     "Nothing fires in the meantime."
                 ),
             }
         else:
             result["tasks_armed"] = armed
-            # Provisioning runs once, on a first install, and only when the
-            # workflow is not held: a backfill against an unconnected app would
-            # fail for exactly the reason its recurring job is disarmed.
-            if existing is None:
-                provisioned = self._trigger_install_task(
-                    bundle,
-                    destination=destination,
-                )
-                if provisioned is not None:
-                    result["provisioning_task_id"] = provisioned
         if failures:
             result["failures"] = {n: str(e) for n, e in failures.items()}
             logger.warning(
@@ -906,51 +957,6 @@ class WorkflowManager(BaseWorkflowManager):
                     slug,
                 )
         return removed
-
-    def _trigger_install_task(
-        self,
-        bundle: WorkflowBundle,
-        *,
-        destination: Optional[str],
-    ) -> Optional[int]:
-        """Run the bundle's provisioning one-shot. Returns its task id, or None.
-
-        Triggered rather than awaited: ``TaskScheduler.execute`` is async and
-        ``install_workflow`` is not, and the house rule is that work starts via
-        the trigger route, never via an update. Triggering also means the run is
-        an ordinary execution with the ordinary handle, history and steering —
-        the workflow contributes nothing of its own, which is what keeps it
-        runtime-free.
-        """
-        if not bundle.install_task:
-            return None
-
-        root = ContextRegistry.write_root(self, "Tasks", destination=destination)
-        rows = unisdk.get_logs(
-            context=f"{root.strip('/')}/Tasks",
-            filter=(
-                f"managed_by == '{bundle.slug}' and "
-                f"custom_key == '{bundle.install_task}'"
-            ),
-            limit=1,
-        )
-        if not rows:
-            logger.warning(
-                "Workflow %r declares install_task %r but no such planted task "
-                "exists; skipping provisioning",
-                bundle.slug,
-                bundle.install_task,
-            )
-            return None
-
-        task_id = (rows[0].entries or {}).get("task_id")
-        if task_id is None:
-            return None
-
-        from ..task_scheduler.typed_tasks_client import trigger_task
-
-        trigger_task(task_id=int(task_id))
-        return int(task_id)
 
     # ------------------------------------------------------------------ #
     # Requested changes (the mutation contract for reading surfaces)     #
@@ -1380,6 +1386,12 @@ class WorkflowManager(BaseWorkflowManager):
                     "installed_surfaces": json.loads(row.get("surfaces") or "[]"),
                     "destination": row.get("destination", "personal"),
                     "installed_at": self._destinations_of(rows),
+                    "jobs": self._planted_jobs(
+                        slug,
+                        destination=self._normalized_destination(
+                            row.get("destination"),
+                        ),
+                    ),
                 },
             )
             if bundle is None:


### PR DESCRIPTION
Installing used to start something. A bundle could name an `install_task` and the install triggered it, so accepting a workflow meant accepting a run you had not asked for — against apps that had only just been connected, at a moment nobody chose. That path is gone: the field, the manifest key, the trigger and its test. An install plants content and arms a schedule, and the first run is the schedule's or a person's.

Which makes naming the jobs necessary. An installed workflow's record now carries the tasks it planted, each with its id, its name and whether it is armed, so "run my briefing now" resolves to a task id and the ordinary task tools rather than a search through every task for one whose name looks close. The read goes through the tasks surface, the same route arming already takes, because which context a destination maps to is the task scheduler's to decide — resolving it here returned an empty list against a live install, which is what the new assertion catches.

Separately, a requirement may now name every app that would satisfy it. A workflow needs somewhere to post or a calendar to read; which product provides that is the user's, and declaring Slack and stopping there shut out everyone on Discord for a workflow that serves them identically. Each option resolves like a requirement of its own, the first connected one settles it, and the rest travel with the answer so a reader can offer the app the user already has. A held install now says "connect one of Slack / Discord / Microsoft Teams" instead of naming whichever the bundle happened to list first.

<!--
Thanks for contributing to Unify! Please fill out the sections below.
For trivial changes (typo fixes, comment-only edits) you can shorten this template — just keep the Summary.

PRs land on `staging`, not `main`. See CONTRIBUTING.md.
-->

## Summary

<!-- 1–3 sentences: what problem does this PR solve, and why is this the right approach? -->



## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes incorrect behavior)
- [ ] Feature (non-breaking change that adds functionality)
- [ ] Refactor (no behavior change)
- [ ] Breaking change (API or data-model change — Unify has zero-backward-compat policy, but please call it out)
- [ ] Test-only (no source changes)
- [ ] Docs / chore / CI

## Areas touched

<!-- Check all that apply. Helps reviewers route. -->

- [ ] Actor / CodeAct
- [ ] ConversationManager / slow brain
- [ ] A specific state manager (Contact / Knowledge / Task / Transcript / Guidance / Function / File / Image / Web / Secret / Blacklist / Data / Memory)
- [ ] Async tool loop (`unify/common/_async_tool/`)
- [ ] Event bus / observability
- [ ] Gateway / external comms
- [ ] Tests / test infra (`tests/`, `conftest.py`, `parallel_run.sh`)
- [ ] CI / build / packaging

## Test plan

<!--
How did you verify this? Paste the command(s) you ran and the result.

The default expectation is to run the relevant directory:
  tests/parallel_run.sh tests/<module>/

For infrastructure changes that are hard to reach via tests, a quick
verification script under tests/_verify_*.py is encouraged
(see .agents/rules/surgical-verification-before-tests.md).
-->

```
tests/parallel_run.sh tests/...
```

- [ ] All relevant tests pass locally
- [ ] If this is a bug fix, I added a regression test (or explained why one isn't feasible)

## Behavior / migration notes

<!--
- Did this change a public manager API, primitive, or event payload?
- Are there schema/context changes in Orchestra that need a migration?
- Any new env vars or config flags? (Update `.env.advanced.example`.)
- If yes to any of the above, describe upgrade steps.
-->

None.

## Checklist

- [ ] PR is targeted at `staging` (not `main`)
- [ ] Followed conventional commit style (`feat(scope):`, `fix(scope):`, `refactor(scope):`, `chore(scope):`, etc.)
- [ ] No `try/except` added defensively — only around specific, recoverable errors
- [ ] No "new" / "updated" / "TODO from chat" temporal comments (see `.agents/rules/no-temporal-comments.md`)
- [ ] No test-specific shortcuts in production code (see `.agents/rules/no-test-info-in-production-code.md`)
- [ ] Updated `AGENTS.md` / `ARCHITECTURE.md` if I changed architectural conventions
