### PR TITLE
chore(deploy): bump brain SHA to ship gateway-capable unillm to prod pods

### DIFF
--- a/deploy/REBUILD_MARKER.md
+++ b/deploy/REBUILD_MARKER.md
@@ -1,0 +1,7 @@
+# Rebuild marker
+
+Bumping the brain SHA to roll a new assistant image out to running pods.
+
+- 2026-08-11: force rebuild so pods pick up gateway-capable `unillm`
+  (LLM gateway routing, unillm#112) — a dependency-only change does not change
+  the brain SHA on its own, so the SHA-keyed image rollout needs this nudge.


### PR DESCRIPTION
Bumps the prod brain SHA so the SHA-keyed image rollout delivers gateway-capable unillm (unillm gateway routing, already on unillm main) to production assistant pods. Dependency-only unillm changes don't change the brain SHA on their own, so pods never re-pull. Marker-only change; no code/behavior impact. Part of the LLM-gateway Phase 3 prod cutover (unify-deploy container cutover follows).