### PR TITLE
Release: staging → main (withhold LLM billing keys from user code)

### DIFF
--- a/tests/actor/state_managers/simulated/dashboards/test_primitives_discovery.py
+++ b/tests/actor/state_managers/simulated/dashboards/test_primitives_discovery.py
@@ -173,6 +173,39 @@ def test_dashboard_not_in_data_routing_guidance():
     assert "primitives.dashboards.*` vs `primitives.data.*" not in context
 
 
+def test_dashboard_prompt_stands_alone_without_canvas():
+    """Without canvas in scope, dashboards is the authoring surface.
+
+    The supersession framing routes all new visual work to
+    ``primitives.canvas``, so it may only render when canvas is actually
+    callable. A prompt that bans authoring on the one visual tool in scope
+    makes the actor refuse work its tools fully support.
+    """
+    from unify.function_manager.primitives import get_registry
+    from unify.function_manager.primitives.scope import PrimitiveScope
+
+    registry = get_registry()
+    solo = registry.prompt_context(
+        PrimitiveScope(scoped_managers=frozenset({"dashboards"})),
+    )
+    assert "primitives.canvas" not in solo
+    assert "superseded" not in solo.lower()
+    assert "Visualizations & Dashboards" in solo
+
+
+def test_dashboard_prompt_superseded_when_canvas_in_scope():
+    """With canvas in scope, the supersession framing steers authoring there."""
+    from unify.function_manager.primitives import get_registry
+    from unify.function_manager.primitives.scope import PrimitiveScope
+
+    registry = get_registry()
+    both = registry.prompt_context(
+        PrimitiveScope(scoped_managers=frozenset({"dashboards", "canvas"})),
+    )
+    assert "Legacy HTML Tiles (superseded by Canvas)" in both
+    assert "SUPERSEDED BY primitives.canvas" in both
+
+
 def test_dashboard_example_generators_registered():
     """Dashboard example generators should be registered in _EXAMPLE_GENERATORS."""
     from unify.function_manager.primitives.registry import _EXAMPLE_GENERATORS

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,7 +31,13 @@ import pytest
 import requests
 import unisdk
 from pytest_metadata.plugin import metadata_key
-from unisdk.utils import http as unisdk_http
+
+# Imported as a symbol (not via module attribute access at call time) so a
+# unisdk checkout that predates it fails collection with an ImportError here,
+# rather than an AttributeError inside per-test setup's broad exception
+# handlers — which would silently skip set_context and collapse every test
+# into one shared context root.
+from unisdk.utils.http import default_timeout as unisdk_default_timeout
 
 from datetime import datetime, timezone
 
@@ -158,6 +164,18 @@ def _reset_singleton_registries() -> None:
         pass
 
 
+def _assert_test_context_active(ctx: str) -> None:
+    # set_context activates the local context vars before any remote
+    # round-trip, so after setup they must hold the per-test root no matter
+    # what the network did. If they don't, every subsequent test would share
+    # one context root and cross-contaminate — fail the session here instead.
+    active = unisdk.get_active_context()
+    assert active.get("read") == ctx and active.get("write") == ctx, (
+        f"Per-test Unify context activation failed: expected {ctx!r}, "
+        f"active is {active!r}. Test isolation would be lost."
+    )
+
+
 def _set_unify_context_for_test(item: pytest.Item) -> None:
     """Set a unique per-test Unify context early (before fixtures)."""
     ctx = _derive_test_context(item)
@@ -169,6 +187,7 @@ def _set_unify_context_for_test(item: pytest.Item) -> None:
         # process. Tests that need Orchestra fail or skip on their own.
         unisdk.set_context(ctx, relative=False, skip_create=True)
         _reset_singleton_registries()
+        _assert_test_context_active(ctx)
         return
 
     # Clean slate unless contexts are pre-created during collection.
@@ -177,18 +196,19 @@ def _set_unify_context_for_test(item: pytest.Item) -> None:
         skip_ctx_create = ctx in PRECREATED_CONTEXTS
     else:
         try:
-            with unisdk_http.default_timeout(SETTINGS.UNIFY_TEST_SETUP_HTTP_TIMEOUT):
+            with unisdk_default_timeout(SETTINGS.UNIFY_TEST_SETUP_HTTP_TIMEOUT):
                 unisdk.delete_context(ctx)
         except _SETUP_NETWORK_ERRORS as exc:
             _trip_orchestra_setup_breaker(exc)
             unisdk.set_context(ctx, relative=False, skip_create=True)
             _reset_singleton_registries()
+            _assert_test_context_active(ctx)
             return
         except Exception:
             pass
 
     try:
-        with unisdk_http.default_timeout(SETTINGS.UNIFY_TEST_SETUP_HTTP_TIMEOUT):
+        with unisdk_default_timeout(SETTINGS.UNIFY_TEST_SETUP_HTTP_TIMEOUT):
             unisdk.set_context(ctx, relative=False, skip_create=skip_ctx_create)
     except _SETUP_NETWORK_ERRORS as exc:
         # set_context activates the local context vars before its remote
@@ -198,6 +218,7 @@ def _set_unify_context_for_test(item: pytest.Item) -> None:
         pass  # Project may not exist yet; tests that need it will fail on their own
 
     _reset_singleton_registries()
+    _assert_test_context_active(ctx)
 
 
 def _uses_unify_context(item: pytest.Item) -> bool:
@@ -216,7 +237,7 @@ def _unset_unify_context_for_test(item: pytest.Item) -> None:
             and _orchestra_usable_for_setup()
         ):
             try:
-                with unisdk_http.default_timeout(
+                with unisdk_default_timeout(
                     SETTINGS.UNIFY_TEST_SETUP_HTTP_TIMEOUT,
                 ):
                     unisdk.delete_context(ctx)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,8 +28,10 @@ import hashlib
 
 import httpx
 import pytest
+import requests
 import unisdk
 from pytest_metadata.plugin import metadata_key
+from unisdk.utils import http as unisdk_http
 
 from datetime import datetime, timezone
 
@@ -113,26 +115,35 @@ def _derive_test_context(item: pytest.Item) -> str:
     return f"{test_path}/{func_name}/{UNASSIGNED_USER_CONTEXT}/{UNASSIGNED_ASSISTANT_CONTEXT}"
 
 
-def _set_unify_context_for_test(item: pytest.Item) -> None:
-    """Set a unique per-test Unify context early (before fixtures)."""
-    ctx = _derive_test_context(item)
-    setattr(item, "_unity_unify_test_ctx", ctx)
+# Trips permanently for this process the first time a per-test setup call
+# stalls or loses the connection, so one network incident costs one bounded
+# timeout instead of taxing every subsequent test. Local context activation
+# still happens for every test; only the remote round-trips are skipped.
+_ORCHESTRA_SETUP_BROKEN = False
 
-    # Clean slate unless contexts are pre-created during collection.
-    skip_ctx_create = False
-    if SETTINGS.UNIFY_PRETEST_CONTEXT_CREATE:
-        skip_ctx_create = ctx in PRECREATED_CONTEXTS
-    else:
-        try:
-            unisdk.delete_context(ctx)
-        except Exception:
-            pass
+_SETUP_NETWORK_ERRORS = (
+    requests.exceptions.Timeout,
+    requests.exceptions.ConnectionError,
+)
 
-    try:
-        unisdk.set_context(ctx, relative=False, skip_create=skip_ctx_create)
-    except Exception:
-        pass  # Project may not exist yet; tests that need it will fail on their own
 
+def _trip_orchestra_setup_breaker(exc: Exception) -> None:
+    global _ORCHESTRA_SETUP_BROKEN
+    if not _ORCHESTRA_SETUP_BROKEN:
+        _ORCHESTRA_SETUP_BROKEN = True
+        print(
+            "\n[unity-conftest] Orchestra became unreachable during test setup "
+            f"({type(exc).__name__}); switching to local-only context setup for "
+            "the rest of this session. Tests that need Orchestra will fail or "
+            "skip on their own.\n",
+        )
+
+
+def _orchestra_usable_for_setup() -> bool:
+    return not _ORCHESTRA_SETUP_BROKEN and _check_orchestra_available()
+
+
+def _reset_singleton_registries() -> None:
     # Ensure singleton registries don't leak across tests and that fixtures see
     # the correct context for any context-derived subcontexts (e.g. FunctionManager).
     try:
@@ -147,6 +158,48 @@ def _set_unify_context_for_test(item: pytest.Item) -> None:
         pass
 
 
+def _set_unify_context_for_test(item: pytest.Item) -> None:
+    """Set a unique per-test Unify context early (before fixtures)."""
+    ctx = _derive_test_context(item)
+    setattr(item, "_unity_unify_test_ctx", ctx)
+
+    if not _orchestra_usable_for_setup():
+        # Local-only: activate the per-test context without touching the
+        # network, keeping context isolation for tests that never leave the
+        # process. Tests that need Orchestra fail or skip on their own.
+        unisdk.set_context(ctx, relative=False, skip_create=True)
+        _reset_singleton_registries()
+        return
+
+    # Clean slate unless contexts are pre-created during collection.
+    skip_ctx_create = False
+    if SETTINGS.UNIFY_PRETEST_CONTEXT_CREATE:
+        skip_ctx_create = ctx in PRECREATED_CONTEXTS
+    else:
+        try:
+            with unisdk_http.default_timeout(SETTINGS.UNIFY_TEST_SETUP_HTTP_TIMEOUT):
+                unisdk.delete_context(ctx)
+        except _SETUP_NETWORK_ERRORS as exc:
+            _trip_orchestra_setup_breaker(exc)
+            unisdk.set_context(ctx, relative=False, skip_create=True)
+            _reset_singleton_registries()
+            return
+        except Exception:
+            pass
+
+    try:
+        with unisdk_http.default_timeout(SETTINGS.UNIFY_TEST_SETUP_HTTP_TIMEOUT):
+            unisdk.set_context(ctx, relative=False, skip_create=skip_ctx_create)
+    except _SETUP_NETWORK_ERRORS as exc:
+        # set_context activates the local context vars before its remote
+        # round-trip, so the test still runs in the right context.
+        _trip_orchestra_setup_breaker(exc)
+    except Exception:
+        pass  # Project may not exist yet; tests that need it will fail on their own
+
+    _reset_singleton_registries()
+
+
 def _uses_unify_context(item: pytest.Item) -> bool:
     """Return whether this test needs the default per-test Unify context."""
 
@@ -157,9 +210,18 @@ def _unset_unify_context_for_test(item: pytest.Item) -> None:
     """Unset (and optionally delete) the per-test Unify context after fixture teardown."""
     ctx = getattr(item, "_unity_unify_test_ctx", None)
     try:
-        if ctx and SETTINGS.UNIFY_DELETE_CONTEXT_ON_EXIT:
+        if (
+            ctx
+            and SETTINGS.UNIFY_DELETE_CONTEXT_ON_EXIT
+            and _orchestra_usable_for_setup()
+        ):
             try:
-                unisdk.delete_context(ctx)
+                with unisdk_http.default_timeout(
+                    SETTINGS.UNIFY_TEST_SETUP_HTTP_TIMEOUT,
+                ):
+                    unisdk.delete_context(ctx)
+            except _SETUP_NETWORK_ERRORS as exc:
+                _trip_orchestra_setup_breaker(exc)
             except Exception:
                 pass
     finally:
@@ -985,6 +1047,8 @@ def pytest_collection_finish(session):
     # Compute all contexts and fire off background creation tasks
     # Skip when UNIFY_SKIP_SESSION_SETUP is set (shared project mode)
     if SETTINGS.UNIFY_PRETEST_CONTEXT_CREATE and not SETTINGS.UNIFY_SKIP_SESSION_SETUP:
+        if not _orchestra_usable_for_setup():
+            return
         contexts: set[str] = set()
         for item in session.items:
             ctx = _get_context_name_for_item(item)
@@ -994,7 +1058,11 @@ def pytest_collection_finish(session):
         # TODO: Should delete contexts before creating them
         # But this is mostly fine now for CI purpose, as we create
         # a fresh project anyway
-        unisdk.create_contexts(list(contexts))
+        try:
+            unisdk.create_contexts(list(contexts))
+        except _SETUP_NETWORK_ERRORS as exc:
+            _trip_orchestra_setup_breaker(exc)
+            return
         PRECREATED_CONTEXTS.update(contexts)
 
 

--- a/tests/llm_broker/test_broker.py
+++ b/tests/llm_broker/test_broker.py
@@ -12,9 +12,10 @@ import json
 
 import httpx
 import pytest
+from fastapi import Request
 from fastapi.testclient import TestClient
 
-from unify.llm_broker.app import build_app
+from unify.llm_broker.app import _assistant_id, build_app
 from unify.llm_broker.settings import BrokerSettings
 from unify.llm_broker.usage import usage_from_stream_tail
 
@@ -244,3 +245,52 @@ class TestUsageExtraction:
 
     def test_a_stream_with_no_usage_reports_nothing(self):
         assert usage_from_stream_tail('data: {"choices":[]}\n\n') is None
+
+
+class TestAssistantAttribution:
+    """A brokered call must still land on the assistant that made it.
+
+    The direct path took this from the billing context when it deducted
+    client-side. Gateway-routed calls skip that deduction, so the id has to
+    travel explicitly -- otherwise spend lands on the account with no
+    assistant, which loses per-assistant reporting and quietly stops the
+    per-assistant spending caps applying, since those are enforced on it.
+    """
+
+    def _request(self, headers=None):
+        scope = {
+            "type": "http",
+            "headers": [
+                (k.lower().encode(), v.encode()) for k, v in (headers or {}).items()
+            ],
+        }
+        return Request(scope)
+
+    def test_the_header_the_runtime_sets_is_used(self):
+        got = _assistant_id(
+            self._request({"X-Unify-Assistant-Id": "7366"}),
+            {},
+        )
+        assert got == 7366
+
+    def test_a_body_field_still_works_for_direct_callers(self):
+        """Callers without a runtime setting headers are not left unattributed."""
+        body = {"assistant_id": 42}
+        assert _assistant_id(self._request(), body) == 42
+        assert "assistant_id" not in body, "must not reach the provider"
+
+    def test_the_header_wins_over_a_body_field(self):
+        assert (
+            _assistant_id(
+                self._request({"X-Unify-Assistant-Id": "7366"}),
+                {"assistant_id": 1},
+            )
+            == 7366
+        )
+
+    def test_an_unusable_id_attributes_nothing_rather_than_failing(self):
+        """A malformed id should not cost the caller the whole call."""
+        assert _assistant_id(self._request({"X-Unify-Assistant-Id": "x"}), {}) is None
+
+    def test_no_id_anywhere_is_simply_unattributed(self):
+        assert _assistant_id(self._request(), {}) is None

--- a/tests/llm_broker/test_broker.py
+++ b/tests/llm_broker/test_broker.py
@@ -1,0 +1,246 @@
+"""The pod-local broker: what it forwards, what it refuses, what it reports.
+
+Exercised through the real routes with the provider and Orchestra stubbed,
+because the behaviours worth pinning are the interactions -- refuse before
+spending, forward bytes unaltered, report usage after -- rather than the
+shape of any one function.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from unify.llm_broker.app import build_app
+from unify.llm_broker.settings import BrokerSettings
+from unify.llm_broker.usage import usage_from_stream_tail
+
+_SETTINGS = BrokerSettings(
+    host="127.0.0.1",
+    port=0,
+    orchestra_url="https://orchestra.test/v0",
+    openrouter_api_key="sk-openrouter",  # pragma: allowlist secret
+    openrouter_api_base="https://openrouter.test/api/v1",
+    anthropic_api_key="sk-anthropic",  # pragma: allowlist secret
+    anthropic_api_base="https://anthropic.test",
+    # Every call re-asks, so a test never passes because of a cached verdict.
+    auth_ttl_s=0.0,
+)
+
+_AUTH = {"Authorization": "Bearer caller-key"}
+
+
+class _Recorder:
+    """Stands in for both Orchestra and the provider, and remembers calls."""
+
+    def __init__(self, *, allowed=True, reason=None, provider_body=None, stream=None):
+        self.allowed = allowed
+        self.reason = reason
+        self.provider_body = provider_body or {"usage": {"cost": 0.002}}
+        self.stream = stream
+        self.authorize_calls: list[dict] = []
+        self.settle_calls: list[dict] = []
+        self.provider_calls: list[dict] = []
+
+    async def handle(self, request: httpx.Request) -> httpx.Response:
+        url = str(request.url)
+        payload = json.loads(request.content or b"{}")
+        if url.endswith("/llm/authorize"):
+            self.authorize_calls.append(payload)
+            return httpx.Response(
+                200,
+                json={"allowed": self.allowed, "reason": self.reason},
+            )
+        if url.endswith("/llm/settle"):
+            self.settle_calls.append(payload)
+            return httpx.Response(200, json={"charged": 0.0024, "metered": True})
+
+        self.provider_calls.append(
+            {"url": url, "headers": dict(request.headers), "body": payload},
+        )
+        if self.stream is not None:
+            return httpx.Response(200, content=self.stream)
+        return httpx.Response(200, json=self.provider_body)
+
+
+def _client(recorder: _Recorder) -> TestClient:
+    app = build_app(_SETTINGS)
+    transport = httpx.MockTransport(recorder.handle)
+    app.state.broker._provider = httpx.AsyncClient(transport=transport)
+    app.state.broker._control = httpx.AsyncClient(transport=transport)
+    return TestClient(app)
+
+
+class TestAuthorizationPrecedesSpending:
+    def test_a_refused_account_never_reaches_the_provider(self):
+        """The point of asking first: no call, so nothing to bill."""
+        recorder = _Recorder(allowed=False, reason="Insufficient credits.")
+        response = _client(recorder).post(
+            "/llm/chat/completions",
+            headers=_AUTH,
+            json={"model": "openai/gpt-5.6-sol", "messages": []},
+        )
+
+        assert response.status_code == 402
+        assert response.json()["detail"] == "Insufficient credits."
+        assert recorder.provider_calls == []
+
+    def test_an_unreachable_ledger_refuses_rather_than_proceeds(self):
+        """Fail closed: an unreachable ledger cannot record what it allows."""
+
+        async def unreachable(request: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectError("orchestra down", request=request)
+
+        app = build_app(_SETTINGS)
+        transport = httpx.MockTransport(unreachable)
+        app.state.broker._control = httpx.AsyncClient(transport=transport)
+        app.state.broker._provider = httpx.AsyncClient(transport=transport)
+
+        response = TestClient(app).post(
+            "/llm/chat/completions",
+            headers=_AUTH,
+            json={"model": "openai/gpt-5.6-sol", "messages": []},
+        )
+        assert response.status_code == 503
+
+    def test_a_call_without_a_key_is_refused_before_anything_else(self):
+        recorder = _Recorder()
+        response = _client(recorder).post(
+            "/llm/chat/completions",
+            json={"model": "openai/gpt-5.6-sol", "messages": []},
+        )
+
+        assert response.status_code == 401
+        assert recorder.authorize_calls == []
+
+
+class TestTheCallerNeverSeesTheProviderKey:
+    def test_the_caller_s_key_is_replaced_not_forwarded(self):
+        """The whole point of the sidecar: the credential is substituted here."""
+        recorder = _Recorder()
+        _client(recorder).post(
+            "/llm/chat/completions",
+            headers=_AUTH,
+            json={"model": "openai/gpt-5.6-sol", "messages": []},
+        )
+
+        sent = recorder.provider_calls[0]["headers"]
+        assert sent["authorization"] == "Bearer sk-openrouter"
+        assert "caller-key" not in sent["authorization"]
+
+    def test_anthropic_receives_its_own_credential_header(self):
+        recorder = _Recorder(provider_body={"usage": {"input_tokens": 10}})
+        _client(recorder).post(
+            "/llm/anthropic/v1/messages",
+            headers=_AUTH,
+            json={"model": "claude-opus-5", "messages": []},
+        )
+
+        sent = recorder.provider_calls[0]["headers"]
+        assert sent["x-api-key"] == "sk-anthropic"
+        assert sent["anthropic-version"] == "2023-06-01"
+
+
+class TestUsageIsReportedNotPriced:
+    def test_the_provider_s_usage_is_relayed_verbatim(self):
+        """Orchestra prices it; a broker that priced could declare anything."""
+        recorder = _Recorder(provider_body={"usage": {"cost": 0.00042}})
+        _client(recorder).post(
+            "/llm/chat/completions",
+            headers=_AUTH,
+            json={"model": "openai/gpt-5.6-sol", "messages": []},
+        )
+
+        assert len(recorder.settle_calls) == 1
+        settled = recorder.settle_calls[0]
+        assert settled["usage"] == {"cost": 0.00042}
+        assert settled["model"] == "openai/gpt-5.6-sol"
+        assert "charged" not in settled
+
+    def test_cost_accounting_is_requested_on_the_way_out(self):
+        """OpenRouter reports cost only when asked, and it is what we settle on."""
+        recorder = _Recorder()
+        _client(recorder).post(
+            "/llm/chat/completions",
+            headers=_AUTH,
+            json={"model": "openai/gpt-5.6-sol", "messages": []},
+        )
+
+        assert recorder.provider_calls[0]["body"]["usage"] == {"include": True}
+
+    def test_a_failed_provider_call_is_not_settled(self):
+        """Nothing was served, so there is nothing to charge for."""
+
+        async def failing(request: httpx.Request) -> httpx.Response:
+            if str(request.url).endswith("/llm/authorize"):
+                return httpx.Response(200, json={"allowed": True})
+            return httpx.Response(500, json={"error": "provider exploded"})
+
+        app = build_app(_SETTINGS)
+        transport = httpx.MockTransport(failing)
+        app.state.broker._provider = httpx.AsyncClient(transport=transport)
+        app.state.broker._control = httpx.AsyncClient(transport=transport)
+
+        response = TestClient(app).post(
+            "/llm/chat/completions",
+            headers=_AUTH,
+            json={"model": "openai/gpt-5.6-sol", "messages": []},
+        )
+        assert response.status_code == 500
+
+
+class TestStreaming:
+    def test_provider_bytes_reach_the_caller_unaltered(self):
+        """A voice turn reads these as they arrive; rewriting them adds delay."""
+        body = (
+            b'data: {"choices":[{"delta":{"content":"He"}}]}\n\n'
+            b'data: {"choices":[{"delta":{"content":"llo"}}]}\n\n'
+            b'data: {"usage":{"cost":0.001}}\n\ndata: [DONE]\n\n'
+        )
+        recorder = _Recorder(stream=body)
+        response = _client(recorder).post(
+            "/llm/chat/completions",
+            headers=_AUTH,
+            json={"model": "openai/gpt-5.6-sol", "messages": [], "stream": True},
+        )
+
+        assert response.content == body
+
+    def test_a_stream_settles_from_its_terminal_usage(self):
+        body = (
+            b'data: {"choices":[{"delta":{"content":"hi"}}]}\n\n'
+            b'data: {"usage":{"cost":0.00123}}\n\ndata: [DONE]\n\n'
+        )
+        recorder = _Recorder(stream=body)
+        _client(recorder).post(
+            "/llm/chat/completions",
+            headers=_AUTH,
+            json={"model": "openai/gpt-5.6-sol", "messages": [], "stream": True},
+        )
+
+        assert recorder.settle_calls[0]["usage"]["cost"] == pytest.approx(0.00123)
+
+
+class TestUsageExtraction:
+    def test_anthropic_counts_split_across_events_are_merged(self):
+        """Input arrives on message_start, output on the final message_delta."""
+        tail = (
+            'data: {"type":"message_start","message":{"usage":'
+            '{"input_tokens":900}}}\n\n'
+            'data: {"type":"message_delta","usage":{"output_tokens":120}}\n\n'
+        )
+        assert usage_from_stream_tail(tail) == {
+            "input_tokens": 900,
+            "output_tokens": 120,
+        }
+
+    def test_a_truncated_leading_line_does_not_discard_the_rest(self):
+        """The tail is a byte window, so its first line is usually incomplete."""
+        tail = '_tokens":5}}\n\ndata: {"usage":{"output_tokens":7}}\n\n'
+        assert usage_from_stream_tail(tail) == {"output_tokens": 7}
+
+    def test_a_stream_with_no_usage_reports_nothing(self):
+        assert usage_from_stream_tail('data: {"choices":[]}\n\n') is None

--- a/tests/parallel_run.sh
+++ b/tests/parallel_run.sh
@@ -403,6 +403,11 @@ if _is_local_url "${ORCHESTRA_URL:-}"; then
     export ORCHESTRA_SEED_USER=1
     export ORCHESTRA_TEST_USER_ID="${ORCHESTRA_TEST_USER_ID:-unity-test-user-001}"
     export ORCHESTRA_TEST_EMAIL="${ORCHESTRA_TEST_EMAIL:-unity-test@debug.local}"
+    # Local orchestra defaults its admin bearer to "local-admin-key"
+    # (scripts/local.sh); the test process needs the same value so reserved
+    # Builtins-project seeding can swap it in (builtins_seed_key_override).
+    # CI sets this explicitly; default it here for local runs.
+    export ORCHESTRA_ADMIN_KEY="${ORCHESTRA_ADMIN_KEY:-local-admin-key}"
 
     # Set up OTEL log directory for cross-repo trace correlation (logs/all/).
     # Note: ORCHESTRA_LOG_DIR (per-request JSON traces to logs/orchestra/) is

--- a/tests/parallel_run.sh
+++ b/tests/parallel_run.sh
@@ -938,6 +938,19 @@ run_cmd() {
   # - UNIFY_TESTS_DELETE_PROJ_ON_START/EXIT: explicitly unset in shared project mode
   #   to prevent race conditions (multiple sessions deleting the same project).
   env_exports='export LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8 UNILLM_CACHE_STATS=true'
+  # Re-assert the runner's auth/routing env inside the session command. tmux
+  # launches each command through the user's default shell, and zsh sources
+  # ~/.zshenv even for plain `zsh -c`, so a dotfile exporting one of these
+  # (e.g. a personal hosted UNIFY_KEY) silently clobbers the inherited value
+  # and every session 401s against the local Orchestra this runner just
+  # seeded. The runner's values are the source of truth; restate them after
+  # shell init has run.
+  local _reassert_var
+  for _reassert_var in UNIFY_KEY ORCHESTRA_URL ORCHESTRA_ADMIN_KEY; do
+    if [[ -n "${!_reassert_var:-}" ]]; then
+      env_exports="$env_exports $(printf '%s=%q' "$_reassert_var" "${!_reassert_var}")"
+    fi
+  done
   if is_random_projects_mode; then
     # Random projects mode: each session gets its own isolated project.
     # Per-session deletion is safe here since projects don't overlap.

--- a/tests/provider_proxy/test_session_env.py
+++ b/tests/provider_proxy/test_session_env.py
@@ -50,16 +50,45 @@ def test_build_sandbox_env_strips_provider_billing_credentials(monkeypatch):
     assert "ELEVEN_API_KEY" not in env
 
 
-def test_provider_billing_keys_stay_in_process_environ(monkeypatch):
-    # The provider SDKs resolve these from os.environ at call time, so the
-    # in-process scrub must leave them alone or concurrent inference breaks.
+def test_llm_billing_keys_are_withheld_in_process(monkeypatch):
+    """User code must not be able to read the LLM billing credentials.
+
+    These are the keys worth stealing: one pod holds a single set for every
+    assistant it runs, so a copy is an uncapped spending instrument usable
+    from anywhere, and the resulting spend is attributable to nobody. UniLLM
+    now sends them with each request from settings captured at import, so
+    nothing resolves them from the environment mid-call and withholding them
+    here cannot strand inference in flight.
+    """
     billing_key = "sk-or-v1-billing"  # pragma: allowlist secret
     monkeypatch.setenv("OPENROUTER_API_KEY", billing_key)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-billing")
     monkeypatch.setenv("ORCHESTRA_ADMIN_KEY", "super-secret")
 
     with scrub_platform_secrets_from_environ():
         assert "ORCHESTRA_ADMIN_KEY" not in os.environ
-        assert os.environ["OPENROUTER_API_KEY"] == billing_key
+        assert "OPENROUTER_API_KEY" not in os.environ
+        assert "ANTHROPIC_API_KEY" not in os.environ
+
+    assert os.environ["OPENROUTER_API_KEY"] == billing_key
+
+
+def test_credentials_read_from_the_environ_mid_call_are_left_alone(monkeypatch):
+    """Only the keys UniLLM sends explicitly may be withheld.
+
+    Speech and telephony SDKs still resolve their credentials at call time,
+    so removing these would break a transcription or voice call that happened
+    to overlap with user code. They stay stripped from subprocess sandboxes,
+    where no such overlap exists.
+    """
+    speech = "dg-live"  # pragma: allowlist secret
+    telephony = "lk-live"  # pragma: allowlist secret
+    monkeypatch.setenv("DEEPGRAM_API_KEY", speech)
+    monkeypatch.setenv("LIVEKIT_API_SECRET", telephony)
+
+    with scrub_platform_secrets_from_environ():
+        assert os.environ["DEEPGRAM_API_KEY"] == speech
+        assert os.environ["LIVEKIT_API_SECRET"] == telephony
 
 
 def test_scrub_platform_secrets_from_environ_restores(monkeypatch):

--- a/tests/provider_trigger_delivery.py
+++ b/tests/provider_trigger_delivery.py
@@ -229,30 +229,30 @@ def ensure_provider_trigger_test_prerequisites() -> None:
         )
 
 
-def _orchestra_db_container() -> str:
-    return os.getenv("ORCHESTRA_DB_CONTAINER", "orchestra-local-db")
+def ensure_integration_backend_enabled(backend_id: str) -> None:
+    """Enable an integration backend the server boot may have disabled.
+
+    Orchestra's self-host bootstrap aligns each backend's status with the
+    configured provider credentials on every start, so a keyless local or CI
+    Orchestra boots with composio and pipedream disabled. Status is the
+    visibility gate for connect/start even on the stub (LocalEcho) execution
+    path, so suites that create stub-backed connections must enable the
+    backend they use first.
+    """
+
+    response = requests.patch(
+        f"{orchestra_api_base()}/v0/admin/integrations/backends/{backend_id}",
+        headers={"Authorization": f"Bearer {orchestra_admin_key()}"},
+        json={"status": "enabled"},
+        timeout=30,
+    )
+    raise_for_status_with_detail(response)
 
 
 def ensure_pipedream_integration_backend_enabled() -> None:
     """Enable the Pipedream integration backend row for local actor E2E runs."""
 
-    subprocess.check_output(
-        [
-            "docker",
-            "exec",
-            _orchestra_db_container(),
-            "psql",
-            "-U",
-            "orchestra",
-            "-d",
-            "orchestra",
-            "-c",
-            "UPDATE integration_backends "
-            "SET status = 'enabled' "
-            "WHERE backend_id = 'pipedream';",
-        ],
-        text=True,
-    )
+    ensure_integration_backend_enabled("pipedream")
 
 
 def sign_composio_payload(
@@ -598,6 +598,7 @@ def create_github_composio_connection(
 ) -> dict[str, Any]:
     """Start and complete one assistant-scoped Composio GitHub connection."""
 
+    ensure_integration_backend_enabled("composio")
     api_key = orchestra_api_key()
     base = orchestra_api_base()
     headers = {"Authorization": f"Bearer {api_key}"}
@@ -636,6 +637,7 @@ def create_github_composio_connection(
 def create_github_pipedream_connection(*, assistant_id: int) -> dict[str, Any]:
     """Start and complete one assistant-scoped Pipedream GitHub connection."""
 
+    ensure_integration_backend_enabled("pipedream")
     api_key = orchestra_api_key()
     base = orchestra_api_base()
     headers = {"Authorization": f"Bearer {api_key}"}

--- a/tests/provider_trigger_delivery.py
+++ b/tests/provider_trigger_delivery.py
@@ -75,6 +75,23 @@ def orchestra_api_base() -> str:
     return raw
 
 
+def raise_for_status_with_detail(response: requests.Response) -> None:
+    """``raise_for_status`` that keeps the server's error body.
+
+    Orchestra explains refusals in the JSON ``detail`` field;
+    ``raise_for_status`` alone reports only the status code and URL, which
+    turns a self-describing failure into archaeology.
+    """
+
+    if response.status_code < 400:
+        return
+    raise requests.HTTPError(
+        f"{response.status_code} for {response.request.method} {response.url}: "
+        f"{response.text[:500]}",
+        response=response,
+    )
+
+
 def orchestra_api_key() -> str:
     return os.getenv("UNIFY_KEY", "local-test-api-key")
 
@@ -116,7 +133,7 @@ def ensure_provider_trigger_catalog_seeded(
                 headers=headers,
                 timeout=120,
             )
-            response.raise_for_status()
+            raise_for_status_with_detail(response)
 
 
 def ensure_pipedream_provider_trigger_catalog_seeded() -> None:
@@ -141,7 +158,7 @@ def _topology_unavailable_reason(assistant_id: int) -> str | None:
         headers={"Authorization": f"Bearer {orchestra_admin_key()}"},
         timeout=30,
     )
-    response.raise_for_status()
+    raise_for_status_with_detail(response)
     info = response.json().get("info") or {}
     if info.get("available"):
         return None
@@ -196,7 +213,7 @@ def ensure_provider_trigger_test_prerequisites() -> None:
         headers={"Authorization": f"Bearer {orchestra_admin_key()}"},
         timeout=30,
     )
-    catalog.raise_for_status()
+    raise_for_status_with_detail(catalog)
     bootstrap = catalog.json().get("bootstrap_states") or []
     seeded = [
         row
@@ -561,7 +578,7 @@ def fetch_orchestra_task_by_name_fragment(
         headers=headers,
         timeout=30,
     )
-    response.raise_for_status()
+    raise_for_status_with_detail(response)
     tasks = response.json()["info"]["tasks"]
     needle = name_fragment.lower()
     matches = [task for task in tasks if needle in str(task.get("name") or "").lower()]
@@ -598,7 +615,7 @@ def create_github_composio_connection(
         },
         timeout=30,
     )
-    start.raise_for_status()
+    raise_for_status_with_detail(start)
     connection = start.json()["connection"]
     connection_id = connection["connection_id"]
     complete = requests.post(
@@ -612,7 +629,7 @@ def create_github_composio_connection(
         },
         timeout=30,
     )
-    complete.raise_for_status()
+    raise_for_status_with_detail(complete)
     return complete.json()
 
 
@@ -636,7 +653,7 @@ def create_github_pipedream_connection(*, assistant_id: int) -> dict[str, Any]:
         },
         timeout=30,
     )
-    start.raise_for_status()
+    raise_for_status_with_detail(start)
     connection = start.json()["connection"]
     connection_id = connection["connection_id"]
     complete = requests.post(
@@ -650,5 +667,5 @@ def create_github_pipedream_connection(*, assistant_id: int) -> dict[str, Any]:
         },
         timeout=30,
     )
-    complete.raise_for_status()
+    raise_for_status_with_detail(complete)
     return complete.json()

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -71,6 +71,11 @@ class TestingSettings(ProductionSettings):
     UNIFY_TESTS_DELETE_PROJ_ON_EXIT: bool = False
     UNITY_CACHE_STATS: bool = False
     UNIFY_PRETEST_CONTEXT_CREATE: bool = False
+    # Per-request timeout (seconds) for the Orchestra metadata calls made in
+    # per-test setup/teardown (context delete/create). These calls normally
+    # complete in well under a second; the bound exists so a stalled network
+    # degrades to local-only context setup instead of hanging the session.
+    UNIFY_TEST_SETUP_HTTP_TIMEOUT: float = 10.0
     UNIFY_TEST_TAGS: str = ""  # Comma-separated list of tags for duration logging
     UNIFY_SKIP_SESSION_SETUP: bool = False  # Skip project/context creation (pre-done)
     UNITY_TEST_PROJECT_NAME: str = "UnityTests"

--- a/tests/task_scheduler/test_provider_event_captured_instance.py
+++ b/tests/task_scheduler/test_provider_event_captured_instance.py
@@ -37,9 +37,9 @@ def _seed_provider_event_definition(
     enabled: bool = True,
     provider_event_binding_id: str | None = "binding-1",
 ) -> int:
-    next_task_id = int(scheduler._store.get_metric_max(key="task_id") or 0) + 1
+    # task_id is auto-counted server-side; computing it client-side races
+    # against parallel test sessions sharing the Tasks context.
     payload = {
-        "task_id": next_task_id,
         "name": "GitHub issue triage",
         "description": "Triage new GitHub issues.",
         "trigger": _provider_event_trigger(),
@@ -50,8 +50,8 @@ def _seed_provider_event_definition(
     if provider_event_binding_id is not None:
         payload["provider_event_binding_id"] = provider_event_binding_id
     with scheduler._use_task_destination(None):
-        scheduler._store.log(entries=payload, new=True)
-    return next_task_id
+        log = scheduler._store.log(entries=payload, new=True)
+    return int(log.entries["task_id"])
 
 
 def _request(*, task_id: int, operation_id: str) -> ProviderEventDispatchRequest:

--- a/unify/actor/environments/base.py
+++ b/unify/actor/environments/base.py
@@ -58,12 +58,19 @@ def resolve_directly_callable(
 def build_filtered_method_docs(
     allowed_methods: frozenset[str],
     namespace: str = "primitives",
+    exposed_aliases: frozenset[str] | None = None,
 ) -> str:
     """Build method-level documentation for only the specified fully-qualified methods.
 
     Reusable across all environment types (state managers, computer, actor).
     Uses the ``ToolSurfaceRegistry`` to introspect method signatures and
     docstrings for each allowed method.
+
+    ``exposed_aliases`` names every manager reachable in the session, which can
+    exceed the aliases present in ``allowed_methods`` when per-method filtering
+    has only promoted part of the surface. A superseded manager keeps its
+    supersession framing whenever its replacement is reachable at all; when the
+    caller omits the set, the aliases in ``allowed_methods`` stand in for it.
     """
     from unify.function_manager.primitives.registry import get_registry
 
@@ -80,6 +87,9 @@ def build_filtered_method_docs(
     if not allowed_aliases:
         return ""
 
+    if exposed_aliases is None:
+        exposed_aliases = frozenset(allowed_aliases)
+
     lines = ["### Method Reference\n"]
     for alias in sorted(allowed_aliases):
         spec = registry.get_manager_spec(alias)
@@ -89,7 +99,8 @@ def build_filtered_method_docs(
 
         lines.append(f"\n#### `{namespace}.{alias}`")
         if spec:
-            lines.append(f"*{spec.domain}* — {spec.description}")
+            text = spec.prompt_text(exposed_aliases)
+            lines.append(f"*{text.domain}* — {text.description}")
 
         for method_name in sorted(allowed_aliases[alias]):
             sig_str = registry._format_method_signature(mgr_cls, method_name)

--- a/unify/actor/environments/state_managers.py
+++ b/unify/actor/environments/state_managers.py
@@ -251,7 +251,11 @@ the handle.
     def _build_filtered_method_docs(self) -> str:
         """Build method-level documentation for only the allowed methods."""
         assert self._allowed_methods is not None
-        return build_filtered_method_docs(self._allowed_methods, self.namespace)
+        return build_filtered_method_docs(
+            self._allowed_methods,
+            self.namespace,
+            exposed_aliases=self._primitive_scope.scoped_managers,
+        )
 
     async def capture_state(self) -> Dict[str, Any]:
         """State manager state is primarily evidenced via return values."""

--- a/unify/actor/simulated.py
+++ b/unify/actor/simulated.py
@@ -87,6 +87,9 @@ class SimulatedActorHandle(BaseActorHandle, SimulatedHandleMixin):
     - done() -> bool
     """
 
+    # Cadence of fabricated progress notifications while the action runs.
+    _PROGRESS_INTERVAL_S = 1.0
+
     # Per-run file sink for simulated LLM I/O logs (request/response)
     _SIM_ACT_LLM_IO_DIR: "str | None" = None
 
@@ -585,12 +588,26 @@ class SimulatedActorHandle(BaseActorHandle, SimulatedHandleMixin):
         return {}
 
     async def next_notification(self) -> dict:
-        # If notifications are disabled, block until the action completes
-        # Use polling instead of asyncio.to_thread() to allow clean cancellation
+        """Yield paced progress updates; block when there is nothing to say.
+
+        Callers (``actor_watch_notifications``) wrap this in
+        ``asyncio.wait_for`` and rely on ``TimeoutError`` as their loop exit,
+        matching the queue-get semantics of the real
+        ``SteerableToolLoopHandle``. A branch that returns without awaiting
+        can never be timed out — ``wait_for`` awaits the coroutine inline —
+        and back-to-back synchronous returns starve the event loop outright,
+        freezing every other task in the process.
+        """
         if not self._emit_notifications:
-            while not self._done_event.is_set():
-                await asyncio.sleep(0.1)
-            return {}
+            await asyncio.Event().wait()
+            return {}  # unreachable; satisfies return type
+
+        # Pace fabricated progress while work runs; once the action is done
+        # there is no further progress, so block until the watcher cancels
+        # us — that silence is what lets its drain timeout fire.
+        await asyncio.sleep(self._PROGRESS_INTERVAL_S)
+        if self._done_event.is_set():
+            await asyncio.Event().wait()
 
         # Report progress without consuming steps (observing isn't work)
         # Compose a small progress message consistent with the configured mode

--- a/unify/conversation_manager/domains/managers_utils.py
+++ b/unify/conversation_manager/domains/managers_utils.py
@@ -994,6 +994,18 @@ async def actor_watch_notifications(
                 break
             continue
 
+        # An empty payload means "nothing to report", never a real
+        # notification — treat it as end-of-stream once the handle is done.
+        # The explicit yield guards against a handle whose
+        # ``next_notification`` completes synchronously: ``wait_for`` awaits
+        # the coroutine inline, so without it this loop would never suspend
+        # and would starve the entire event loop.
+        if not notif:
+            if already_done:
+                break
+            await asyncio.sleep(0)
+            continue
+
         # Determine whether this is a turn-complete response or a progress
         # notification. The loop emits responses with {"type": "response", ...}.
         is_response = isinstance(notif, dict) and notif.get("type") == "response"

--- a/unify/function_manager/function_manager.py
+++ b/unify/function_manager/function_manager.py
@@ -7957,7 +7957,9 @@ if __name__ == "__main__":
         # Use the scoped primitive_scope from this FunctionManager
         for spec in self._registry.manager_specs(self._primitive_scope):
             manager_name = spec.manager_alias
-            description = spec.description
+            description = spec.prompt_text(
+                self._primitive_scope.scoped_managers,
+            ).description
 
             # Get primitive rows which contain signature and docstring
             single_scope = PrimitiveScope(scoped_managers=frozenset({manager_name}))

--- a/unify/function_manager/primitives/registry.py
+++ b/unify/function_manager/primitives/registry.py
@@ -32,6 +32,17 @@ logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True, slots=True)
+class PromptText:
+    """The overview fields rendered for one manager in the actor prompt."""
+
+    domain: str
+    description: str
+    use_when: str
+    examples: str
+    special_note: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
 class ManagerSpec:
     """
     Configuration for a single manager in the tool surface.
@@ -59,6 +70,30 @@ class ManagerSpec:
     use_when: str = ""
     examples: str = ""
     special_note: str | None = None
+    # A manager that replaces this one for new work. The primary prompt fields
+    # above may steer authoring toward that replacement, so they only render
+    # while the replacement is exposed in the same scope; when it is absent,
+    # ``standalone`` renders instead. A prompt must never route to a tool the
+    # session cannot call — an actor told "author over there" with no "there"
+    # in scope refuses work its visible tools fully support.
+    superseded_by: str | None = None
+    standalone: PromptText | None = None
+
+    def prompt_text(self, exposed_aliases: frozenset[str]) -> PromptText:
+        """The overview text to render given which managers are exposed."""
+        if (
+            self.superseded_by is not None
+            and self.superseded_by not in exposed_aliases
+            and self.standalone is not None
+        ):
+            return self.standalone
+        return PromptText(
+            domain=self.domain,
+            description=self.description,
+            use_when=self.use_when,
+            examples=self.examples,
+            special_note=self.special_note,
+        )
 
 
 # =============================================================================
@@ -258,6 +293,53 @@ _MANAGER_SPECS: tuple[ManagerSpec, ...] = (
             "side effects and ``result_mode='show_result'`` when Console "
             "should present the return value. Do not put Python side-effect "
             "click handlers in tile HTML -- Console owns action chrome."
+        ),
+        superseded_by="canvas",
+        standalone=PromptText(
+            domain="Visualizations & Dashboards",
+            description=(
+                "Create HTML visualization tiles (charts, plots, KPI cards, "
+                "tables) and compose them into dashboard grid layouts"
+            ),
+            use_when=(
+                "Generate any visualization, chart, plot, dashboard, KPI card, "
+                "or interactive HTML output for the user to view"
+            ),
+            examples=(
+                "'Plot repairs by category', 'Show me a bar chart of revenue', "
+                "'Create a dashboard with KPIs and charts', "
+                "'Generate an interactive table of orders'"
+            ),
+            special_note=(
+                "The actor has full creative freedom over tile HTML -- any "
+                "HTML/CSS/JS that renders in a browser works. PREFER live "
+                "tiles: declare data_bindings (FilterBinding, ReduceBinding, "
+                "JoinBinding, JoinReduceBinding) as the single source of truth "
+                "and provide an on_data JS callback that receives fetched data "
+                "keyed by alias. Console auto-generates bridge calls from the "
+                "serialized bindings -- the actor never writes bridge API "
+                "calls. Each binding is auto-validated via the corresponding "
+                "DataManager method before the tile is stored. Compose tiles "
+                "into dashboards with create_dashboard(). ``destination`` "
+                "chooses which dashboard pool stores the tile; ``data_scope`` "
+                "chooses the live-data root. Keep ``data_scope='dashboard'`` "
+                "when data should inherit that pool (including shared team "
+                "dashboards); set ``data_scope='team:<id>'`` only when a tile "
+                "must read a different team's data than where it lives. If the "
+                "user names a team board that is not listed yet under that "
+                "destination, create the dashboard and tile there rather than "
+                "asking for an existing token. Live data tiles are essential "
+                "for production: large datasets, joins, aggregation, and "
+                "frequently updated data. Only bake data into HTML for very "
+                "small static snapshots. For authenticated Console buttons "
+                "that run Python, declare ``actions=[TileAction(...)]`` on "
+                "create_tile/update_tile (author via ``implementation`` or "
+                "wire ``function_id``/``function_name``). Use "
+                "``result_mode='fire_and_forget'`` for side effects and "
+                "``result_mode='show_result'`` when Console should present "
+                "the return value. Do not put Python side-effect click "
+                "handlers in tile HTML -- Console owns action chrome."
+            ),
         ),
     ),
     ManagerSpec(
@@ -1322,16 +1404,19 @@ class ToolSurfaceRegistry:
             "Choose the right manager for your task:\n",
         )
 
+        exposed_aliases = primitive_scope.scoped_managers
+
         # ── Section 1: Brief manager overview (routing-focused) ──
         for spec in specs:
-            lines.append(f"\n**{spec.domain}** → `primitives.{spec.manager_alias}`")
-            lines.append(f"- {spec.description}")
-            if spec.use_when:
-                lines.append(f"- **Use when**: {spec.use_when}")
-            if spec.examples:
-                lines.append(f"- **Examples**: {spec.examples}")
-            if spec.special_note:
-                lines.append(f"- **Note**: {spec.special_note}")
+            text = spec.prompt_text(exposed_aliases)
+            lines.append(f"\n**{text.domain}** → `primitives.{spec.manager_alias}`")
+            lines.append(f"- {text.description}")
+            if text.use_when:
+                lines.append(f"- **Use when**: {text.use_when}")
+            if text.examples:
+                lines.append(f"- **Examples**: {text.examples}")
+            if text.special_note:
+                lines.append(f"- **Note**: {text.special_note}")
 
         # ── Section 2: Manager selection priorities ──
         if len(specs) > 1:
@@ -1359,7 +1444,6 @@ class ToolSurfaceRegistry:
             )
 
         # ── Section 3: Routing guidance for commonly confused pairs ──
-        exposed_aliases = primitive_scope.scoped_managers
         for guidance in _ROUTING_GUIDANCE:
             if guidance["managers"].issubset(exposed_aliases):
                 lines.append(f"\n**CRITICAL: {guidance['title']} Routing**:")

--- a/unify/llm_broker/__init__.py
+++ b/unify/llm_broker/__init__.py
@@ -1,0 +1,25 @@
+"""Pod-local LLM broker: the provider key's container, not the runtime's.
+
+Runs as a sidecar beside the assistant runtime. The provider credentials are
+mounted here and nowhere else in the pod, so the container that executes user
+code holds none. Containers in a pod share a network namespace but not a PID
+namespace, so in-process sandbox code can reach this broker over loopback and
+have it make a call, but cannot read the key it makes the call with -- it has
+no access to this process's environment or memory. That distinction is the
+whole point: the incident this exists to prevent was a raw key being lifted
+out of ``os.environ`` and spent off-platform, not calls being made on-platform.
+
+Bytes go pod -> loopback -> provider and never traverse Orchestra. Orchestra
+is consulted only for metadata: may this call proceed, and what did it cost.
+Proxying the bytes instead would hold one of Orchestra's request slots for the
+length of a generation, putting LLM volume in contention with billing, logs
+and search, and adding a network hop to every voice turn.
+
+What the broker does *not* do is decide what anything costs. It reports the
+provider's own usage object verbatim and lets Orchestra price it, so the side
+holding the ledger stays the side that sets prices.
+"""
+
+from unify.llm_broker.app import build_app
+
+__all__ = ["build_app"]

--- a/unify/llm_broker/__main__.py
+++ b/unify/llm_broker/__main__.py
@@ -1,0 +1,34 @@
+"""Entrypoint for ``python -m unify.llm_broker``.
+
+Started as the sidecar container's command. Runs in its own container so the
+provider credentials it reads are outside the runtime's process and namespace,
+which is what stops user code from reading them.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import uvicorn
+
+from unify.llm_broker.app import build_app
+from unify.llm_broker.settings import load_settings
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO)
+    settings = load_settings()
+    uvicorn.run(
+        build_app(settings),
+        host=settings.host,
+        port=settings.port,
+        log_level="warning",
+        # Every request carries a model and an assistant; an access log would
+        # restate that at volume without adding anything the ledger does not
+        # already record.
+        access_log=False,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/unify/llm_broker/app.py
+++ b/unify/llm_broker/app.py
@@ -1,0 +1,365 @@
+"""The broker's HTTP surface: authorise, stream to the provider, report usage.
+
+Two routes, shaped like the providers themselves rather than like a common
+abstraction, because the callers are provider SDKs: an OpenAI-compatible
+chat-completions route for OpenRouter traffic, and Anthropic's Messages API
+for native Claude traffic. Each forwards its caller's body essentially
+unchanged, so features we have never heard of keep working.
+
+Every request follows the same three steps: ask Orchestra whether the account
+may spend, stream the provider's bytes straight back to the caller, then
+report what the provider said it used. Only the first and last touch
+Orchestra, and neither waits on the model.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any, AsyncIterator, Optional
+
+import httpx
+from fastapi import APIRouter, FastAPI, Request
+from starlette.responses import JSONResponse, StreamingResponse
+
+from unify.llm_broker.settings import BrokerSettings, load_settings
+from unify.llm_broker.usage import (
+    USAGE_TAIL_LIMIT,
+    usage_from_body,
+    usage_from_stream_tail,
+)
+
+LOGGER = logging.getLogger(__name__)
+
+#: Generations run long; the connect timeout stays short so a provider that is
+#: down fails fast instead of holding the caller for the full read window.
+_PROVIDER_TIMEOUT = httpx.Timeout(600.0, connect=10.0)
+#: Metadata calls. A slow answer here delays a turn, so it is bounded tightly
+#: and treated as a refusal rather than waited on.
+_CONTROL_TIMEOUT = httpx.Timeout(5.0, connect=2.0)
+
+
+class _AuthorizationCache:
+    """Short-lived memory of positive verdicts, keyed by caller and model.
+
+    Only successes are remembered. A refusal is always re-asked, so an
+    account that has just been suspended or run dry is refused on its next
+    call rather than at the end of a cache window.
+    """
+
+    def __init__(self, ttl_s: float) -> None:
+        self._ttl_s = ttl_s
+        self._entries: dict[tuple[str, str], float] = {}
+
+    def is_fresh(self, key: str, model: str) -> bool:
+        if self._ttl_s <= 0:
+            return False
+        expires_at = self._entries.get((key, model))
+        return expires_at is not None and expires_at > time.monotonic()
+
+    def remember(self, key: str, model: str) -> None:
+        if self._ttl_s > 0:
+            self._entries[(key, model)] = time.monotonic() + self._ttl_s
+
+
+def _caller_key(request: Request) -> Optional[str]:
+    """The Unify API key the caller is spending as.
+
+    The broker never substitutes an identity of its own: whatever the caller
+    presents is what Orchestra meters, so a call made by sandbox code is
+    charged to the same assistant as one made by the runtime.
+    """
+    header = request.headers.get("authorization") or ""
+    if header.lower().startswith("bearer "):
+        return header[7:].strip() or None
+    return request.headers.get("x-api-key") or None
+
+
+def _refusal(status_code: int, detail: str) -> JSONResponse:
+    return JSONResponse(status_code=status_code, content={"detail": detail})
+
+
+class Broker:
+    """Holds the provider credentials and the clients that use them."""
+
+    def __init__(self, settings: BrokerSettings) -> None:
+        self.settings = settings
+        self._auth_cache = _AuthorizationCache(settings.auth_ttl_s)
+        self._provider = httpx.AsyncClient(timeout=_PROVIDER_TIMEOUT)
+        self._control = httpx.AsyncClient(timeout=_CONTROL_TIMEOUT)
+
+    async def aclose(self) -> None:
+        await self._provider.aclose()
+        await self._control.aclose()
+
+    async def authorize(
+        self,
+        *,
+        caller_key: str,
+        model: str,
+        assistant_id: Optional[int],
+    ) -> Optional[JSONResponse]:
+        """Return a refusal to send back, or ``None`` to proceed.
+
+        Fails closed. If Orchestra cannot be reached the call is refused
+        rather than allowed through unmetered -- an unreachable ledger is
+        exactly when an unchecked call is most likely to be the one that
+        should have been stopped.
+        """
+        if self._auth_cache.is_fresh(caller_key, model):
+            return None
+        if not self.settings.orchestra_url:
+            return _refusal(503, "LLM broker is not configured (no Orchestra URL).")
+
+        try:
+            response = await self._control.post(
+                self.settings.authorize_url,
+                headers={"Authorization": f"Bearer {caller_key}"},
+                json={"model": model, "assistant_id": assistant_id},
+            )
+        except httpx.RequestError as exc:
+            LOGGER.warning("LLM broker: authorize unreachable: %s", exc)
+            return _refusal(503, "Spending authorization is unavailable; try again.")
+
+        if response.status_code == 401:
+            return _refusal(401, "Invalid API key.")
+        if response.status_code >= 400:
+            LOGGER.warning(
+                "LLM broker: authorize failed (%s)",
+                response.status_code,
+            )
+            return _refusal(503, "Spending authorization failed; try again.")
+
+        verdict = response.json()
+        if not verdict.get("allowed"):
+            # 402 carries the meaning the caller needs: the account, not the
+            # request, is why this cannot run.
+            return _refusal(402, verdict.get("reason") or "Spending refused.")
+
+        self._auth_cache.remember(caller_key, model)
+        return None
+
+    async def settle(
+        self,
+        *,
+        caller_key: str,
+        model: str,
+        usage: Optional[dict],
+        assistant_id: Optional[int],
+    ) -> None:
+        """Report a completed call's usage.
+
+        Best-effort by necessity -- the provider has already served and
+        already billed us, so there is nothing to undo -- but never silent:
+        an unreported call is spend with no ledger row, which is the failure
+        this whole design exists to prevent, and it has to be visible in logs
+        to be noticed at all.
+        """
+        if usage is None:
+            LOGGER.warning("LLM broker: no usage to report (model=%s)", model)
+            return
+        try:
+            response = await self._control.post(
+                self.settings.settle_url,
+                headers={"Authorization": f"Bearer {caller_key}"},
+                json={
+                    "model": model,
+                    "usage": usage,
+                    "assistant_id": assistant_id,
+                },
+            )
+        except httpx.RequestError as exc:
+            LOGGER.error(
+                "LLM broker: usage NOT recorded (model=%s): %s",
+                model,
+                exc,
+            )
+            return
+        if response.status_code >= 400:
+            LOGGER.error(
+                "LLM broker: usage NOT recorded (model=%s): settle returned %s",
+                model,
+                response.status_code,
+            )
+
+    async def relay(
+        self,
+        *,
+        request: Request,
+        url: str,
+        headers: dict[str, str],
+        body: dict,
+        model: str,
+        assistant_id: Optional[int],
+        caller_key: str,
+        stream: bool,
+    ) -> Any:
+        """Send the call to the provider and report what it used."""
+        if not stream:
+            try:
+                response = await self._provider.post(url, headers=headers, json=body)
+            except httpx.RequestError as exc:
+                return _refusal(502, f"Upstream provider error: {exc}")
+
+            payload = response.json() if response.content else {}
+            if response.status_code < 400:
+                await self.settle(
+                    caller_key=caller_key,
+                    model=model,
+                    usage=usage_from_body(payload),
+                    assistant_id=assistant_id,
+                )
+            return JSONResponse(status_code=response.status_code, content=payload)
+
+        async def _stream() -> AsyncIterator[bytes]:
+            tail = ""
+            try:
+                async with self._provider.stream(
+                    "POST",
+                    url,
+                    headers=headers,
+                    json=body,
+                ) as upstream:
+                    if upstream.status_code >= 400:
+                        yield await upstream.aread()
+                        return
+                    async for chunk in upstream.aiter_bytes():
+                        # Forwarded before anything is parsed: the caller is
+                        # often a voice turn, and holding a chunk back to
+                        # inspect it would be latency spent on accounting.
+                        yield chunk
+                        tail = (tail + chunk.decode("utf-8", "ignore"))[
+                            -USAGE_TAIL_LIMIT:
+                        ]
+            except httpx.RequestError as exc:
+                LOGGER.warning("LLM broker: stream error: %s", exc)
+                return
+
+            await self.settle(
+                caller_key=caller_key,
+                model=model,
+                usage=usage_from_stream_tail(tail),
+                assistant_id=assistant_id,
+            )
+
+        return StreamingResponse(_stream(), media_type="text/event-stream")
+
+
+def build_router(broker: Broker) -> APIRouter:
+    router = APIRouter()
+    settings = broker.settings
+
+    @router.post("/llm/chat/completions")
+    async def chat_completions(request: Request) -> Any:
+        """OpenAI-compatible calls, forwarded to OpenRouter."""
+        caller_key = _caller_key(request)
+        if not caller_key:
+            return _refusal(401, "Missing API key.")
+        if not settings.openrouter_api_key:
+            return _refusal(503, "LLM broker holds no OpenRouter credential.")
+
+        body = await request.json()
+        model = str(body.get("model") or "").strip()
+        if not model:
+            return _refusal(400, "`model` is required.")
+        assistant_id = body.pop("assistant_id", None)
+
+        refusal = await broker.authorize(
+            caller_key=caller_key,
+            model=model,
+            assistant_id=assistant_id,
+        )
+        if refusal is not None:
+            return refusal
+
+        stream = bool(body.get("stream"))
+        # Ask for cost on the way out: it is what Orchestra prices the call
+        # from, and OpenRouter only reports it when a request opts in.
+        body["usage"] = {"include": True}
+        if stream:
+            options = dict(body.get("stream_options") or {})
+            options["include_usage"] = True
+            body["stream_options"] = options
+
+        return await broker.relay(
+            request=request,
+            url=f"{settings.openrouter_api_base.rstrip('/')}/chat/completions",
+            headers={
+                "Authorization": f"Bearer {settings.openrouter_api_key}",
+                "Content-Type": "application/json",
+            },
+            body=body,
+            model=model,
+            assistant_id=assistant_id,
+            caller_key=caller_key,
+            stream=stream,
+        )
+
+    @router.post("/llm/anthropic/v1/messages")
+    async def anthropic_messages(request: Request) -> Any:
+        """Anthropic's own Messages API, forwarded to Anthropic."""
+        caller_key = _caller_key(request)
+        if not caller_key:
+            return _refusal(401, "Missing API key.")
+        if not settings.anthropic_api_key:
+            return _refusal(503, "LLM broker holds no Anthropic credential.")
+
+        body = await request.json()
+        model = str(body.get("model") or "").strip()
+        if not model:
+            return _refusal(400, "`model` is required.")
+        assistant_id = body.pop("assistant_id", None)
+
+        refusal = await broker.authorize(
+            caller_key=caller_key,
+            model=model,
+            assistant_id=assistant_id,
+        )
+        if refusal is not None:
+            return refusal
+
+        stream = bool(body.get("stream"))
+        headers = {
+            "x-api-key": settings.anthropic_api_key,
+            "anthropic-version": request.headers.get(
+                "anthropic-version",
+                "2023-06-01",
+            ),
+            "content-type": "application/json",
+            "accept": "text/event-stream" if stream else "application/json",
+        }
+        beta = request.headers.get("anthropic-beta")
+        if beta:
+            headers["anthropic-beta"] = beta
+
+        return await broker.relay(
+            request=request,
+            url=f"{settings.anthropic_api_base.rstrip('/')}/v1/messages",
+            headers=headers,
+            body=body,
+            model=model,
+            assistant_id=assistant_id,
+            caller_key=caller_key,
+            stream=stream,
+        )
+
+    @router.get("/healthz")
+    async def healthz() -> dict:
+        """Readiness for the pod, not a report on which keys are present."""
+        return {"ok": True}
+
+    return router
+
+
+def build_app(settings: Optional[BrokerSettings] = None) -> FastAPI:
+    resolved = settings or load_settings()
+    broker = Broker(resolved)
+    app = FastAPI(title="Unify LLM broker", docs_url=None, redoc_url=None)
+    app.state.broker = broker
+    app.include_router(build_router(broker))
+
+    @app.on_event("shutdown")
+    async def _close() -> None:
+        await broker.aclose()
+
+    return app

--- a/unify/llm_broker/app.py
+++ b/unify/llm_broker/app.py
@@ -75,6 +75,29 @@ def _caller_key(request: Request) -> Optional[str]:
     return request.headers.get("x-api-key") or None
 
 
+def _assistant_id(request: Request, body: dict) -> Optional[int]:
+    """Which assistant to attribute this call to.
+
+    Read from a header the runtime sets, because the body is provider-shaped
+    and forwarded verbatim -- an id left in it would reach a provider that
+    rejects unknown fields. Without this the call still runs and is still
+    charged, but lands on the account with no assistant, which loses
+    per-assistant reporting and silently stops the per-assistant spending
+    caps from applying, since those are enforced against this id.
+
+    The body form is still accepted for direct callers that have no runtime
+    setting the header.
+    """
+    raw = request.headers.get("x-unify-assistant-id") or body.pop("assistant_id", None)
+    if raw is None:
+        return None
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        LOGGER.warning("LLM broker: unusable assistant id %r; not attributing", raw)
+        return None
+
+
 def _refusal(status_code: int, detail: str) -> JSONResponse:
     return JSONResponse(status_code=status_code, content={"detail": detail})
 
@@ -262,7 +285,7 @@ def build_router(broker: Broker) -> APIRouter:
         model = str(body.get("model") or "").strip()
         if not model:
             return _refusal(400, "`model` is required.")
-        assistant_id = body.pop("assistant_id", None)
+        assistant_id = _assistant_id(request, body)
 
         refusal = await broker.authorize(
             caller_key=caller_key,
@@ -308,7 +331,7 @@ def build_router(broker: Broker) -> APIRouter:
         model = str(body.get("model") or "").strip()
         if not model:
             return _refusal(400, "`model` is required.")
-        assistant_id = body.pop("assistant_id", None)
+        assistant_id = _assistant_id(request, body)
 
         refusal = await broker.authorize(
             caller_key=caller_key,

--- a/unify/llm_broker/settings.py
+++ b/unify/llm_broker/settings.py
@@ -1,0 +1,83 @@
+"""Configuration for the pod-local LLM broker.
+
+Read from the environment of the sidecar container, which is the only place
+in the pod the provider credentials are mounted.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+#: How long a positive authorisation may be reused for the same key and model.
+#:
+#: Zero means every call asks. A few seconds removes the round trip from the
+#: middle of a rapid exchange -- voice turns arrive faster than an account's
+#: standing changes -- at the cost of a window in which a newly-depleted
+#: account can still spend. The window is bounded by this value and by usage
+#: being reported after every call, so the overspend is one short burst rather
+#: than an open tab. Negative verdicts are never reused.
+_DEFAULT_AUTH_TTL_S = 5.0
+
+_DEFAULT_PORT = 8787
+
+
+@dataclass(frozen=True)
+class BrokerSettings:
+    """Resolved sidecar configuration."""
+
+    host: str
+    port: int
+    orchestra_url: str
+    openrouter_api_key: Optional[str]
+    openrouter_api_base: str
+    anthropic_api_key: Optional[str]
+    anthropic_api_base: str
+    auth_ttl_s: float
+
+    @property
+    def authorize_url(self) -> str:
+        return f"{self.orchestra_url.rstrip('/')}/llm/authorize"
+
+    @property
+    def settle_url(self) -> str:
+        return f"{self.orchestra_url.rstrip('/')}/llm/settle"
+
+
+def _float_env(name: str, default: float) -> float:
+    raw = (os.environ.get(name) or "").strip()
+    if not raw:
+        return default
+    try:
+        value = float(raw)
+    except ValueError:
+        return default
+    return value if value >= 0 else default
+
+
+def load_settings() -> BrokerSettings:
+    """Read broker configuration from the sidecar's environment.
+
+    Binds loopback by default. The pod's containers share a network
+    namespace, so loopback is reachable by the runtime beside it and by
+    nothing outside the pod -- the broker is not a service anyone else can
+    route to, and should not become one by having a bind address configured
+    to something wider.
+    """
+    return BrokerSettings(
+        host=os.environ.get("UNIFY_LLM_BROKER_HOST", "127.0.0.1"),
+        port=int(os.environ.get("UNIFY_LLM_BROKER_PORT", _DEFAULT_PORT)),
+        orchestra_url=os.environ.get("ORCHESTRA_URL", "").strip(),
+        openrouter_api_key=os.environ.get("OPENROUTER_API_KEY") or None,
+        openrouter_api_base=os.environ.get(
+            "OPENROUTER_API_BASE",
+            "https://openrouter.ai/api/v1",
+        ),
+        anthropic_api_key=os.environ.get("ANTHROPIC_API_KEY") or None,
+        anthropic_api_base=os.environ.get(
+            "ANTHROPIC_API_BASE",
+            "https://api.anthropic.com",
+        ),
+        auth_ttl_s=_float_env("UNIFY_LLM_BROKER_AUTH_TTL_S", _DEFAULT_AUTH_TTL_S),
+    )

--- a/unify/llm_broker/usage.py
+++ b/unify/llm_broker/usage.py
@@ -1,0 +1,74 @@
+"""Find a provider's usage object so it can be reported for pricing.
+
+Deliberately extraction only. What a call costs is decided by Orchestra,
+which holds the ledger and the catalogue; a broker that priced its own calls
+could declare any number, and Orchestra refusing to serve models it cannot
+price would stop meaning anything. So this locates the provider's own usage
+object and passes it on unaltered.
+
+The two providers report it differently. OpenAI-compatible responses carry a
+single ``usage`` object at the end. Anthropic splits it: ``message_start``
+carries the input tokens and the final ``message_delta`` the output count, so
+a stream has to merge what it finds rather than expect one event to hold both.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Optional
+
+#: Retained tail of a stream, bounded so a long generation is not buffered in
+#: memory to read a usage block that only ever appears at the end.
+USAGE_TAIL_LIMIT = 16_384
+
+
+def usage_from_body(body: Any) -> Optional[dict]:
+    """Pull the usage object out of a non-streamed response body."""
+    if not isinstance(body, dict):
+        return None
+    usage = body.get("usage")
+    return usage if isinstance(usage, dict) else None
+
+
+def _iter_sse_payloads(tail: str) -> list[dict]:
+    """Decode the JSON payloads of any complete ``data:`` lines in *tail*."""
+    payloads: list[dict] = []
+    for line in tail.splitlines():
+        line = line.strip()
+        if not line.startswith("data:"):
+            continue
+        data = line[len("data:") :].strip()
+        if not data or data == "[DONE]":
+            continue
+        try:
+            obj = json.loads(data)
+        except json.JSONDecodeError:
+            # A truncated first line is expected: the tail is a byte window,
+            # not a message boundary.
+            continue
+        if isinstance(obj, dict):
+            payloads.append(obj)
+    return payloads
+
+
+def usage_from_stream_tail(tail: str) -> Optional[dict]:
+    """Merge whatever usage the tail of a stream carries.
+
+    Merging rather than taking the last one seen is what makes this work for
+    Anthropic, whose input and output counts arrive in different events. For
+    an OpenAI-compatible stream there is only one usage object, so merging is
+    a no-op.
+    """
+    merged: dict[str, Any] = {}
+    for obj in _iter_sse_payloads(tail):
+        sources = (obj.get("usage"), (obj.get("message") or {}).get("usage"))
+        for source in sources:
+            if not isinstance(source, dict):
+                continue
+            for name, value in source.items():
+                # Scalars only: nested breakdowns (cost_details,
+                # prompt_tokens_details) are informational, and merging them
+                # key-by-key across events would interleave unrelated shapes.
+                if isinstance(value, (int, float)):
+                    merged[name] = value
+    return merged or None

--- a/unify/provider_proxy/session.py
+++ b/unify/provider_proxy/session.py
@@ -94,18 +94,35 @@ def provider_billing_env_keys() -> frozenset[str]:
     return _PROVIDER_BILLING_ENV_KEYS
 
 
+#: Billing credentials the runtime no longer needs in the environment, because
+#: UniLLM now sends them with each request from settings captured at import.
+#: Nothing resolves these from ``os.environ`` mid-call, so they can be withheld
+#: from user code without stranding inference that is already in flight.
+#:
+#: The rest of :data:`_PROVIDER_BILLING_ENV_KEYS` stays put: those SDKs still
+#: read the environment at call time, and removing them here would break a
+#: transcription or voice call that happened to overlap with user code. They
+#: remain stripped from subprocess sandboxes, where no such overlap exists.
+_IN_PROCESS_SCRUBBABLE_PROVIDER_KEYS: frozenset[str] = frozenset(
+    {
+        "ANTHROPIC_API_KEY",
+        "OPENROUTER_API_KEY",
+    },
+)
+
+
 @contextlib.contextmanager
 def scrub_platform_secrets_from_environ() -> Iterator[None]:
     """Temporarily remove platform secrets from ``os.environ``.
 
     Used to wrap in-process ``execute_code`` so user Python cannot read
-    ``os.environ["ORCHESTRA_ADMIN_KEY"]`` directly. Subprocess sandboxes get
-    the same guarantee for free via :func:`build_sandbox_env` (which never seeds
-    these keys into the child env). Values are restored on exit so the parent
-    process is unaffected.
+    ``os.environ["ORCHESTRA_ADMIN_KEY"]`` — or the LLM billing credentials —
+    directly. Subprocess sandboxes get the same guarantee for free via
+    :func:`build_sandbox_env` (which never seeds these keys into the child
+    env). Values are restored on exit so the parent process is unaffected.
     """
     saved: dict[str, str] = {}
-    for key in _PLATFORM_SECRET_ENV_KEYS:
+    for key in _PLATFORM_SECRET_ENV_KEYS | _IN_PROCESS_SCRUBBABLE_PROVIDER_KEYS:
         if key in os.environ:
             saved[key] = os.environ.pop(key)
     try:


### PR DESCRIPTION
**Must ship together with unillm #115.** This withholds the LLM billing
credentials from the process environment during user code, which is only safe
because unillm now sends them with each request. Both are cloned into the same
image at build time, so landing them on `main` together keeps them in step.

A pod holds one set of provider credentials for every assistant it runs, so a
copy read out of the environment is an uncapped spending instrument usable from
anywhere, with none of the resulting spend attributable to the caller.
Subprocess sandboxes have been denied them; the in-process code tool — the
default surface — could still read them.

They were left readable because the provider SDKs resolved them from
`os.environ` at call time, so removing them would have stranded inference
already in flight. That dependency is now gone for the LLM credentials.

Scoped to the two that travel with the request. Speech and telephony SDKs still
read the environment mid-call, so those stay in place in-process and remain
stripped from subprocess sandboxes, where nothing can overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)