### PR TITLE
Feat/workflows

### DIFF
--- a/tests/task_scheduler/test_prompt_builders.py
+++ b/tests/task_scheduler/test_prompt_builders.py
@@ -156,3 +156,32 @@ def test_build_ask_prompt_includes_provider_event_discovery_guidance() -> None:
     )
     assert "null means the catalog has no native lifecycle gate" in prompt
     assert "provisioning, and health checks" in prompt
+
+
+def test_build_task_execution_request_carries_installation_settings():
+    """A workflow-planted run receives its settings on the request itself.
+
+    The settings are resolved by the scheduler at run start, so the run
+    never has to discover or call a settings tool — an instruction that,
+    read by a code-writing actor, became a NameError in a plan.
+    """
+
+    task = Task(
+        task_id=9,
+        name="Daily briefing",
+        description="Compose and deliver the morning briefing.",
+        priority=Priority.normal,
+        repeat=[RepeatPattern(frequency=Frequency.WEEKLY)],
+    )
+
+    request = build_task_execution_request(
+        task,
+        installation_settings={"focus": "renewals"},
+        workflow_slug="daily_briefing",
+    )
+
+    assert "Installation settings of workflow 'daily_briefing'" in request
+    assert '{"focus": "renewals"}' in request
+
+    bare = build_task_execution_request(task)
+    assert "Installation settings" not in bare

--- a/unify/actor/base.py
+++ b/unify/actor/base.py
@@ -118,16 +118,22 @@ class BaseActor(ABC):
         self.knowledge_manager = (
             knowledge_manager or ManagerRegistry.get_knowledge_manager()
         )
-        # The workflow catalogue is the feature gate: with no
-        # UNITY_WORKFLOWS_DIR configured there is nothing to install, no
-        # WorkflowManager_* tools enter the schema, and deployments
-        # without the shelf keep their existing tool set (and LLM caches)
-        # byte-identical.
-        from unify.settings import SETTINGS
+        # The workflow catalogue is the feature gate: with no catalogue
+        # resolvable there is nothing to install, no WorkflowManager_* tools
+        # enter the schema, and deployments without the shelf keep their
+        # existing tool set (and LLM caches) byte-identical.
+        #
+        # Ask the one resolver, not the env var. The hosted deployment ships
+        # the catalogue inside the image and sets no UNITY_WORKFLOWS_DIR, so
+        # gating on the raw setting handed every deployed actor an empty
+        # workflow tool set while installs (which use the resolver) worked:
+        # planted tasks told the actor to read its settings with a tool it
+        # did not have, and every run degraded to catalogue archaeology.
+        from unify.workflow_manager.catalog import resolve_catalogue_root
 
         if workflow_manager is not None:
             self.workflow_manager = workflow_manager
-        elif (SETTINGS.UNITY_WORKFLOWS_DIR or "").strip():
+        elif resolve_catalogue_root() is not None:
             self.workflow_manager = ManagerRegistry.get_workflow_manager()
         else:
             self.workflow_manager = None

--- a/unify/actor/prompt_builders.py
+++ b/unify/actor/prompt_builders.py
@@ -183,6 +183,11 @@ _WORKFLOW_SHELF = textwrap.dedent("""
     because a workflow has no runtime: the task it planted does. A job
     reporting `enabled: false` is held on a missing connection, and
     starting it is refused — say which app to connect instead.
+
+    **Settings travel with the run.** A planted task's run request carries
+    the workflow's recorded installation settings, already resolved. The
+    settings tool exists for reading and discussing configuration with the
+    user, not for runs to fetch their own.
 """)
 
 

