### PR TITLE
Promote staging → main: brain SHA bump for LLM gateway prod rollout

### DIFF
--- a/.github/workflows/llm-cache-refresh.yml
+++ b/.github/workflows/llm-cache-refresh.yml
@@ -21,6 +21,14 @@ on:
         options:
         - write-misses
         - uncached-eval
+      keying:
+        description: "canonical spends only on real drift; exact re-records byte-identical misses"
+        required: false
+        type: choice
+        default: canonical
+        options:
+        - canonical
+        - exact
       timeout_minutes:
         description: "Per-matrix-job session timeout"
         required: false
@@ -207,6 +215,7 @@ jobs:
       UNIFY_TESTS_DELETE_PROJ_ON_START: "false"
       UNIFY_TESTS_DELETE_PROJ_ON_EXIT: "false"
       UNILLM_CACHE: ${{ inputs.cache_mode == 'uncached-eval' && 'false' || 'true' }}
+      UNILLM_CACHE_KEYING: ${{ inputs.keying }}
       ORCHESTRA_REPO_PATH: ${{ github.workspace }}/orchestra
       UNIFY_DEPLOY_REPO_PATH: ${{ github.workspace }}/unify-deploy
       LOCAL_STACK_NO_AUTO: "1"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -740,8 +740,12 @@ jobs:
       UNIFY_TESTS_DELETE_PROJ_ON_START: "false"   # Handled by setup job at workflow level
       UNIFY_TESTS_DELETE_PROJ_ON_EXIT: "false"    # Keep project after tests
       # Normal CI must fail closed on cache misses. Real LLM cache refreshes
-      # are isolated in the protected LLM Cache Refresh workflow.
+      # are isolated in the protected LLM Cache Refresh workflow. Canonical
+      # keying lets recordings survive mundane prompt churn (block reordering,
+      # docstring rewording, volatile substrings); byte-identical re-recording
+      # is an explicit refresh-workflow decision, not a CI requirement.
       UNILLM_CACHE: "read-only"
+      UNILLM_CACHE_KEYING: "canonical"
       # Local orchestra path (cloned into workspace, not sibling directory)
       ORCHESTRA_REPO_PATH: ${{ github.workspace }}/orchestra
       # Coordinator local-stack tests need unify-deploy/selfhost/stack.sh when

