### PR TITLE
Promote: brain SHA bump to ship reverted unillm to prod (retire LLM gateway)

### DIFF
--- a/deploy/REBUILD_MARKER.md
+++ b/deploy/REBUILD_MARKER.md
@@ -5,3 +5,6 @@ Bumping the brain SHA to roll a new assistant image out to running pods.
 - 2026-08-11: force rebuild so pods pick up gateway-capable `unillm`
   (LLM gateway routing, unillm#112) — a dependency-only change does not change
   the brain SHA on its own, so the SHA-keyed image rollout needs this nudge.
+
+- 2026-08-11: bump brain SHA to ship reverted unillm (OpenRouter direct again;
+  Orchestra LLM gateway retired) to pods.

--- a/tests/conversation_manager/voice/test_proactive_speech_discard.py
+++ b/tests/conversation_manager/voice/test_proactive_speech_discard.py
@@ -195,6 +195,7 @@ async def _boot_entrypoint(monkeypatch):
         ),
         assistant=SimpleNamespace(
             has_managed_desktop=False,
+            managed_desktop_entitled=False,
             about="Assistant bio",
             name="Ava",
             first_name="Ava",

--- a/tests/conversation_manager/voice/test_whatsapp_call_speaks_on_answer.py
+++ b/tests/conversation_manager/voice/test_whatsapp_call_speaks_on_answer.py
@@ -198,6 +198,7 @@ def _install_entrypoint_fakes(monkeypatch, sequence, extra_metadata=None):
         user=SimpleNamespace(id=None),
         assistant=SimpleNamespace(
             has_managed_desktop=False,
+            managed_desktop_entitled=False,
             about="Assistant bio",
             is_coordinator=False,
             agent_id=None,

--- a/tests/test_session_details.py
+++ b/tests/test_session_details.py
@@ -320,3 +320,32 @@ class TestAssistantManagedDesktop:
             desktop_url="https://example.com",
         )
         assert assistant.has_managed_desktop is False
+
+    def test_entitlement_does_not_require_a_bound_desktop_url(self):
+        """Requesting a desktop must not depend on already having one.
+
+        A deferred voice activation has no desktop_url yet, so gating the
+        promotion on ``has_managed_desktop`` never fired and the session never
+        got a desktop.
+        """
+        assistant = AssistantDetails(
+            desktop_mode="ubuntu",
+            managed_desktop_status="active",
+            desktop_url=None,
+        )
+        assert assistant.managed_desktop_entitled is True
+        assert assistant.has_managed_desktop is False
+
+    def test_entitlement_requires_the_addon_to_be_active(self):
+        assistant = AssistantDetails(
+            desktop_mode="ubuntu",
+            managed_desktop_status=None,
+        )
+        assert assistant.managed_desktop_entitled is False
+
+    def test_entitlement_requires_a_managed_desktop_mode(self):
+        assistant = AssistantDetails(
+            desktop_mode="none",
+            managed_desktop_status="active",
+        )
+        assert assistant.managed_desktop_entitled is False

--- a/unify/conversation_manager/medium_scripts/call.py
+++ b/unify/conversation_manager/medium_scripts/call.py
@@ -3917,7 +3917,11 @@ async def entrypoint(ctx: agents.JobContext):
     def _schedule_deferred_desktop_binding() -> None:
         if not _voice_call_channel_defers_desktop_binding(channel):
             return
-        if not SESSION_DETAILS.assistant.has_managed_desktop:
+        # Entitlement, not ``has_managed_desktop``: the whole point of this call
+        # is that the activation deferred VM binding, so no desktop_url exists
+        # yet. Gating on one meant the promotion never fired and a deferred
+        # voice session never got a desktop at all.
+        if not SESSION_DETAILS.assistant.managed_desktop_entitled:
             return
         agent_id = SESSION_DETAILS.assistant.agent_id
         if agent_id is None:

--- a/unify/session_details.py
+++ b/unify/session_details.py
@@ -316,13 +316,23 @@ class AssistantDetails:
         return f"{self.first_name} {self.surname}".strip()
 
     @property
-    def has_managed_desktop(self) -> bool:
-        """True when managed Computer Use is entitled and a VM URL is assigned."""
+    def managed_desktop_entitled(self) -> bool:
+        """True when the managed Computer Use add-on is enabled and paid for.
+
+        Independent of whether a VM is currently bound, so it is the correct
+        gate for *requesting* a desktop. Asking ``has_managed_desktop`` there is
+        circular: it requires ``desktop_url``, which only arrives once the
+        desktop the caller wants to request is already ready.
+        """
         return (
             self.desktop_mode in ("ubuntu", "windows")
             and self.managed_desktop_status == "active"
-            and bool(self.desktop_url)
         )
+
+    @property
+    def has_managed_desktop(self) -> bool:
+        """True when managed Computer Use is entitled and a VM URL is assigned."""
+        return self.managed_desktop_entitled and bool(self.desktop_url)
 
     def user_desktop_for(self, user_id: str | None) -> UserDesktopLink | None:
         """Return the desktop the given user has linked to this assistant."""


### PR DESCRIPTION
Promotes unity staging to main to bump the prod brain SHA so the reverted unillm (OpenRouter direct; gateway retired) reaches prod pods. Verified on staging (direct 200, subprocess-scrubbed). @magic-marty