--- a/unify/conversation_manager/domains/workflow_requests.py
+++ b/unify/conversation_manager/domains/workflow_requests.py
@@ -120,9 +120,9 @@ async def arm_workflows_for_connected_app(app_slug: str) -> Dict[str, Any]:
 
     report = await asyncio.to_thread(manager.reconcile_installed)
     armed = {
-        slug: result["tasks_armed"]
+        slug: result["tasks_newly_armed"]
         for slug, result in (report.get("reconciled") or {}).items()
-        if result.get("tasks_armed")
+        if result.get("tasks_newly_armed")
     }
     if armed:
         LOGGER.info(

--- a/unify/events/task_run_lineage.py
+++ b/unify/events/task_run_lineage.py
@@ -45,6 +45,10 @@ class TaskRunLineage:
 
     task_id: int
     run_key: str | None = None
+    task_name: str | None = None
+    """Human-readable definition name, carried on payloads so viewers can
+    label the run without parsing or resolving the hierarchy segment. The
+    segment itself stays ids-only — it is machine lineage, not display."""
 
     def as_payload_fields(self) -> dict[str, Any]:
         fields: dict[str, Any] = {
@@ -52,6 +56,8 @@ class TaskRunLineage:
         }
         if self.run_key:
             fields["run_key"] = str(self.run_key)
+        if self.task_name:
+            fields["task_name"] = str(self.task_name)
         return fields
 
 
@@ -96,12 +102,14 @@ def push_task_run_lineage(
     *,
     task_id: int,
     run_key: str | None = None,
+    task_name: str | None = None,
 ) -> _TaskRunLineageTokens:
     """Push task-run context onto lineage ContextVars; return reset tokens."""
 
     lineage = TaskRunLineage(
         task_id=int(task_id),
         run_key=str(run_key) if run_key else None,
+        task_name=str(task_name) if task_name else None,
     )
     segment = format_task_run_lineage_segment(
         task_id=lineage.task_id,
@@ -130,12 +138,14 @@ def task_run_lineage_scope(
     *,
     task_id: int,
     run_key: str | None = None,
+    task_name: str | None = None,
 ) -> Generator[_TaskRunLineageTokens, None, None]:
     """Context manager that pushes then resets execution lineage."""
 
     tokens = push_task_run_lineage(
         task_id=task_id,
         run_key=run_key,
+        task_name=task_name,
     )
     try:
         yield tokens

--- a/unify/guidance_manager/guidance_manager.py
+++ b/unify/guidance_manager/guidance_manager.py
@@ -1220,6 +1220,23 @@ class GuidanceManager(BaseGuidanceManager):
             source_guidance = source_guidance or {}
             synced_key = (guidance_context, managed_by)
 
+            # A caller that pre-built the name map (the deployment
+            # reconcile) stays authoritative, including an empty map. A
+            # caller that didn't — a workflow install fanning out through
+            # the surface registry — gets names resolved against the
+            # functions actually readable right now, so a guidance row's
+            # ``function_names`` links survive regardless of who drove the
+            # sync. Without this, workflow guidance planted with every
+            # link silently dropped.
+            if function_name_to_id is None and any(
+                (row or {}).get("function_names") for row in source_guidance.values()
+            ):
+                function_name_to_id = {
+                    name: fid
+                    for fid, name in self._available_functions_by_id().items()
+                    if name
+                }
+
             return run_custom_sync(
                 adapter=_GuidanceSyncAdapter(
                     self,

--- a/unify/task_scheduler/active_task.py
+++ b/unify/task_scheduler/active_task.py
@@ -250,7 +250,15 @@ class ActiveTask(BaseActiveTask, HandleWrapperMixin):
         try:
             try:
                 lineage_scope = (
-                    task_run_lineage_scope(task_id=int(task_id), run_key=run_key)
+                    task_run_lineage_scope(
+                        task_id=int(task_id),
+                        run_key=run_key,
+                        task_name=(
+                            task_run_provenance.task_name
+                            if task_run_provenance is not None
+                            else None
+                        ),
+                    )
                     if task_id is not None
                     else nullcontext()
                 )

--- a/unify/task_scheduler/prompt_builders.py
+++ b/unify/task_scheduler/prompt_builders.py
@@ -22,8 +22,20 @@ from ..common.prompt_helpers import (
 )
 
 
-def build_task_execution_request(task: Task) -> str:
-    """Build the actor-facing request for one task instance."""
+def build_task_execution_request(
+    task: Task,
+    *,
+    installation_settings: Dict[str, Any] | None = None,
+    workflow_slug: str | None = None,
+) -> str:
+    """Build the actor-facing request for one task instance.
+
+    ``installation_settings`` are the recorded settings of the workflow that
+    planted this task, resolved by the caller at run start. Carrying them on
+    the request makes the run deterministic about its own configuration:
+    the actor honours what is written here instead of having to discover
+    and call a settings tool mid-run.
+    """
 
     lines = [
         "Execute this TaskScheduler task as a contained task run.",
@@ -34,6 +46,17 @@ def build_task_execution_request(task: Task) -> str:
         "Task description:",
         task.description or task.name,
     ]
+    if installation_settings is not None:
+        source = f" of workflow {workflow_slug!r}" if workflow_slug else ""
+        lines.extend(
+            [
+                "",
+                f"Installation settings{source} (already resolved for this "
+                "run — honour them as given; empty values mean the default "
+                "described in the task):",
+                json.dumps(installation_settings, sort_keys=True),
+            ],
+        )
     if task.response_policy:
         lines.extend(["", "Task response policy:", task.response_policy])
     if task.schedule is not None:
@@ -73,7 +96,10 @@ def build_task_run_guidelines(task: Task, reason: ActivatedBy) -> str:
         "You are executing exactly one TaskScheduler task. Treat the task "
         "name, description, schedule, trigger, repeat, and response policy "
         "as the authoritative statement of the task's INTENT and required "
-        "outcome for this run. Details the description records about "
+        "outcome for this run. If the request carries an 'Installation "
+        "settings' section, those are this run's resolved configuration: "
+        "honour them as given and never re-fetch, guess, or search for "
+        "settings elsewhere. Details the description records about "
         "external interfaces (endpoint shapes, field names, response "
         "formats) describe the environment as it looked when the task was "
         "created; such interfaces evolve, and the live environment is "

--- a/unify/task_scheduler/prompt_builders.py
+++ b/unify/task_scheduler/prompt_builders.py
@@ -35,6 +35,11 @@ def build_task_execution_request(
     the request makes the run deterministic about its own configuration:
     the actor honours what is written here instead of having to discover
     and call a settings tool mid-run.
+
+    The instruction lives in this section rather than in the general run
+    guidelines so that a task with no settings produces a byte-identical
+    request — every non-workflow task run keeps its prompt, and its cache,
+    untouched.
     """
 
     lines = [
@@ -52,8 +57,8 @@ def build_task_execution_request(
             [
                 "",
                 f"Installation settings{source} (already resolved for this "
-                "run — honour them as given; empty values mean the default "
-                "described in the task):",
+                "run — honour them as given and do not look them up again; "
+                "empty values mean the default described in the task):",
                 json.dumps(installation_settings, sort_keys=True),
             ],
         )
@@ -96,10 +101,7 @@ def build_task_run_guidelines(task: Task, reason: ActivatedBy) -> str:
         "You are executing exactly one TaskScheduler task. Treat the task "
         "name, description, schedule, trigger, repeat, and response policy "
         "as the authoritative statement of the task's INTENT and required "
-        "outcome for this run. If the request carries an 'Installation "
-        "settings' section, those are this run's resolved configuration: "
-        "honour them as given and never re-fetch, guess, or search for "
-        "settings elsewhere. Details the description records about "
+        "outcome for this run. Details the description records about "
         "external interfaces (endpoint shapes, field names, response "
         "formats) describe the environment as it looked when the task was "
         "created; such interfaces evolve, and the live environment is "

--- a/unify/task_scheduler/task_scheduler.py
+++ b/unify/task_scheduler/task_scheduler.py
@@ -2079,7 +2079,11 @@ class TaskScheduler(BaseTaskScheduler):
         rather than raised on: re-arming the rest of a source's tasks must
         not fail because its provisioning task already did its job.
 
-        Returns the ids of the definitions whose flag was written.
+        Returns the ids of the definitions whose flag actually changed. A
+        definition already in the requested state is left unwritten and
+        unreported, so callers reacting to the return value — a connect
+        event arming whatever a missing app held — see real transitions,
+        not every reconcile pass restating the status quo.
         """
         tasks_context, _meta_context, _is_personal = self._sync_destination_contexts(
             destination,
@@ -2091,6 +2095,8 @@ class TaskScheduler(BaseTaskScheduler):
             entries = dict(row.entries or {})
             task_id = entries.get("task_id")
             if task_id is None:
+                continue
+            if (entries.get("enabled") is not False) == enabled:
                 continue
             if enabled:
                 task = self._get_task_or_raise(int(task_id))

--- a/unify/task_scheduler/task_scheduler.py
+++ b/unify/task_scheduler/task_scheduler.py
@@ -1241,6 +1241,13 @@ class TaskScheduler(BaseTaskScheduler):
                 state=ExecutionState.running.value,
             )
 
+        workflow_slug, installation_settings = self._workflow_run_settings(task)
+        task_request = build_task_execution_request(
+            task,
+            installation_settings=installation_settings,
+            workflow_slug=workflow_slug,
+        )
+
         # The successor is projected by Orchestra when this run is marked
         # running: recurrence is a ledger invariant, not something each
         # dispatcher must remember to do.
@@ -1257,7 +1264,7 @@ class TaskScheduler(BaseTaskScheduler):
         try:
             handle = await ActiveTask.create(
                 fallback_actor,
-                task_description=build_task_execution_request(task),
+                task_description=task_request,
                 _parent_chat_context=_parent_chat_context,
                 _clarification_up_q=_clarification_up_q,
                 _clarification_down_q=_clarification_down_q,
@@ -1278,7 +1285,7 @@ class TaskScheduler(BaseTaskScheduler):
                             "task_execution_context",
                             {},
                         ),
-                        "task_request": build_task_execution_request(task),
+                        "task_request": task_request,
                     }
                     if entrypoint_kwargs is not None
                     else None
@@ -1394,11 +1401,18 @@ class TaskScheduler(BaseTaskScheduler):
                 "captured_task_revision"
             ] = captured_task_revision
 
-        task_request = (
-            build_provider_event_task_request(definition, provider_event_context)
-            if definition.entrypoint is None
-            else build_task_execution_request(definition)
-        )
+        if definition.entrypoint is None:
+            task_request = build_provider_event_task_request(
+                definition,
+                provider_event_context,
+            )
+        else:
+            slug, settings = self._workflow_run_settings(definition)
+            task_request = build_task_execution_request(
+                definition,
+                installation_settings=settings,
+                workflow_slug=slug,
+            )
         return await ActiveTask.create(
             fallback_actor,
             task_description=task_request,
@@ -2105,6 +2119,45 @@ class TaskScheduler(BaseTaskScheduler):
             self._set_tasks_enabled(task_ids=int(task_id), enabled=enabled)
             touched.append(int(task_id))
         return touched
+
+    def _workflow_run_settings(
+        self,
+        task: Task,
+    ) -> tuple[Optional[str], Optional[Dict[str, Any]]]:
+        """The installed settings of the workflow that planted *task*, if any.
+
+        Resolved once at run start and carried on the run request, so the
+        run's configuration is a deterministic input rather than something
+        the actor has to discover mid-run. Best-effort by design: a task
+        whose settings cannot be read still runs, with the request saying
+        nothing about settings rather than something wrong about them.
+        """
+        if not task.custom_hash:
+            return None, None
+        try:
+            managed_by, released = self._task_reconcile_owner(int(task.task_id))
+            if released or not managed_by or managed_by == MANAGED_BY_DEPLOYMENT:
+                return None, None
+            from unify.manager_registry import ManagerRegistry
+
+            manager = ManagerRegistry.get_workflow_manager()
+            if manager is None:
+                return None, None
+            settings = manager.get_installation_params(
+                slug=managed_by,
+                destination=task.destination,
+            )
+        except Exception:
+            logger.warning(
+                "Could not resolve installation settings for task %s; the "
+                "run proceeds without them",
+                task.task_id,
+                exc_info=True,
+            )
+            return None, None
+        if not isinstance(settings, dict):
+            return None, None
+        return managed_by, settings
 
     def _task_reconcile_owner(self, task_id: int) -> tuple[Optional[str], bool]:
         """Who reconciles this row, and whether the user already owns it.

--- a/unify/workflow_manager/workflow_manager.py
+++ b/unify/workflow_manager/workflow_manager.py
@@ -722,11 +722,17 @@ class WorkflowManager(BaseWorkflowManager):
             # otherwise. A repeat install after connecting is therefore
             # also the arm-on-connect path.
             unmet = self._unmet_requirements(bundle)
-            armed = self._arm_workflow_tasks(
+            flipped = self._arm_workflow_tasks(
                 bundle,
                 destination=destination,
                 enabled=not unmet,
             )
+            # The armer reports transitions; the planted jobs are the state.
+            # Both matter: the result's held/armed lists must describe every
+            # job (a repeat install flips nothing but the jobs are still
+            # armed), while the connect event that re-ran this install wants
+            # to know whether anything actually changed hands.
+            jobs = self._planted_jobs(bundle.slug, destination=destination)
 
             # Views are published after the surfaces land, because a view
             # binds to tables the data surface just created. A publish that
@@ -760,7 +766,9 @@ class WorkflowManager(BaseWorkflowManager):
         if canvases:
             result["canvases"] = canvases
         if unmet:
-            result["tasks_held"] = armed
+            result["tasks_held"] = [
+                job["task_id"] for job in jobs if not job["enabled"]
+            ]
             result["connect_required"] = {
                 "requirements": unmet,
                 "message": (
@@ -770,7 +778,9 @@ class WorkflowManager(BaseWorkflowManager):
                 ),
             }
         else:
-            result["tasks_armed"] = armed
+            result["tasks_armed"] = [job["task_id"] for job in jobs if job["enabled"]]
+            if flipped:
+                result["tasks_newly_armed"] = flipped
         if failures:
             result["failures"] = {n: str(e) for n, e in failures.items()}
             logger.warning(


### PR DESCRIPTION
<!--
Thanks for contributing to Unify! Please fill out the sections below.
For trivial changes (typo fixes, comment-only edits) you can shorten this template — just keep the Summary.

PRs land on `staging`, not `main`. See CONTRIBUTING.md.
-->

## Summary

<!-- 1–3 sentences: what problem does this PR solve, and why is this the right approach? -->



## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes incorrect behavior)
- [ ] Feature (non-breaking change that adds functionality)
- [ ] Refactor (no behavior change)
- [ ] Breaking change (API or data-model change — Unify has zero-backward-compat policy, but please call it out)
- [ ] Test-only (no source changes)
- [ ] Docs / chore / CI

## Areas touched

<!-- Check all that apply. Helps reviewers route. -->

- [ ] Actor / CodeAct
- [ ] ConversationManager / slow brain
- [ ] A specific state manager (Contact / Knowledge / Task / Transcript / Guidance / Function / File / Image / Web / Secret / Blacklist / Data / Memory)
- [ ] Async tool loop (`unify/common/_async_tool/`)
- [ ] Event bus / observability
- [ ] Gateway / external comms
- [ ] Tests / test infra (`tests/`, `conftest.py`, `parallel_run.sh`)
- [ ] CI / build / packaging

## Test plan

<!--
How did you verify this? Paste the command(s) you ran and the result.

The default expectation is to run the relevant directory:
  tests/parallel_run.sh tests/<module>/

For infrastructure changes that are hard to reach via tests, a quick
verification script under tests/_verify_*.py is encouraged
(see .agents/rules/surgical-verification-before-tests.md).
-->

```
tests/parallel_run.sh tests/...
```

- [ ] All relevant tests pass locally
- [ ] If this is a bug fix, I added a regression test (or explained why one isn't feasible)

## Behavior / migration notes

<!--
- Did this change a public manager API, primitive, or event payload?
- Are there schema/context changes in Orchestra that need a migration?
- Any new env vars or config flags? (Update `.env.advanced.example`.)
- If yes to any of the above, describe upgrade steps.
-->

None.

## Checklist

- [ ] PR is targeted at `staging` (not `main`)
- [ ] Followed conventional commit style (`feat(scope):`, `fix(scope):`, `refactor(scope):`, `chore(scope):`, etc.)
- [ ] No `try/except` added defensively — only around specific, recoverable errors
- [ ] No "new" / "updated" / "TODO from chat" temporal comments (see `.agents/rules/no-temporal-comments.md`)
- [ ] No test-specific shortcuts in production code (see `.agents/rules/no-test-info-in-production-code.md`)
- [ ] Updated `AGENTS.md` / `ARCHITECTURE.md` if I changed architectural conventions
