### PR TITLE
Release: staging → main (broker-aware LLM provider validation)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1965,28 +1965,28 @@
         "filename": "tests/common/test_production_settings.py",
         "hashed_secret": "fd9a45bc0b07706d849cf85021ecf9123fa83d82",
         "is_verified": false,
-        "line_number": 43
+        "line_number": 44
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/common/test_production_settings.py",
         "hashed_secret": "e9a5f12a8ecbb3eb46eca5096b5c52aa5e7c9fdd",
         "is_verified": false,
-        "line_number": 53
+        "line_number": 55
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/common/test_production_settings.py",
         "hashed_secret": "6b8f36db289d14c3c7ba1bb21147b7a4fa7e7536",
         "is_verified": false,
-        "line_number": 68
+        "line_number": 70
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/common/test_production_settings.py",
         "hashed_secret": "ffc7b27c5ee452d6f8eb9d91972a62df55b48c3d",
         "is_verified": false,
-        "line_number": 87
+        "line_number": 89
       }
     ],
     "tests/conversation_manager/actions/integration/conftest.py": [
@@ -2371,5 +2371,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-12T09:40:08Z"
+  "generated_at": "2026-08-13T08:13:29Z"
 }

--- a/tests/common/test_production_settings.py
+++ b/tests/common/test_production_settings.py
@@ -20,8 +20,9 @@ class TestLLMProviderValidation:
         effort = ProductionSettings.model_fields["UNIFY_REASONING_EFFORT"]
         assert effort.default == "high"
 
-    def test_validation_fails_when_all_credentials_missing(self):
+    def test_validation_fails_when_all_credentials_missing(self, monkeypatch):
         """Validation raises RuntimeError when no credentials are set."""
+        monkeypatch.delenv("UNILLM_LLM_GATEWAY_URL", raising=False)
         settings = ProductionSettings(
             UNITY_VALIDATE_LLM_PROVIDERS=True,
             OPENAI_API_KEY="",
@@ -46,8 +47,9 @@ class TestLLMProviderValidation:
         )
         settings.validate_llm_providers()
 
-    def test_validation_rejects_openai_only_credentials(self):
+    def test_validation_rejects_openai_only_credentials(self, monkeypatch):
         """OpenAI chat models route via OpenRouter, so its key grants no access."""
+        monkeypatch.delenv("UNILLM_LLM_GATEWAY_URL", raising=False)
         settings = ProductionSettings(
             UNITY_VALIDATE_LLM_PROVIDERS=True,
             OPENAI_API_KEY="sk-test",
@@ -109,3 +111,44 @@ class TestLLMProviderValidation:
         # Verify the class-level default is True (env vars may override at runtime)
         field_info = ProductionSettings.model_fields["UNITY_VALIDATE_LLM_PROVIDERS"]
         assert field_info.default is True
+
+
+class TestBrokeredProviderValidation:
+    """Hosted pods hold no provider keys; the broker sidecar is the credential."""
+
+    @staticmethod
+    def _keyless_settings() -> ProductionSettings:
+        return ProductionSettings(
+            UNITY_VALIDATE_LLM_PROVIDERS=True,
+            OPENAI_API_KEY="",
+            ANTHROPIC_API_KEY="",
+            DEEPSEEK_API_KEY="",
+            OPENROUTER_API_KEY="",
+        )
+
+    def test_broker_sidecar_satisfies_validation(self, monkeypatch):
+        """A configured broker passes validation with zero provider keys."""
+        monkeypatch.setenv("UNILLM_LLM_GATEWAY_URL", "http://127.0.0.1:8787/llm")
+        monkeypatch.setenv("UNIFY_KEY", "unify-test-key")
+        self._keyless_settings().validate_llm_providers()
+
+    def test_broker_without_unify_key_fails(self, monkeypatch):
+        """The gateway URL alone is not enough: UNIFY_KEY is the sidecar nonce."""
+        monkeypatch.setenv("UNILLM_LLM_GATEWAY_URL", "http://127.0.0.1:8787/llm")
+        monkeypatch.delenv("UNIFY_KEY", raising=False)
+        with pytest.raises(RuntimeError):
+            self._keyless_settings().validate_llm_providers()
+
+    def test_malformed_gateway_url_fails(self, monkeypatch):
+        """A gateway value that is not a URL does not count as a broker."""
+        monkeypatch.setenv("UNILLM_LLM_GATEWAY_URL", "not-a-url")
+        monkeypatch.setenv("UNIFY_KEY", "unify-test-key")
+        with pytest.raises(RuntimeError):
+            self._keyless_settings().validate_llm_providers()
+
+    def test_error_message_mentions_broker(self, monkeypatch):
+        """The failure message tells operators about the broker alternative."""
+        monkeypatch.delenv("UNILLM_LLM_GATEWAY_URL", raising=False)
+        with pytest.raises(RuntimeError) as exc_info:
+            self._keyless_settings().validate_llm_providers()
+        assert "UNILLM_LLM_GATEWAY_URL" in str(exc_info.value)

--- a/unify/settings.py
+++ b/unify/settings.py
@@ -335,12 +335,20 @@ class ProductionSettings(BaseSettings):
         return "" if self.DEPLOY_ENV == "production" else f"-{self.DEPLOY_ENV}"
 
     def validate_llm_providers(self) -> None:
-        """Validate that at least one LLM provider credential is set.
+        """Validate that the runtime has some way to reach an LLM provider.
+
+        Either a raw provider credential in the environment, or a broker
+        sidecar (hosted pods hold no provider keys at all -- every LLM call
+        routes through the sidecar, authenticated by the pod's UNIFY_KEY).
 
         Raises:
-            RuntimeError: If no LLM provider credentials are set.
+            RuntimeError: If neither a credential nor a broker is available.
         """
         if not self.UNITY_VALIDATE_LLM_PROVIDERS:
+            return
+        from unify.common.broker import broker_origin
+
+        if broker_origin() is not None:
             return
         available = {
             "ANTHROPIC_API_KEY": self.ANTHROPIC_API_KEY,
@@ -351,7 +359,8 @@ class ProductionSettings(BaseSettings):
             raise RuntimeError(
                 "At least one LLM provider credential is required. "
                 "Set OPENROUTER_API_KEY, ANTHROPIC_API_KEY, "
-                "and/or DEEPSEEK_API_KEY.",
+                "and/or DEEPSEEK_API_KEY, or configure the broker "
+                "sidecar (UNILLM_LLM_GATEWAY_URL + UNIFY_KEY).",
             )
 
 


### PR DESCRIPTION
## Why

Prod twins have been coming up chat-only since the broker-sidecar key removal: hosted pods hold zero raw provider keys, but `validate_llm_providers()` still demanded one in the runtime env. `unify.init()` raised inside the ManagersWorker on every hosted twin, so the ConversationManager ran (its LLM calls route through the sidecar) while the managers/actor never started — the `Event: Error` loop seen on `unity-2026-08-13-06-03-27-u4b7f`.

## What

- `validate_llm_providers()` now passes when a broker sidecar is resolvable (`broker_origin()`: `UNILLM_LLM_GATEWAY_URL` + `UNIFY_KEY`). Deployments with neither a broker nor a key still fail closed.
- Tests: keyless-brokered pod passes; gateway URL without the `UNIFY_KEY` nonce fails; malformed gateway URL fails; error message names the broker alternative; existing no-credential tests made hermetic against a broker configured in the shell env.

## Verification

`tests/common/test_production_settings.py` + `tests/common/test_broker.py`: 17 passed locally.

Rollout note: reaches pods via the next brain-image rebuild + new assistant jobs.