--- a/deploy/REBUILD_MARKER.md
+++ b/deploy/REBUILD_MARKER.md
@@ -1,0 +1,7 @@
+# Rebuild marker
+
+Bumping the brain SHA to roll a new assistant image out to running pods.
+
+- 2026-08-11: force rebuild so pods pick up gateway-capable `unillm`
+  (LLM gateway routing, unillm#112) — a dependency-only change does not change
+  the brain SHA on its own, so the SHA-keyed image rollout needs this nudge.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -594,7 +594,7 @@ def pytest_sessionfinish(session, exitstatus):
         if session_id:
             stats_file = f"/tmp/parallel_run_cache_{session_id}.txt"
             with open(stats_file, "w") as f:
-                f.write(f"{stats.hits}|{stats.misses}\n")
+                f.write(f"{stats.hits}|{stats.canonical_hits}|{stats.misses}\n")
     except Exception:
         pass  # Don't fail the test run if cache stats writing fails
 
@@ -663,7 +663,7 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
 
         stats = unillm.get_cache_stats()
         terminalreporter.section(
-            f"Unify cache report | Hits ({stats.get_percentage_of_cache_hits():.2f}%): {stats.hits} | Misses ({stats.get_percentage_of_cache_misses():.2f}%): {stats.misses} | Reads: {stats.reads} | Writes: {stats.writes}",
+            f"Unify cache report | Hits ({stats.get_percentage_of_cache_hits():.2f}%): {stats.hits} ({stats.canonical_hits} canonical) | Misses ({stats.get_percentage_of_cache_misses():.2f}%): {stats.misses} | Reads: {stats.reads} | Writes: {stats.writes}",
         )
 
     total = sum(cost for _, cost in _session_costs)
@@ -913,7 +913,7 @@ def pytest_html_results_summary(prefix, summary, postfix):
         prefix.extend(
             [
                 f"<h4>Unify Cache Stats Report:</h4>",
-                f"<p>Hits ({stats.get_percentage_of_cache_hits():.2f}%): {stats.hits} | Misses ({stats.get_percentage_of_cache_misses():.2f}%): {stats.misses}</p>",
+                f"<p>Hits ({stats.get_percentage_of_cache_hits():.2f}%): {stats.hits} ({stats.canonical_hits} canonical) | Misses ({stats.get_percentage_of_cache_misses():.2f}%): {stats.misses}</p>",
                 f"<p>Reads: {stats.reads} | Writes: {stats.writes}</p>",
             ],
         )

--- a/tests/conversation_manager/core/test_credit_gate.py
+++ b/tests/conversation_manager/core/test_credit_gate.py
@@ -4,12 +4,15 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from unify.conversation_manager.cm_types import Medium
+from unillm.limit_hooks import LimitCheckResponse, SpendingLimitExceededError
+
 from unify.conversation_manager.conversation_manager import (
     ACCOUNT_SUSPENDED_EMAIL_SUBJECT,
     ACCOUNT_SUSPENDED_SLOW_BRAIN_RESPONSE,
     CREDIT_GATE_REPLY_THROTTLE_SECONDS,
     DEPLETED_CREDITS_EMAIL_SUBJECT,
     DEPLETED_CREDITS_SLOW_BRAIN_RESPONSE,
+    SPENDING_GATE_EMAIL_SUBJECT,
     ConversationManager,
 )
 from unify.spending_limits import (
@@ -291,3 +294,131 @@ class TestTheRefusalCarriesActionableAdvice:
 
     def test_the_two_refusals_are_distinguishable_in_a_mailbox(self):
         assert ACCOUNT_SUSPENDED_EMAIL_SUBJECT != DEPLETED_CREDITS_EMAIL_SUBJECT
+
+
+def _cm_for_refusal(*, is_voice: bool, reply_context: dict | None):
+    """A ConversationManager wired only for the spending-refusal path."""
+    cm = object.__new__(ConversationManager)
+    cm.mode = SimpleNamespace(is_voice=is_voice)
+    cm._last_inbound_reply_context = reply_context
+    cm._credit_gate_reply_sent_at = {}
+    cm._session_logger = MagicMock()
+    cm.loop = SimpleNamespace(time=MagicMock(return_value=1000.0))
+    cm._send_system_reply = AsyncMock(return_value=True)
+    cm.get_active_contact = MagicMock(return_value={})
+    cm.event_broker = SimpleNamespace(publish=AsyncMock())
+    return cm
+
+
+def _refusal(reason: str) -> SpendingLimitExceededError:
+    return SpendingLimitExceededError(LimitCheckResponse(allowed=False, reason=reason))
+
+
+class TestSpendingRefusalReachesTheUser:
+    """The spend boundary states a cause; the user must receive that cause.
+
+    A refusal is permanent until the account changes, so the failure copy
+    for a flaky provider — which asks the user to try again shortly — is
+    the one thing these paths must never fall back to.
+    """
+
+    @pytest.mark.asyncio
+    async def test_text_surface_repeats_the_reason_verbatim(self):
+        reason = (
+            "Anthropic models unlock once this account has made its first "
+            "payment. Subscribe in billing to use them."
+        )
+        cm = _cm_for_refusal(
+            is_voice=False,
+            reply_context={"medium": Medium.UNIFY_MESSAGE.value, "contact_id": 1},
+        )
+
+        with patch(
+            "unify.conversation_manager.conversation_manager.publish_system_error",
+        ):
+            await ConversationManager._surface_spending_gate_refusal(
+                cm,
+                _refusal(reason),
+            )
+
+        cm._send_system_reply.assert_awaited_once()
+        assert cm._send_system_reply.await_args.kwargs["content"] == reason
+        assert (
+            cm._send_system_reply.await_args.kwargs["email_subject"]
+            == SPENDING_GATE_EMAIL_SUBJECT
+        )
+
+    @pytest.mark.asyncio
+    async def test_console_is_told_this_is_billing_not_a_crash(self):
+        """Console renders on the error type; 'unknown' becomes 'try refreshing'."""
+        cm = _cm_for_refusal(is_voice=False, reply_context=None)
+
+        with patch(
+            "unify.conversation_manager.conversation_manager.publish_system_error",
+        ) as publish:
+            await ConversationManager._surface_spending_gate_refusal(
+                cm,
+                _refusal("Insufficient credits: balance is $0.00."),
+            )
+
+        publish.assert_called_once()
+        assert publish.call_args.args[0] == "Insufficient credits: balance is $0.00."
+        assert publish.call_args.kwargs["error_type"] == "billing_blocked"
+
+    @pytest.mark.asyncio
+    async def test_a_call_hears_the_reason_spoken(self):
+        reason = "Anthropic models unlock once this account has paid."
+        cm = _cm_for_refusal(is_voice=True, reply_context=None)
+
+        with patch(
+            "unify.conversation_manager.conversation_manager.publish_system_error",
+        ):
+            await ConversationManager._surface_spending_gate_refusal(
+                cm,
+                _refusal(reason),
+            )
+
+        assert cm.event_broker.publish.await_count == 2
+        spoken = cm.event_broker.publish.await_args_list[0].args[1]
+        assert reason in spoken
+        # A caller must not be sent to a text reply they cannot read.
+        cm._send_system_reply.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_a_blocked_account_is_not_told_twice_per_message(self):
+        reply_context = {"medium": Medium.UNIFY_MESSAGE.value, "contact_id": 1}
+        cm = _cm_for_refusal(is_voice=False, reply_context=reply_context)
+        error = _refusal("Insufficient credits: balance is $0.00.")
+
+        with patch(
+            "unify.conversation_manager.conversation_manager.publish_system_error",
+        ):
+            await ConversationManager._surface_spending_gate_refusal(cm, error)
+            await ConversationManager._surface_spending_gate_refusal(cm, error)
+
+        assert cm._send_system_reply.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_the_refusal_still_propagates_for_the_failure_log(self):
+        cm = _cm_for_refusal(is_voice=False, reply_context=None)
+        cm._run_llm = AsyncMock(side_effect=_refusal("Account is suspended."))
+
+        with patch(
+            "unify.conversation_manager.conversation_manager.publish_system_error",
+        ):
+            with pytest.raises(SpendingLimitExceededError):
+                await ConversationManager._run_llm_with_failure_notification(cm)
+
+    @pytest.mark.asyncio
+    async def test_a_refusal_never_borrows_the_try_again_copy(self):
+        cm = _cm_for_refusal(is_voice=False, reply_context=None)
+        cm._run_llm = AsyncMock(side_effect=_refusal("Account is suspended."))
+        cm._send_slow_brain_failure_reply = AsyncMock()
+
+        with patch(
+            "unify.conversation_manager.conversation_manager.publish_system_error",
+        ):
+            with pytest.raises(SpendingLimitExceededError):
+                await ConversationManager._run_llm_with_failure_notification(cm)
+
+        cm._send_slow_brain_failure_reply.assert_not_awaited()

--- a/tests/event_bus/test_payment_gated_providers.py
+++ b/tests/event_bus/test_payment_gated_providers.py
@@ -59,6 +59,49 @@ class TestGatePredicate:
         assert "anthropic" in PAYMENT_GATED_PROVIDERS
 
 
+class TestTheRouteCannotBeUsedToEvadeTheGate:
+    """An aggregator reaches the same models, so it is gated the same way.
+
+    OpenRouter ids keep the vendor prefix, and the curated catalogue's
+    Anthropic entries route natively while the model-search results route
+    through OpenRouter. Gating only the trailing route segment would leave
+    the search path as an open door to exactly the models the gate exists
+    to hold back.
+    """
+
+    def test_anthropic_through_openrouter_is_gated(self):
+        assert (
+            _payment_gated("anthropic/claude-opus-4.8@openrouter", never_paid=True)
+            is True
+        )
+
+    def test_the_native_anthropic_route_is_still_gated(self):
+        assert _payment_gated("claude-fable-5@anthropic", never_paid=True) is True
+
+    def test_a_paid_account_reaches_both_routes(self):
+        for model in (
+            "anthropic/claude-opus-4.8@openrouter",
+            "claude-fable-5@anthropic",
+        ):
+            assert _payment_gated(model, never_paid=False) is False
+
+    def test_other_vendors_on_the_same_aggregator_are_untouched(self):
+        """Gating a route wholesale would take the platform default with it."""
+        assert _payment_gated("openai/gpt-5.6-sol@openrouter", never_paid=True) is False
+
+    @pytest.mark.asyncio
+    async def test_the_refusal_names_the_vendor_not_the_aggregator(self):
+        """ "OpenRouter models require payment" would misdescribe the block."""
+        response = await _run_callback(
+            "anthropic/claude-opus-4.8@openrouter",
+            _NEVER_PAID,
+        )
+
+        assert response.allowed is False
+        assert "Anthropic" in response.reason
+        assert "OpenRouter" not in response.reason
+
+
 def _run_callback(model: str, spend_data: dict):
     """Drive the callback for a personal account with *spend_data*."""
 

--- a/tests/event_bus/test_payment_gated_providers.py
+++ b/tests/event_bus/test_payment_gated_providers.py
@@ -95,7 +95,29 @@ class TestGateAtTheSpendBoundary:
         response = await _run_callback("claude-fable-5@anthropic", _NEVER_PAID)
 
         assert response.allowed is False
-        assert "payment method" in response.reason
+        # The refusal has to carry its own remedy: this string is what the
+        # user is shown, and a denial they cannot act on is the failure mode
+        # this gate keeps reproducing.
+        assert "payment" in response.reason.lower()
+        assert "billing" in response.reason.lower()
+
+    @pytest.mark.asyncio
+    async def test_reason_does_not_promise_that_a_card_is_enough(self):
+        """Access turns on payment history, not on a card being attached.
+
+        Earlier copy said "add a payment method", which sends someone to
+        attach a card and hit the identical refusal afterwards.
+        """
+        response = await _run_callback("claude-fable-5@anthropic", _NEVER_PAID)
+
+        assert "add a payment method" not in response.reason.lower()
+
+    @pytest.mark.asyncio
+    async def test_reason_offers_a_way_to_keep_working_now(self):
+        """An included model is reachable immediately; say so."""
+        response = await _run_callback("claude-fable-5@anthropic", _NEVER_PAID)
+
+        assert "included models" in response.reason.lower()
 
     @pytest.mark.asyncio
     async def test_allows_anthropic_once_the_account_has_paid(self):
@@ -121,4 +143,6 @@ class TestGateAtTheSpendBoundary:
     async def test_reason_names_the_provider(self):
         response = await _run_callback("claude-opus-5@anthropic", _NEVER_PAID)
 
-        assert "anthropic" in response.reason
+        # Spelled as a reader writes it, not as the endpoint suffix is
+        # matched — this string is shown to the account holder.
+        assert "Anthropic" in response.reason

--- a/tests/parallel_run.sh
+++ b/tests/parallel_run.sh
@@ -93,17 +93,18 @@ report_completed_sessions() {
         _mark_reported "$sid"
         # Record duration, cache stats, and cost for sorted output
         if [[ -n "${START_TIMES_FILE:-}" && -f "$START_TIMES_FILE" ]]; then
-          local start_time end_time duration hits misses cost
+          local start_time end_time duration hits canonical misses cost
           start_time=$(grep "^$sid " "$START_TIMES_FILE" 2>/dev/null | cut -d' ' -f2)
           if [[ -n "$start_time" ]]; then
             end_time=$(date +%s)
             duration=$((end_time - start_time))
             # Read cache stats from temp file (written by inner script)
             hits=0
+            canonical=0
             misses=0
             local stats_file="/tmp/parallel_run_cache_${sid}.txt"
             if [[ -f "$stats_file" ]]; then
-              IFS='|' read -r hits misses < "$stats_file" 2>/dev/null || true
+              IFS='|' read -r hits canonical misses < "$stats_file" 2>/dev/null || true
               rm -f "$stats_file"
             fi
             # Read LLM provider cost from temp file (written by inner script)
@@ -124,7 +125,7 @@ report_completed_sessions() {
                 status="skip"
               fi
             fi
-            echo "$duration|$status|$hits|$misses|$cost|$base" >> "$RESULTS_FILE"
+            echo "$duration|$status|$hits|$canonical|$misses|$cost|$base" >> "$RESULTS_FILE"
           fi
         fi
         ;;
@@ -134,17 +135,18 @@ report_completed_sessions() {
         _mark_reported "$sid"
         # Record duration, cache stats, and cost for sorted output
         if [[ -n "${START_TIMES_FILE:-}" && -f "$START_TIMES_FILE" ]]; then
-          local start_time end_time duration hits misses cost
+          local start_time end_time duration hits canonical misses cost
           start_time=$(grep "^$sid " "$START_TIMES_FILE" 2>/dev/null | cut -d' ' -f2)
           if [[ -n "$start_time" ]]; then
             end_time=$(date +%s)
             duration=$((end_time - start_time))
             # Read cache stats from temp file (written by inner script)
             hits=0
+            canonical=0
             misses=0
             local stats_file="/tmp/parallel_run_cache_${sid}.txt"
             if [[ -f "$stats_file" ]]; then
-              IFS='|' read -r hits misses < "$stats_file" 2>/dev/null || true
+              IFS='|' read -r hits canonical misses < "$stats_file" 2>/dev/null || true
               rm -f "$stats_file"
             fi
             # Read LLM provider cost from temp file
@@ -154,7 +156,7 @@ report_completed_sessions() {
               cost=$(cat "$cost_file" 2>/dev/null | tr -d '[:space:]')
               rm -f "$cost_file"
             fi
-            echo "$duration|fail|$hits|$misses|$cost|$base" >> "$RESULTS_FILE"
+            echo "$duration|fail|$hits|$canonical|$misses|$cost|$base" >> "$RESULTS_FILE"
           fi
         fi
         ;;
@@ -1665,13 +1667,13 @@ format_cache_rate() {
 > "$DURATION_SUMMARY_FILE"
 
 # Print passed tests sorted by duration (fastest first, slowest last)
-# Format: duration|status|hits|misses|cost|name
+# Format: duration|status|hits|canonical|misses|cost|name
 if (( pass_count > 0 )); then
   echo ""
   print_duration_line "✅ PASSED ($pass_count tests):"
   print_duration_line "$(printf "  %6s  %6s  %10s  %s" "time" "cache" "cost" "test")"
   print_duration_line "$(printf "  %6s  %6s  %10s  %s" "----" "-----" "----" "----")"
-  { grep '|pass|' "$RESULTS_FILE" || true; } | sort -t'|' -k1 -n | while IFS='|' read -r dur status hits misses cost name; do
+  { grep '|pass|' "$RESULTS_FILE" || true; } | sort -t'|' -k1 -n | while IFS='|' read -r dur status hits canonical misses cost name; do
     cache_rate=$(format_cache_rate "$hits" "$misses")
     formatted_cost=$(printf '$%.6f' "$cost")
     print_duration_line "$(printf "  %5ds  %6s  %10s  %s" "$dur" "$cache_rate" "$formatted_cost" "$name")"
@@ -1685,7 +1687,7 @@ if (( skip_count > 0 )); then
   print_duration_line "⏭️  SKIPPED ($skip_count tests — no coverage from these):"
   print_duration_line "$(printf "  %6s  %6s  %10s  %s" "time" "cache" "cost" "test")"
   print_duration_line "$(printf "  %6s  %6s  %10s  %s" "----" "-----" "----" "----")"
-  { grep '|skip|' "$RESULTS_FILE" || true; } | sort -t'|' -k1 -n | while IFS='|' read -r dur status hits misses cost name; do
+  { grep '|skip|' "$RESULTS_FILE" || true; } | sort -t'|' -k1 -n | while IFS='|' read -r dur status hits canonical misses cost name; do
     cache_rate=$(format_cache_rate "$hits" "$misses")
     formatted_cost=$(printf '$%.6f' "$cost")
     print_duration_line "$(printf "  %5ds  %6s  %10s  %s" "$dur" "$cache_rate" "$formatted_cost" "$name")"
@@ -1698,7 +1700,7 @@ if (( fail_count > 0 )); then
   print_duration_line "❌ FAILED ($fail_count tests):"
   print_duration_line "$(printf "  %6s  %6s  %10s  %s" "time" "cache" "cost" "test")"
   print_duration_line "$(printf "  %6s  %6s  %10s  %s" "----" "-----" "----" "----")"
-  { grep '|fail|' "$RESULTS_FILE" || true; } | sort -t'|' -k1 -n | while IFS='|' read -r dur status hits misses cost name; do
+  { grep '|fail|' "$RESULTS_FILE" || true; } | sort -t'|' -k1 -n | while IFS='|' read -r dur status hits canonical misses cost name; do
     cache_rate=$(format_cache_rate "$hits" "$misses")
     formatted_cost=$(printf '$%.6f' "$cost")
     print_duration_line "$(printf "  %5ds  %6s  %10s  %s" "$dur" "$cache_rate" "$formatted_cost" "$name")"
@@ -1708,11 +1710,13 @@ fi
 # Calculate and print aggregated totals
 total_duration=0
 total_hits=0
+total_canonical=0
 total_misses=0
 total_cost="0"
-while IFS='|' read -r dur status hits misses cost name; do
+while IFS='|' read -r dur status hits canonical misses cost name; do
   total_duration=$((total_duration + dur))
   total_hits=$((total_hits + hits))
+  total_canonical=$((total_canonical + canonical))
   total_misses=$((total_misses + misses))
   total_cost=$(awk "BEGIN {printf \"%.6g\", $total_cost + $cost}")
 done < "$RESULTS_FILE"
@@ -1734,7 +1738,9 @@ if (( total_tests > 0 )); then
   total_cache_rate=$(format_cache_rate "$total_hits" "$total_misses")
   total_calls=$((total_hits + total_misses))
   print_duration_line "  Serial duration: $duration_str"
-  print_duration_line "  LLM cache: $total_cache_rate ($total_hits hits, $total_misses misses, $total_calls total)"
+  # Canonical hits are recordings accepted through canonical keying rather
+  # than byte-identical raw keys — the share of prompt drift being absorbed.
+  print_duration_line "  LLM cache: $total_cache_rate ($total_hits hits [$total_canonical canonical], $total_misses misses, $total_calls total)"
   print_duration_line "  LLM cost: \$$total_cost"
 fi
 

--- a/tests/task_scheduler/test_prompt_builders.py
+++ b/tests/task_scheduler/test_prompt_builders.py
@@ -104,6 +104,25 @@ def test_build_task_run_guidelines_keep_child_actor_focused_on_one_task():
     assert "Instance id:" not in guidelines
 
 
+def test_update_tools_include_catalog_inspection() -> None:
+    """The update loop must be able to execute its own authoring order.
+
+    The prompt instructs: list catalog -> list connections -> describe
+    schema -> resolve resources. Without these read-only tools in the
+    update tool set, trigger feasibility gets decided blind and reported
+    as "no supported trigger" (observed in prod, 2026-08-10).
+    """
+    scheduler = TaskScheduler()
+    tools = scheduler.get_tools("update")
+    for name in (
+        "list_provider_trigger_catalog",
+        "list_provider_trigger_connections",
+        "describe_provider_trigger",
+        "list_provider_trigger_resources",
+    ):
+        assert name in tools, f"update tool set is missing {name}"
+
+
 def test_build_update_prompt_includes_provider_event_guidance() -> None:
     scheduler = TaskScheduler()
     prompt = build_update_prompt(
@@ -113,6 +132,15 @@ def test_build_update_prompt_includes_provider_event_guidance() -> None:
         include_activity=False,
     ).flatten()
     assert "Provider-event triggers" in prompt
+    assert (
+        "List supported third-party events: `list_provider_trigger_catalog()`" in prompt
+    )
+    assert "never decide feasibility from memory" in prompt
+    assert (
+        "List eligible connections: "
+        "`list_provider_trigger_connections(canonical_app_slug='<app>')`" in prompt
+    )
+    assert "Describe trigger config schema: `describe_provider_trigger" in prompt
     assert "task_revision_conflict" in prompt
     assert "pause_provider_trigger" in prompt
     assert "provider_event_context" in prompt

--- a/tests/task_scheduler/test_update_tools.py
+++ b/tests/task_scheduler/test_update_tools.py
@@ -155,3 +155,78 @@ def test_update_task_priority():
 
     task_list = ts._filter_tasks()
     assert task_list[0].priority == Priority.high
+
+
+@_handle_project
+def test_update_task_clears_schedule_with_explicit_none():
+    """None means clear, omission means keep (the _UNSET sentinel contract).
+
+    Previously the schedule fields used plain ``=None`` defaults, so a
+    clear request was indistinguishable from "no change" and silently
+    no-opped (observed in prod 2026-08-10: 'the task API retained the
+    stored schedule metadata when asked to clear it').
+    """
+    ts = TaskScheduler()
+
+    start = datetime.now(timezone.utc) + timedelta(days=1)
+    rule = RepeatPattern(frequency=Frequency.DAILY, interval=1)
+    ts._create_task(
+        name="Daily sync briefing",
+        description="Send the briefing after the sync.",
+        schedule=Schedule(start_at=start),
+        repeat=[rule],
+    )
+
+    # Unrelated update: omitted schedule fields stay untouched.
+    ts._update_task(task_id=0, name="Daily sync briefing (v2)")
+    row = ts._filter_tasks()[0]
+    assert row.schedule is not None
+    assert row.repeat
+
+    # Explicit clear: schedule goes, and the anchored cadence goes with it.
+    ts._update_task(task_id=0, start_at=None)
+    row = ts._filter_tasks()[0]
+    assert row.schedule is None
+    assert not row.repeat
+
+
+@_handle_project
+def test_update_task_clears_deadline_with_explicit_none():
+    ts = TaskScheduler()
+
+    deadline = datetime.now(timezone.utc) + timedelta(days=30)
+    ts._create_task(
+        name="File quarterly taxes",
+        description="Prepare documents for accounting.",
+        deadline=deadline,
+    )
+    assert ts._filter_tasks()[0].deadline == deadline
+
+    ts._update_task(task_id=0, deadline=None)
+    assert ts._filter_tasks()[0].deadline is None
+
+
+@_handle_project
+def test_update_task_converts_schedule_to_trigger_in_one_call():
+    """The schedule/trigger exclusivity is resolvable in a single mutation."""
+    from unify.task_scheduler.types.trigger import CommunicationTrigger
+
+    ts = TaskScheduler()
+
+    start = datetime.now(timezone.utc) + timedelta(days=1)
+    ts._create_task(
+        name="Escalation follow-up",
+        description="Follow up when the customer replies.",
+        schedule=Schedule(start_at=start),
+    )
+
+    trigger = CommunicationTrigger(medium="sms_message")
+    ts._update_task(
+        task_id=0,
+        trigger=trigger.model_dump(mode="json"),
+        start_at=None,
+    )
+    row = ts._filter_tasks()[0]
+    assert row.schedule is None
+    assert row.trigger is not None
+    assert row.trigger.kind == "communication"

--- a/unify/conversation_manager/conversation_manager.py
+++ b/unify/conversation_manager/conversation_manager.py
@@ -60,6 +60,7 @@ from unify.conversation_manager.cm_types.screenshot import (
 from unify.actor.base import BaseActor
 from unify.conversation_manager.domains.proactive_speech import ProactiveSpeech
 from unify.conversation_manager.medium_scripts.common import FastBrainLogger
+from unillm.limit_hooks import SpendingLimitExceededError
 from unify.spending_limits import (
     GATE_BLOCK_ACCOUNT_SUSPENDED,
     GATE_BLOCK_CREDITS_DEPLETED,
@@ -98,6 +99,17 @@ SLOW_BRAIN_FAILURE_RESPONSE = (
     "so we can look into it."
 )
 SLOW_BRAIN_FAILURE_EMAIL_SUBJECT = "Temporary problem responding"
+# A spending gate refuses a turn for a stated reason — no credits, a paid-only
+# provider, a suspended account. The reason is written for the account holder
+# and names the remedy, so it is delivered verbatim rather than folded into the
+# transient-failure copy above: telling someone to try again in a moment is
+# actively wrong when nothing about a retry can change the answer.
+SPENDING_GATE_EMAIL_SUBJECT = "Action needed to continue"
+# The spoken form drops the written remedy: a caller cannot click a billing
+# link mid-sentence, and reading a URL aloud is worse than pointing at it.
+SPENDING_GATE_SPOKEN_PREFIX = (
+    "I can't run that right now for a billing reason on this account. "
+)
 # Self-scheduled wait(delay) polling backoff. Timer wakes are full-priced
 # slow-brain turns; a model that busy-polls a long-running act ("check
 # again in 10 seconds", repeatedly) burns tokens with zero information
@@ -1676,6 +1688,14 @@ class ConversationManager(metaclass=SingletonABCMeta):
             return await self._run_llm(trace_meta=trace_meta)
         except asyncio.CancelledError:
             raise
+        except SpendingLimitExceededError as exc:
+            # A refusal with a stated cause and remedy. The pre-turn billing
+            # gate catches the account-wide cases, but it fails open and is
+            # blind to per-call causes such as a paid-only provider, so the
+            # spend boundary stays the only place every refusal is known.
+            with contextlib.suppress(Exception):
+                await self._surface_spending_gate_refusal(exc)
+            raise
         except Exception as exc:
             if self.mode.is_voice and self._is_transient_llm_error(exc):
                 with contextlib.suppress(Exception):
@@ -1708,6 +1728,80 @@ class ConversationManager(metaclass=SingletonABCMeta):
             reply_context,
             content=SLOW_BRAIN_FAILURE_RESPONSE,
             email_subject=SLOW_BRAIN_FAILURE_EMAIL_SUBJECT,
+        )
+
+    async def _surface_spending_gate_refusal(
+        self,
+        exc: SpendingLimitExceededError,
+    ) -> None:
+        """Deliver a spending-gate refusal to the user, in its own words.
+
+        The reason string is authored for the account holder and names the
+        remedy ("add a payment method", "switch to one of the included
+        models"), so every surface repeats it rather than paraphrasing.
+        Reusing the transient-failure copy here would tell someone to retry
+        an operation whose outcome is fixed until they act on the account.
+
+        Shares the billing-gate throttle with the pre-turn check so a blocked
+        account that keeps sending gets one explanation, not one per message.
+        """
+        reason = str(exc).strip()
+        if not reason:
+            return
+
+        # Console classifies on this type, so a refusal renders as its own
+        # message instead of the generic "attempting to recover" copy.
+        with contextlib.suppress(Exception):
+            publish_system_error(reason, error_type="billing_blocked")
+
+        if self.mode.is_voice:
+            with contextlib.suppress(Exception):
+                await self._speak_spending_gate_refusal(reason)
+            return
+
+        reply_context = self._last_inbound_reply_context
+        if not reply_context:
+            return
+        if self._credit_gate_reply_is_throttled(reply_context):
+            self._session_logger.info(
+                "billing_gate",
+                "Skipped repeated spending-gate refusal reply",
+            )
+            return
+        await self._send_system_reply(
+            reply_context,
+            content=reason,
+            email_subject=SPENDING_GATE_EMAIL_SUBJECT,
+        )
+
+    async def _speak_spending_gate_refusal(self, reason: str) -> None:
+        """Have the fast brain state a spending refusal aloud.
+
+        Speaks directly rather than notifying, for the same reason a provider
+        outage does: the fast brain's own model call runs through the gate
+        that just refused, so asking it to compose the apology would hit the
+        same wall.
+        """
+        contact = self.get_active_contact()
+        event = FastBrainNotification(
+            contact=contact or {},
+            message=(
+                f"The spending gate refused this turn: {reason} "
+                "The user has been told; do not claim you are still working."
+            ),
+            spoken_message=f"{SPENDING_GATE_SPOKEN_PREFIX}{reason}",
+            should_speak=True,
+            source="spending_gate_refusal",
+        )
+        self._session_logger.info(
+            "billing_gate",
+            f"Speaking spending-gate refusal: {reason}",
+        )
+        event_json = event.to_json()
+        await self.event_broker.publish("app:call:notification", event_json)
+        await self.event_broker.publish(
+            "app:comms:assistant_notification",
+            event_json,
         )
 
     def record_last_inbound_reply(self, reply_context: dict[str, Any]) -> None:

--- a/unify/spending_limits.py
+++ b/unify/spending_limits.py
@@ -529,12 +529,44 @@ def _provider_label(provider: str) -> str:
     return _PROVIDER_DISPLAY_NAMES.get(provider, provider)
 
 
+def _vendor_of(model: str) -> Optional[str]:
+    """Extract the vendor that owns the model, independent of the route.
+
+    OpenRouter ids are vendor-prefixed (``anthropic/claude-opus-4.8``), so
+    the vendor survives being routed through an aggregator. Returns ``None``
+    when the model half carries no prefix.
+    """
+    endpoint, _, _ = model.rpartition("@")
+    vendor, sep, _ = (endpoint or model).partition("/")
+    if not sep:
+        return None
+    return vendor.strip().lower() or None
+
+
+def _gated_provider_of(model: str, *, never_paid: bool) -> Optional[str]:
+    """The gated provider this call would reach, or ``None`` if it is allowed.
+
+    Checked against both the route and the vendor, because they can differ
+    and either one is a way to reach the same models: ``claude-opus-5@anthropic``
+    bills Anthropic directly, while ``anthropic/claude-opus-4.8@openrouter``
+    reaches the identical model through an aggregator. Gating only the route
+    would leave the aggregator as an open door to exactly what the gate
+    exists to hold back, so the vendor is enough on its own.
+
+    The vendor is reported in preference to the route, since it names what
+    the user is actually being refused.
+    """
+    if not never_paid:
+        return None
+    for candidate in (_vendor_of(model), _provider_of(model)):
+        if candidate is not None and candidate in PAYMENT_GATED_PROVIDERS:
+            return candidate
+    return None
+
+
 def _payment_gated(model: str, *, never_paid: bool) -> bool:
     """Whether this call is for a paid-only provider on an unpaid account."""
-    if not never_paid:
-        return False
-    provider = _provider_of(model)
-    return provider is not None and provider in PAYMENT_GATED_PROVIDERS
+    return _gated_provider_of(model, never_paid=never_paid) is not None
 
 
 async def check_spending_limits_callback(
@@ -718,12 +750,12 @@ async def check_spending_limits_callback(
     # these providers from the Console either — that is the point, since
     # the Console is where the free grant is meant to be spent and these
     # models are what make spending it worthwhile.
-    if _payment_gated(request.model, never_paid=never_paid):
-        provider = _provider_of(request.model)
+    gated_provider = _gated_provider_of(request.model, never_paid=never_paid)
+    if gated_provider is not None:
         return LimitCheckResponse(
             allowed=False,
             reason=(
-                f"{_provider_label(str(provider))} models unlock once this "
+                f"{_provider_label(gated_provider)} models unlock once this "
                 "account has made its first payment — adding a card alone "
                 "does not enable them. Subscribe in billing to use them, or "
                 "switch this assistant to one of the included models to "

--- a/unify/spending_limits.py
+++ b/unify/spending_limits.py
@@ -511,6 +511,24 @@ def _provider_of(model: str) -> Optional[str]:
     return provider.strip().lower() or None
 
 
+#: Display spellings for providers that appear in user-facing refusals. The
+#: endpoint suffix is lowercased for matching, which is not how anyone writes
+#: these names; falling back to the raw slug keeps a newly-gated provider
+#: readable rather than blocking on an entry here.
+_PROVIDER_DISPLAY_NAMES = {
+    "anthropic": "Anthropic",
+    "openai": "OpenAI",
+    "openrouter": "OpenRouter",
+    "vertex-ai": "Vertex AI",
+    "deepseek": "DeepSeek",
+}
+
+
+def _provider_label(provider: str) -> str:
+    """How a provider is spelled when the user reads it."""
+    return _PROVIDER_DISPLAY_NAMES.get(provider, provider)
+
+
 def _payment_gated(model: str, *, never_paid: bool) -> bool:
     """Whether this call is for a paid-only provider on an unpaid account."""
     if not never_paid:
@@ -705,9 +723,11 @@ async def check_spending_limits_callback(
         return LimitCheckResponse(
             allowed=False,
             reason=(
-                f"{provider} models require a payment method on this "
-                "account. Add one to enable them, or switch this assistant "
-                "to one of the included models."
+                f"{_provider_label(str(provider))} models unlock once this "
+                "account has made its first payment — adding a card alone "
+                "does not enable them. Subscribe in billing to use them, or "
+                "switch this assistant to one of the included models to "
+                "carry on now."
             ),
         )
 

--- a/unify/task_scheduler/prompt_builders.py
+++ b/unify/task_scheduler/prompt_builders.py
@@ -340,6 +340,7 @@ def build_update_prompt(
     catalog_fname = tool_name(tools, "list_provider_trigger_catalog")
     connections_fname = tool_name(tools, "list_provider_trigger_connections")
     trigger_fname = tool_name(tools, "describe_provider_trigger")
+    resources_fname = tool_name(tools, "list_provider_trigger_resources")
     health_fname = tool_name(tools, "get_provider_trigger_health")
     context_fname = tool_name(tools, "get_provider_event_context")
 
@@ -455,6 +456,28 @@ def build_update_prompt(
             "Use provider-event triggers for third-party SaaS events configured in the trigger catalog.",
             "Authoring order: list catalog → list eligible connections → describe schema → "
             "resolve required resources → create with trigger_config filled → enable.",
+            (
+                f"List supported third-party events: `{catalog_fname}()`. "
+                "Always inspect the catalog before concluding an event trigger "
+                "is unavailable; never decide feasibility from memory."
+                if catalog_fname
+                else ""
+            ),
+            (
+                f"List eligible connections: `{connections_fname}(canonical_app_slug='<app>')`."
+                if connections_fname
+                else ""
+            ),
+            (
+                f"Describe trigger config schema: `{trigger_fname}(provider_trigger_slug='<slug>', backend_id='<backend>')`."
+                if trigger_fname
+                else ""
+            ),
+            (
+                f"Resolve required resources: `{resources_fname}(target_resource_family='<family from describe>', query='<optional name>')`."
+                if resources_fname
+                else ""
+            ),
             "Stop before create/enable only when the catalog row explicitly has `live_ready=false`, "
             "`provisionable=false`, or `delivery_only=true` (for example Chat batch rows). "
             "`null` means there is no native lifecycle gate for that field, not that the trigger is unavailable; "

--- a/unify/task_scheduler/prompt_builders.py
+++ b/unify/task_scheduler/prompt_builders.py
@@ -450,6 +450,7 @@ def build_update_prompt(
             "----------------------",
             f"A task with a `trigger` is armed by that trigger, not by a start time. Use `{update_task_fname}(task_id=<id>, trigger=...)` to add/remove triggers. Do not set `start_at` on trigger-based tasks.",
             "`schedule` and `trigger` are mutually exclusive. Use `repeat` with `schedule` for cadence-based tasks; use `trigger` for inbound-event tasks.",
+            f"Explicit `null` clears: `{update_task_fname}(task_id=<id>, start_at=None)` removes the schedule (sweeping `repeat` with it unless replaced in the same call); `deadline=None` / `repeat=None` clear likewise. Convert a scheduled task to a triggered one in ONE call: `{update_task_fname}(task_id=<id>, trigger=..., start_at=None)`.",
             "",
             "Provider-event triggers",
             "-----------------------",

--- a/unify/task_scheduler/task_scheduler.py
+++ b/unify/task_scheduler/task_scheduler.py
@@ -324,6 +324,27 @@ class TaskScheduler(BaseTaskScheduler):
                     fn=self._retry_provider_trigger,
                     display_label="Retrying provider trigger provisioning",
                 ),
+                # Read-only catalog inspection: the update prompt's authoring
+                # order (list catalog -> list connections -> describe schema ->
+                # resolve resources) must be executable from this loop, not
+                # only from ``ask`` -- otherwise trigger feasibility gets
+                # decided blind and reported as "no supported trigger".
+                ToolSpec(
+                    fn=self._list_provider_trigger_catalog,
+                    display_label="Listing provider trigger catalog",
+                ),
+                ToolSpec(
+                    fn=self._list_provider_trigger_connections,
+                    display_label="Listing provider trigger connections",
+                ),
+                ToolSpec(
+                    fn=self._describe_provider_trigger,
+                    display_label="Describing provider trigger config",
+                ),
+                ToolSpec(
+                    fn=self._list_provider_trigger_resources,
+                    display_label="Listing provider trigger resources",
+                ),
                 ToolSpec(
                     fn=self._export_provider_event_context,
                     display_label="Exporting provider event context",

--- a/unify/task_scheduler/task_scheduler.py
+++ b/unify/task_scheduler/task_scheduler.py
@@ -2146,9 +2146,9 @@ class TaskScheduler(BaseTaskScheduler):
         task_id: int,
         name: Optional[str] = None,
         description: Optional[str] = None,
-        start_at: Optional[Union[str, datetime]] = None,
-        deadline: Optional[Union[str, datetime]] = None,
-        repeat: Optional[List[Union[RepeatPattern, Dict[str, Any]]]] = None,
+        start_at: Any = _UNSET,
+        deadline: Any = _UNSET,
+        repeat: Any = _UNSET,
         priority: Optional[Union[Priority, str]] = None,
         trigger: Any = _UNSET,
         entrypoint: Any = _UNSET,
@@ -2165,6 +2165,13 @@ class TaskScheduler(BaseTaskScheduler):
         schedule, deadline, repeat, priority, trigger, entrypoint, offline
         flag, enabled flag).  Only the fields that are explicitly provided are
         changed; omitted fields keep their current values.
+
+        ``start_at``, ``deadline``, ``repeat`` and ``trigger`` distinguish
+        *omitted* from *explicitly null*: passing ``None`` clears the field.
+        ``start_at=None`` removes the schedule (and sweeps ``repeat`` with it
+        unless a new ``repeat`` is set in the same call — a cadence has
+        nothing to anchor to without a schedule). Converting a scheduled task
+        to a triggered one is a single call: ``trigger=..., start_at=None``.
         """
 
         if not _root_applied:
@@ -2202,6 +2209,10 @@ class TaskScheduler(BaseTaskScheduler):
         requires_filesystem_provided = requires_filesystem is not _UNSET
         requires_computer_provided = requires_computer is not _UNSET
         enabled_provided = enabled is not _UNSET
+        start_at_provided = start_at is not _UNSET
+        deadline_provided = deadline is not _UNSET
+        repeat_provided = repeat is not _UNSET
+        schedule_cleared = start_at_provided and start_at is None
         task = self._resolve_task_for_mutation(task_id)
 
         # A managed task (custom_hash set) gets its authored fields from a
@@ -2225,9 +2236,9 @@ class TaskScheduler(BaseTaskScheduler):
                 for field, provided in (
                     ("name", name is not None),
                     ("description", description is not None),
-                    ("start_at", start_at is not None),
-                    ("deadline", deadline is not None),
-                    ("repeat", repeat is not None),
+                    ("start_at", start_at_provided),
+                    ("deadline", deadline_provided),
+                    ("repeat", repeat_provided),
                     ("priority", priority is not None),
                     ("trigger", trigger_provided),
                     ("entrypoint", entrypoint is not _UNSET),
@@ -2256,9 +2267,9 @@ class TaskScheduler(BaseTaskScheduler):
         if (
             name is None
             and description is None
-            and start_at is None
-            and deadline is None
-            and repeat is None
+            and not start_at_provided
+            and not deadline_provided
+            and not repeat_provided
             and priority is None
             and not trigger_provided
             and entrypoint is _UNSET
@@ -2269,9 +2280,15 @@ class TaskScheduler(BaseTaskScheduler):
         ):
             raise ValueError("At least one field must be provided for an update.")
 
-        if trigger_provided and trigger is not None and task.schedule is not None:
+        if (
+            trigger_provided
+            and trigger is not None
+            and task.schedule is not None
+            and not schedule_cleared
+        ):
             raise ValueError(
-                "Cannot add a trigger while a schedule exists. Remove schedule first.",
+                "Cannot add a trigger while a schedule exists. Clear it in the "
+                "same call (start_at=None) or remove the schedule first.",
             )
 
         if isinstance(start_at, datetime):
@@ -2280,7 +2297,7 @@ class TaskScheduler(BaseTaskScheduler):
             deadline = deadline.isoformat()
 
         schedule_payload: Optional[Dict[str, Any]] = None
-        if start_at is not None:
+        if start_at_provided and start_at is not None:
             if task.trigger is not None and not (trigger_provided and trigger is None):
                 raise ValueError(
                     "Cannot add or update start_at while the task is trigger-based.",
@@ -2297,13 +2314,17 @@ class TaskScheduler(BaseTaskScheduler):
         else:
             prospective_trigger = trigger
 
-        prospective_schedule: ScheduleLike = (
-            schedule_payload if schedule_payload is not None else task.schedule
-        )
+        prospective_schedule: ScheduleLike
+        if schedule_cleared:
+            prospective_schedule = None
+        elif schedule_payload is not None:
+            prospective_schedule = schedule_payload
+        else:
+            prospective_schedule = task.schedule
         if prospective_schedule is not None and prospective_trigger is not None:
             raise ValueError("A task cannot have both a schedule and a trigger.")
 
-        if schedule_payload is not None or trigger_provided:
+        if start_at_provided or trigger_provided:
             self._validate_scheduled_invariants(
                 schedule=prospective_schedule,
                 trigger=prospective_trigger,
@@ -2315,23 +2336,26 @@ class TaskScheduler(BaseTaskScheduler):
             entries["name"] = name
         if description is not None:
             entries["description"] = description
-        if deadline is not None:
-            entries["deadline"] = deadline
-        if repeat is not None:
-            normalized_repeat = normalize_repeat_patterns(
-                [
-                    RepeatPattern(**item) if isinstance(item, dict) else item
-                    for item in repeat
-                ],
-            )
-            entries["repeat"] = [
-                (
-                    item.model_dump(mode="json")
-                    if isinstance(item, RepeatPattern)
-                    else item
+        if deadline_provided:
+            entries["deadline"] = deadline  # explicit None clears the deadline
+        if repeat_provided:
+            if repeat is None:
+                entries["repeat"] = None
+            else:
+                normalized_repeat = normalize_repeat_patterns(
+                    [
+                        RepeatPattern(**item) if isinstance(item, dict) else item
+                        for item in repeat
+                    ],
                 )
-                for item in normalized_repeat or []
-            ]
+                entries["repeat"] = [
+                    (
+                        item.model_dump(mode="json")
+                        if isinstance(item, RepeatPattern)
+                        else item
+                    )
+                    for item in normalized_repeat or []
+                ]
         if priority is not None:
             if isinstance(priority, Priority):
                 entries["priority"] = priority
@@ -2349,6 +2373,13 @@ class TaskScheduler(BaseTaskScheduler):
                 entries["trigger"] = prospective_trigger
         if schedule_payload is not None:
             entries["schedule"] = schedule_payload
+        elif schedule_cleared:
+            entries["schedule"] = None
+            # A repeat pattern has nothing to anchor to without a schedule;
+            # clearing the schedule sweeps the cadence too unless the caller
+            # replaced it explicitly in the same call.
+            if task.repeat is not None and not repeat_provided:
+                entries["repeat"] = None
         if entrypoint is not _UNSET:
             if entrypoint is None:
                 entries["entrypoint"] = None


### PR DESCRIPTION
Promotes unity staging to main for the LLM-gateway Phase 3 prod cutover. Bumps the prod brain SHA (via the REBUILD_MARKER) so the prod base rebuild ships gateway-capable unillm (already on unillm main) to production assistant pods, and the SHA-keyed image rollout actually propagates. Carries 5 other recent staging commits (cache keying, model-vendor labelling, task update fixes, spending-refusal wording). Verified end-to-end on staging: pods route OpenRouter through the gateway and no longer carry the OpenRouter key. Requires @magic-marty approval.