### PR TITLE
Fix/pod lifecycle health gating

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -2116,7 +2116,7 @@
         "filename": "tests/conversation_manager/core/test_inactivity_lifecycle.py",
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_verified": false,
-        "line_number": 809
+        "line_number": 881
       }
     ],
     "tests/conversation_manager/core/test_initialization_race.py": [
@@ -2371,5 +2371,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-13T08:13:29Z"
+  "generated_at": "2026-08-13T11:22:14Z"
 }

--- a/tests/conversation_manager/core/test_inactivity_activity_source.py
+++ b/tests/conversation_manager/core/test_inactivity_activity_source.py
@@ -15,10 +15,12 @@ worth tracing.
 
 from unify.conversation_manager.events import (
     AssistantUpdateEvent,
+    Error,
     Event,
     GetBusEventsResponse,
     GetChatHistory,
     InitializationComplete,
+    IntegrationToolsSyncFailed,
     OpenSlowBrainTurn,
     Ping,
     StartupEvent,
@@ -31,6 +33,20 @@ def test_only_provably_internal_events_stop_counting_as_presence():
     # The pod telling itself it booted, and a reply to its own query.
     assert InitializationComplete.counts_as_activity is False
     assert GetBusEventsResponse.counts_as_activity is False
+
+
+def test_a_pod_cannot_hold_itself_open_by_failing():
+    """Failure output is the pod talking to itself, however loud.
+
+    Whatever these were a response to already counted when it arrived -- a
+    message, a due task, an assignment -- so discounting them drops nothing
+    a person did. Counting them let a pod with no managers stay alive on its
+    own noise: nine integration syncs failed at boot and were its last
+    recorded activity for forty-five minutes, and later a send it could not
+    complete was retried seven times and reset the clock each time.
+    """
+    assert Error.counts_as_activity is False
+    assert IntegrationToolsSyncFailed.counts_as_activity is False
 
 
 def test_a_person_doing_something_still_keeps_the_pod_alive():
@@ -62,6 +78,12 @@ def test_the_default_is_to_count():
     The safe direction is keeping a live pod alive: wrongly counting costs
     an idle pod some extra minutes, wrongly discounting drops a session
     somebody is in the middle of.
+
+    That asymmetry survives the pod that stayed up for three hours unable to
+    serve, because what was wrong there was not the tagging: a pod that
+    cannot serve now retires on `unserviceable_reason` whatever its clock
+    says. Inverting this default would trade a bounded cost for the one
+    failure this flag can actually cause.
     """
     assert Event.counts_as_activity is True
 

--- a/tests/conversation_manager/core/test_inactivity_lifecycle.py
+++ b/tests/conversation_manager/core/test_inactivity_lifecycle.py
@@ -1101,3 +1101,192 @@ class TestEdgeCases:
 
         # aclose should only be called once
         assert aclose_count == 1, f"aclose called {aclose_count} times, expected 1"
+
+
+# =============================================================================
+# Test: Control-plane drain
+# =============================================================================
+
+
+class TestDrainShutdown:
+    """A drain armed by the control plane must actually end the process."""
+
+    def _cm(self, event_broker, stop_event):
+        from unify.conversation_manager.conversation_manager import ConversationManager
+
+        cm = ConversationManager(
+            event_broker=event_broker,
+            job_name="test-job",
+            user_id="user_1",
+            assistant_id="assistant_1",
+            user_first_name="Test",
+            user_surname="User",
+            assistant_first_name="Test",
+            assistant_surname="Assistant",
+            assistant_age="25",
+            assistant_nationality="American",
+            assistant_about="Test bio",
+            assistant_number="+15555550000",
+            assistant_email="assistant@test.com",
+            user_number="+15555551111",
+            user_email="user@test.com",
+            stop=stop_event,
+        )
+        cm.inactivity_check_interval = 0.05
+        # Nowhere near the idle timeout: a drain must not have to wait for it.
+        cm.inactivity_timeout = 3600
+        cm.last_activity_time = cm.loop.time()
+        return cm
+
+    @pytest.mark.asyncio
+    async def test_armed_drain_shuts_down_while_the_pod_is_far_from_idle(
+        self,
+        event_broker,
+    ):
+        """The drain branch must end the process, not merely announce it.
+
+        It used to call ``await self.stop()`` -- ``stop`` is an Event, so that
+        raised TypeError into an ``except Exception`` guarding the probe. The
+        pod logged "shutting down for restart" every 30s for as long as it
+        lived and never shut down; drains only completed when the control
+        plane force-stopped the session at its deadline.
+        """
+        stop_event = asyncio.Event()
+        cm = self._cm(event_broker, stop_event)
+
+        with patch(
+            "unify.runtime.drain_gate.is_admission_blocked",
+            return_value=True,
+        ):
+            check_task = asyncio.create_task(cm.check_inactivity())
+            try:
+                await asyncio.wait_for(stop_event.wait(), timeout=2.0)
+            except asyncio.TimeoutError:
+                pytest.fail("Armed drain did not shut the conversation manager down")
+            finally:
+                check_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await check_task
+
+        assert cm.shutdown_reason == "drain_restart"
+
+    @pytest.mark.asyncio
+    async def test_a_failing_drain_probe_leaves_the_pod_running(self, event_broker):
+        """The probe is best-effort; a control-plane blip must not kill a pod.
+
+        This is the shield the shutdown call was wrongly sharing: it belongs
+        around the probe alone.
+        """
+        stop_event = asyncio.Event()
+        cm = self._cm(event_broker, stop_event)
+
+        with patch(
+            "unify.runtime.drain_gate.is_admission_blocked",
+            side_effect=RuntimeError("comms unreachable"),
+        ):
+            check_task = asyncio.create_task(cm.check_inactivity())
+            await asyncio.sleep(0.2)
+            check_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await check_task
+
+        assert not stop_event.is_set()
+        assert cm.shutdown_reason is None
+
+
+# =============================================================================
+# Test: Unserviceable pod retirement
+# =============================================================================
+
+
+class TestUnserviceableRetirement:
+    """A pod that cannot serve must not keep the assistant's session."""
+
+    @pytest.mark.asyncio
+    async def test_a_pod_that_cannot_serve_retires_without_waiting_to_be_idle(
+        self,
+        event_broker,
+    ):
+        """Being talked to is not evidence a pod can answer.
+
+        A failed manager init leaves no actor for the rest of the pod's life,
+        and every wake it then receives fails. Because presence heartbeats
+        count as activity, its idle clock never ran down: one such pod held a
+        live assistant for three hours, swallowing two scheduled runs and a
+        user message, while the fix sat in an image it could not reach.
+        """
+        from unify.conversation_manager.conversation_manager import ConversationManager
+
+        stop_event = asyncio.Event()
+        cm = ConversationManager(
+            event_broker=event_broker,
+            job_name="test-job",
+            user_id="user_1",
+            assistant_id="assistant_1",
+            user_first_name="Test",
+            user_surname="User",
+            assistant_first_name="Test",
+            assistant_surname="Assistant",
+            assistant_age="25",
+            assistant_nationality="American",
+            assistant_about="Test bio",
+            assistant_number="+15555550000",
+            assistant_email="assistant@test.com",
+            user_number="+15555551111",
+            user_email="user@test.com",
+            stop=stop_event,
+        )
+        cm.inactivity_check_interval = 0.05
+        cm.inactivity_timeout = 3600
+        # Freshly "active": the idle path would never fire here.
+        cm.last_activity_time = cm.loop.time()
+        cm.unserviceable_reason = "manager initialization failed: no LLM credential"
+
+        check_task = asyncio.create_task(cm.check_inactivity())
+        try:
+            await asyncio.wait_for(stop_event.wait(), timeout=2.0)
+        except asyncio.TimeoutError:
+            pytest.fail("Unserviceable pod did not retire")
+        finally:
+            check_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await check_task
+
+        assert cm.shutdown_reason == "unserviceable"
+
+    @pytest.mark.asyncio
+    async def test_a_serviceable_pod_is_left_alone(self, event_broker):
+        """The gate is the recorded reason, not merely being early in startup."""
+        from unify.conversation_manager.conversation_manager import ConversationManager
+
+        stop_event = asyncio.Event()
+        cm = ConversationManager(
+            event_broker=event_broker,
+            job_name="test-job",
+            user_id="user_1",
+            assistant_id="assistant_1",
+            user_first_name="Test",
+            user_surname="User",
+            assistant_first_name="Test",
+            assistant_surname="Assistant",
+            assistant_age="25",
+            assistant_nationality="American",
+            assistant_about="Test bio",
+            assistant_number="+15555550000",
+            assistant_email="assistant@test.com",
+            user_number="+15555551111",
+            user_email="user@test.com",
+            stop=stop_event,
+        )
+        cm.inactivity_check_interval = 0.05
+        cm.inactivity_timeout = 3600
+        cm.last_activity_time = cm.loop.time()
+
+        check_task = asyncio.create_task(cm.check_inactivity())
+        await asyncio.sleep(0.2)
+        check_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await check_task
+
+        assert not stop_event.is_set()
+        assert cm.shutdown_reason is None

--- a/tests/llm_broker/test_broker.py
+++ b/tests/llm_broker/test_broker.py
@@ -331,3 +331,61 @@ class TestAssistantAttribution:
 
     def test_no_id_anywhere_is_simply_unattributed(self):
         assert _assistant_id(self._request(), {}) is None
+
+
+class TestHealthz:
+    """What the pod is allowed to conclude from this endpoint.
+
+    The manifest probes it twice, for two decisions it cannot take back: the
+    runtime container does not start until it answers, and a container that
+    stops answering is restarted. Both are right for a frozen broker and
+    catastrophic for a healthy one, so the answer must depend on nothing but
+    this process.
+    """
+
+    def test_a_broker_with_no_provider_keys_is_still_serving(self):
+        """Credentials are not health. A keyless broker answers and says so.
+
+        Were this to report on keys, a secret that failed to mount would stop
+        the runtime from starting at all rather than failing the calls that
+        needed it.
+        """
+        keyless = BrokerSettings(
+            host="127.0.0.1",
+            port=0,
+            orchestra_url="https://orchestra.test/v0",
+            openrouter_api_key=None,
+            openrouter_api_base="https://openrouter.test/api/v1",
+            anthropic_api_key=None,
+            anthropic_api_base="https://anthropic.test",
+            auth_ttl_s=0.0,
+        )
+        with TestClient(build_app(keyless)) as client:
+            response = client.get("/healthz")
+
+        assert response.status_code == 200
+        assert response.json() == {"ok": True}
+
+    def test_it_answers_without_reaching_orchestra_or_a_provider(self, monkeypatch):
+        """An upstream outage must not read as this container being broken.
+
+        A provider check here would turn one OpenRouter incident into every
+        assistant pod restarting at once, and none of them starting again
+        until it cleared.
+        """
+        calls: list[str] = []
+
+        def _explode(*args, **kwargs):
+            calls.append("outbound")
+            raise AssertionError("healthz must not make an outbound call")
+
+        # Only the async client: both the provider and control-plane legs are
+        # AsyncClients, while TestClient is itself an httpx.Client -- patching
+        # that one breaks the harness rather than catching the broker.
+        monkeypatch.setattr(httpx.AsyncClient, "send", _explode)
+
+        with TestClient(build_app(_SETTINGS)) as client:
+            response = client.get("/healthz")
+
+        assert response.status_code == 200
+        assert calls == []

--- a/unify/conversation_manager/conversation_manager.py
+++ b/unify/conversation_manager/conversation_manager.py
@@ -407,6 +407,14 @@ class ConversationManager(metaclass=SingletonABCMeta):
         self.last_activity_time = self.loop.time()
         self._last_activity_source = "startup"
         self.shutdown_reason: str | None = None
+        # Set when the process has established it cannot serve this assistant
+        # at all -- currently only a failed manager init, which leaves no
+        # actor and no managers for the rest of the pod's life. Liveness is
+        # otherwise a question about traffic, and a pod being *talked to* says
+        # nothing about whether it can answer: one that could not held a live
+        # assistant for three hours, failing every scheduled task and every
+        # message, while Console presence kept resetting its idle clock.
+        self.unserviceable_reason: str | None = None
         self.stop = stop
 
         self.event_broker = event_broker
@@ -3078,22 +3086,46 @@ class ConversationManager(metaclass=SingletonABCMeta):
 
             # Control-plane drain: once in-flight work is gone, shut down so
             # the next wake loads a fresh client bundle.
+            #
+            # Only the probe is shielded. Wrapping the shutdown too is what
+            # let `await self.stop()` -- a TypeError, because `stop` is an
+            # Event and not a coroutine -- read as a transient probe failure
+            # for three weeks: the pod logged that it was shutting down every
+            # 30s and never did, and drains completed only when the control
+            # plane force-stopped the session at its deadline.
             if not has_active_work:
                 try:
                     from unify.runtime.drain_gate import is_admission_blocked
 
-                    if is_admission_blocked():
-                        LOGGER.info(
-                            "Drain in progress and ACTIVE_WORK empty; "
-                            "shutting down for restart",
-                        )
-                        await self.stop()
-                        return
+                    drain_armed = is_admission_blocked()
                 except Exception:  # noqa: BLE001 — never break inactivity loop
                     LOGGER.debug(
                         "drain gate probe in inactivity failed",
                         exc_info=True,
                     )
+                    drain_armed = False
+                if drain_armed:
+                    await self._request_shutdown(
+                        "drain_restart",
+                        "Drain in progress and ACTIVE_WORK empty; "
+                        "shutting down for restart",
+                    )
+                    break
+
+            # A pod that cannot serve retires regardless of how busy its
+            # inbox looks. Nothing here recovers in place: the replacement is
+            # scheduled fresh, which is also how it picks up the image that
+            # fixed whatever broke this one. Retrying in process could not
+            # have done that -- the credential check that started this ran
+            # against an image that had already been superseded.
+            if not has_active_work and self.unserviceable_reason:
+                await self._request_shutdown(
+                    "unserviceable",
+                    "Cannot serve this assistant "
+                    f"({self.unserviceable_reason}); retiring so a fresh pod "
+                    "takes over",
+                )
+                break
 
             # A pod with no assistant has nobody to be idle *from*: its only
             # traffic is the pre-startup keepalive, which is not presence.
@@ -3142,6 +3174,7 @@ class ConversationManager(metaclass=SingletonABCMeta):
 
             if effective_idle_seconds > self.inactivity_timeout or ghost_publish:
                 if ghost_publish:
+                    reason = "ghost_publish"
                     log_str = (
                         f"Ghost-publish shutdown: pubsub_idle={pubsub_idle:.0f}s "
                         f"but eventbus_idle stuck at {eventbus_idle:.1f}s "
@@ -3149,13 +3182,24 @@ class ConversationManager(metaclass=SingletonABCMeta):
                         f"(timeout={self.inactivity_timeout}s)"
                     )
                 else:
-                    self.shutdown_reason = "idle_timeout"
+                    reason = "idle_timeout"
                     log_str = f"Inactivity timeout reached ({self.inactivity_timeout}s), requesting shutdown"
-                LOGGER.info(f"{DEFAULT_ICON} {log_str}")
-                self._session_logger.info("session_end", log_str)
-                self.stop.set()
-                await self.event_broker.aclose()
+                await self._request_shutdown(reason, log_str)
                 break  # Exit the loop after triggering shutdown
+
+    async def _request_shutdown(self, reason: str, log_str: str) -> None:
+        """Signal the process to wind down, from any reason the loop recognises.
+
+        One sequence for every exit so a new one cannot half-implement it. The
+        drain branch used to open-code its own and got it wrong, which is why
+        this exists rather than three call sites that look similar.
+        """
+
+        self.shutdown_reason = reason
+        LOGGER.info(f"{DEFAULT_ICON} {log_str}")
+        self._session_logger.info("session_end", log_str)
+        self.stop.set()
+        await self.event_broker.aclose()
 
     def set_details(self, payload: dict):
         """Populate assistant/user/voice details into SESSION_DETAILS."""

--- a/unify/conversation_manager/domains/managers_utils.py
+++ b/unify/conversation_manager/domains/managers_utils.py
@@ -2903,4 +2903,10 @@ async def init_conv_manager(
                 "correctly. Please try again shortly.",
                 error_type="init_failed",
             )
+            # The raise below unwinds into a bare create_task that nobody
+            # awaits, so on its own it ends here and the pod carries on
+            # looking healthy with no actor and no managers. Recording it on
+            # the ConversationManager is what lets the inactivity loop retire
+            # the pod instead.
+            cm.unserviceable_reason = f"manager initialization failed: {e}"
             raise

--- a/unify/conversation_manager/events.py
+++ b/unify/conversation_manager/events.py
@@ -1626,6 +1626,13 @@ class Ping(Event):
 @dataclass
 class Error(Event):
     prominent: ClassVar[bool] = True
+    # The pod's own failure output. Whatever the error was a response to --
+    # a message, a due task -- already counted as presence when it arrived,
+    # so discounting this drops nothing; counting it lets a pod that can only
+    # fail hold itself open on the strength of failing. One did, retrying a
+    # send seven times and then listing its own error as the last thing that
+    # touched its idle clock.
+    counts_as_activity: ClassVar[bool] = False
 
     message: str
 
@@ -2382,6 +2389,11 @@ class IntegrationToolsSyncFailed(Event):
     """Unity failed to prepare active provider tools for an app."""
 
     topic: ClassVar[str | None] = "app:comms:integration_tools_sync_failed"
+    # Emitted by the pod's own sync coordinator, once per app, never by a
+    # person. A pod whose managers had not initialized failed all nine at
+    # boot and then reported this as its last activity for forty-five
+    # minutes.
+    counts_as_activity: ClassVar[bool] = False
 
     app_slug: str
     app_display_name: str | None = None

--- a/unify/llm_broker/app.py
+++ b/unify/llm_broker/app.py
@@ -381,7 +381,21 @@ def build_router(broker: Broker) -> APIRouter:
 
     @router.get("/healthz")
     async def healthz() -> dict:
-        """Readiness for the pod, not a report on which keys are present."""
+        """Whether this process is answering. Never whether anything else is.
+
+        The pod probes this to decide two things it cannot take back: the
+        runtime container does not start until this answers, and a container
+        that stops answering is restarted. Both are right for a broker that
+        has frozen, and both are catastrophic for a broker that is fine while
+        a provider is not -- an OpenRouter outage would become every assistant
+        pod restarting at once, and none of them starting.
+
+        So this reports on nothing but itself. Do not add a provider
+        reachability check, a credential check, or a call to Orchestra: the
+        answer must stay a constant that only an unresponsive event loop can
+        fail to return. What keys are present is likewise not its business --
+        a broker with none is still serving, and says so.
+        """
         return {"ok": True}
 
     return router


### PR DESCRIPTION
<!--
Thanks for contributing to Unify! Please fill out the sections below.
For trivial changes (typo fixes, comment-only edits) you can shorten this template — just keep the Summary.

PRs land on `staging`, not `main`. See CONTRIBUTING.md.
-->

## Summary

<!-- 1–3 sentences: what problem does this PR solve, and why is this the right approach? -->



## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes incorrect behavior)
- [ ] Feature (non-breaking change that adds functionality)
- [ ] Refactor (no behavior change)
- [ ] Breaking change (API or data-model change — Unify has zero-backward-compat policy, but please call it out)
- [ ] Test-only (no source changes)
- [ ] Docs / chore / CI

## Areas touched

<!-- Check all that apply. Helps reviewers route. -->

- [ ] Actor / CodeAct
- [ ] ConversationManager / slow brain
- [ ] A specific state manager (Contact / Knowledge / Task / Transcript / Guidance / Function / File / Image / Web / Secret / Blacklist / Data / Memory)
- [ ] Async tool loop (`unify/common/_async_tool/`)
- [ ] Event bus / observability
- [ ] Gateway / external comms
- [ ] Tests / test infra (`tests/`, `conftest.py`, `parallel_run.sh`)
- [ ] CI / build / packaging

## Test plan

<!--
How did you verify this? Paste the command(s) you ran and the result.

The default expectation is to run the relevant directory:
  tests/parallel_run.sh tests/<module>/

For infrastructure changes that are hard to reach via tests, a quick
verification script under tests/_verify_*.py is encouraged
(see .agents/rules/surgical-verification-before-tests.md).
-->

```
tests/parallel_run.sh tests/...
```

- [ ] All relevant tests pass locally
- [ ] If this is a bug fix, I added a regression test (or explained why one isn't feasible)

## Behavior / migration notes

<!--
- Did this change a public manager API, primitive, or event payload?
- Are there schema/context changes in Orchestra that need a migration?
- Any new env vars or config flags? (Update `.env.advanced.example`.)
- If yes to any of the above, describe upgrade steps.
-->

None.

## Checklist

- [ ] PR is targeted at `staging` (not `main`)
- [ ] Followed conventional commit style (`feat(scope):`, `fix(scope):`, `refactor(scope):`, `chore(scope):`, etc.)
- [ ] No `try/except` added defensively — only around specific, recoverable errors
- [ ] No "new" / "updated" / "TODO from chat" temporal comments (see `.agents/rules/no-temporal-comments.md`)
- [ ] No test-specific shortcuts in production code (see `.agents/rules/no-test-info-in-production-code.md`)
- [ ] Updated `AGENTS.md` / `ARCHITECTURE.md` if I changed architectural conventions
