### PR TITLE
fix(desktop): a ready VM settles its own entitlement in the session s…

### DIFF
--- a/tests/common/test_runtime_oauth.py
+++ b/tests/common/test_runtime_oauth.py
@@ -219,3 +219,116 @@ def test_refresh_token_oauth_token_names_are_sensitive_subset():
     # Expiry / granted-scope metadata is NOT sensitive and stays out of this set.
     assert "MICROSOFT_TOKEN_EXPIRES_AT" not in names
     assert "GOOGLE_GRANTED_SCOPES" not in names
+
+
+# ── Connected-provider reporting (actor prompt context) ──────────────────────
+
+
+class _IsolatedSecretManager:
+    """A SecretManager holding raw tokens the way production does.
+
+    ``_sync_assistant_secrets`` keeps access/refresh tokens in an in-memory
+    store and never mirrors them to the ``Secrets`` context, ``.env`` or
+    ``os.environ``, so sandboxed actor code cannot read them and bypass the
+    provider proxy. Only non-sensitive metadata (expiry, granted scopes) is
+    reachable through ``_get_secret_value``.
+    """
+
+    def __init__(self, oauth_tokens: dict[str, str], secrets: dict[str, str]) -> None:
+        self._oauth_tokens = oauth_tokens
+        self.secrets = secrets
+
+    def get_oauth_token(self, name: str) -> str | None:
+        return self._oauth_tokens.get(name)
+
+    def _get_secret_value(self, name: str) -> str | None:
+        return self.secrets.get(name)
+
+
+def test_connected_providers_sees_tokens_held_only_in_memory(monkeypatch):
+    # The production storage shape: the token is present and usable, but is
+    # deliberately absent from the secret store the legacy lookup consults.
+    sm = _IsolatedSecretManager(
+        oauth_tokens={"MICROSOFT_ACCESS_TOKEN": "real-ms-token"},
+        secrets={"MICROSOFT_GRANTED_SCOPES": "Files.Read.All"},
+    )
+    _install_secret_manager(monkeypatch, sm)
+
+    assert runtime_oauth.connected_oauth_providers() == ["microsoft"]
+
+
+def test_connected_providers_reports_each_provider_independently(monkeypatch):
+    sm = _IsolatedSecretManager(
+        oauth_tokens={
+            "GOOGLE_REFRESH_TOKEN": "real-google-refresh",
+            "MICROSOFT_ACCESS_TOKEN": "real-ms-token",
+        },
+        secrets={},
+    )
+    _install_secret_manager(monkeypatch, sm)
+
+    assert runtime_oauth.connected_oauth_providers() == ["google", "microsoft"]
+
+
+def test_a_refresh_token_alone_is_a_connection(monkeypatch):
+    # The proxy exchanges the refresh token for access, so a provider with only
+    # a refresh token stored is still connected.
+    sm = _IsolatedSecretManager(
+        oauth_tokens={"MICROSOFT_REFRESH_TOKEN": "real-ms-refresh"},
+        secrets={},
+    )
+    _install_secret_manager(monkeypatch, sm)
+
+    assert runtime_oauth.connected_oauth_providers() == ["microsoft"]
+
+
+def test_no_tokens_reports_nothing_connected(monkeypatch):
+    # Non-sensitive metadata lingering in the secret store must not read as a
+    # connection on its own -- only a token the proxy can exchange counts.
+    sm = _IsolatedSecretManager(
+        oauth_tokens={},
+        secrets={
+            "MICROSOFT_GRANTED_SCOPES": "Files.Read.All",
+            "MICROSOFT_TOKEN_EXPIRES_AT": _future_expiry(),
+        },
+    )
+    _install_secret_manager(monkeypatch, sm)
+
+    assert runtime_oauth.connected_oauth_providers() == []
+
+
+def test_the_actor_prompt_names_a_connected_provider(monkeypatch):
+    # The single consumer: an inverted check tells the actor the workspace is
+    # unavailable, and an actor forbidden from falling back then refuses
+    # without ever issuing a request.
+    sm = _IsolatedSecretManager(
+        oauth_tokens={"MICROSOFT_ACCESS_TOKEN": "real-ms-token"},
+        secrets={},
+    )
+    _install_secret_manager(monkeypatch, sm)
+    _install_fake_proxy(monkeypatch)
+
+    context = runtime_oauth.get_oauth_prompt_context()
+
+    assert "Currently connected workspace providers" in context
+    assert "`microsoft`" in context
+    assert "No workspace provider is currently connected" not in context
+
+
+def test_the_actor_prompt_still_reports_a_genuine_disconnection(monkeypatch):
+    sm = _IsolatedSecretManager(oauth_tokens={}, secrets={})
+    _install_secret_manager(monkeypatch, sm)
+    _install_fake_proxy(monkeypatch)
+
+    context = runtime_oauth.get_oauth_prompt_context()
+
+    assert "No workspace provider is currently connected" in context
+
+
+def test_a_legacy_secret_store_token_still_counts(monkeypatch):
+    # Self-host and test environments that still populate the secret store
+    # directly keep working: _read_access_token falls back to it.
+    sm = _FakeSecretManager({"GOOGLE_ACCESS_TOKEN": "legacy-google-token"})
+    _install_secret_manager(monkeypatch, sm)
+
+    assert runtime_oauth.connected_oauth_providers() == ["google"]

--- a/tests/conversation_manager/test_desktop_ready_entitlement.py
+++ b/tests/conversation_manager/test_desktop_ready_entitlement.py
@@ -67,6 +67,55 @@ class TestAReadyDesktopSettlesEntitlement:
         assert assistant.has_managed_desktop is True
 
 
+class TestASparseUpdateDoesNotRevokeALiveDesktop:
+    """An assistant update must not disable a desktop that is already running.
+
+    ``set_details`` repopulates the whole snapshot from an update payload that
+    is sparser than the snapshot, so any field ``populate`` accepts and the
+    event omits reverts to its default. ``AssistantUpdateEvent`` carries
+    ``desktop_mode`` and ``desktop_url`` but not ``managed_desktop_status``,
+    which made every rename, voice change, membership change and OAuth re-auth
+    a silent revocation -- and it landed the session back in the split-brain
+    state, because ``desktop_url`` survives the repopulate untouched.
+
+    Two sibling fields in the same function carry comments recording this exact
+    failure being fixed for them individually. This is the third instance and
+    the first with a test.
+    """
+
+    def _repopulate(self, payload: dict, current: str | None) -> str | None:
+        """The one expression in ``set_details`` that decides the outcome."""
+        return payload.get("managed_desktop_status", current)
+
+    def test_an_omitted_status_keeps_the_desktop_alive(self, assistant):
+        _apply()
+        assert assistant.has_managed_desktop is True
+
+        # A rename: the payload carries no desktop keys at all.
+        assistant.managed_desktop_status = self._repopulate(
+            {"assistant_first_name": "Renamed"},
+            assistant.managed_desktop_status,
+        )
+        assert assistant.has_managed_desktop is True
+
+    def test_an_explicit_status_still_wins(self, assistant):
+        # Revocation stays possible: an update that genuinely says the add-on
+        # is off must be honoured.
+        _apply()
+        assistant.managed_desktop_status = self._repopulate(
+            {"managed_desktop_status": "inactive"},
+            assistant.managed_desktop_status,
+        )
+        assert assistant.has_managed_desktop is False
+
+    def test_a_url_without_entitlement_reads_as_no_desktop(self, assistant):
+        # The split-brain shape itself: a URL alone must never imply a usable
+        # desktop, or the surfaces disagree again.
+        assistant.desktop_url = "https://vm.example/api"
+        assistant.managed_desktop_status = None
+        assert assistant.has_managed_desktop is False
+
+
 class TestAnInvalidModeIsNeverWrittenBack:
     def test_the_unset_sentinel_does_not_round_trip(self, assistant):
         # One caller passes ``vm_type=SESSION_DETAILS.assistant.desktop_mode or

--- a/tests/conversation_manager/test_desktop_ready_entitlement.py
+++ b/tests/conversation_manager/test_desktop_ready_entitlement.py
@@ -1,0 +1,82 @@
+"""A desktop that reports ready makes every surface that reaches it usable.
+
+``SESSION_DETAILS`` is a bootstrap-time snapshot of the assistant row, so a
+managed desktop enabled *after* the pod started leaves ``desktop_mode`` and
+``managed_desktop_status`` claiming the add-on is off. The ready handler used to
+set only ``desktop_url``, which split the two surfaces that reach the same VM:
+``ComputerPrimitives`` resolves its container from the URL alone and worked,
+while shell, python and file access consult ``has_managed_desktop`` and refused
+with "No managed desktop is assigned to this assistant" for the life of the pod.
+
+Observed live on staging: the desktop reported ready at 13:38:35 with a URL, and
+sixteen minutes later the assistant drove a browser on that VM, downloaded a
+file, and then could not read the directory it had just written to.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from unify.session_details import SESSION_DETAILS, AssistantDetails
+
+
+@pytest.fixture()
+def assistant() -> AssistantDetails:
+    """A pod that bootstrapped before the desktop add-on was switched on."""
+    original = SESSION_DETAILS.assistant
+    SESSION_DETAILS.assistant = AssistantDetails(
+        desktop_mode="none",
+        managed_desktop_status=None,
+    )
+    yield SESSION_DETAILS.assistant
+    SESSION_DETAILS.assistant = original
+
+
+def _apply(vm_type: str = "ubuntu", url: str = "https://vm.example/api") -> None:
+    """Run only the snapshot reconciliation the ready handler performs."""
+    if url:
+        SESSION_DETAILS.assistant.desktop_url = url
+    if vm_type in ("ubuntu", "windows"):
+        SESSION_DETAILS.assistant.desktop_mode = vm_type
+    SESSION_DETAILS.assistant.managed_desktop_status = "active"
+
+
+class TestAReadyDesktopSettlesEntitlement:
+    def test_a_stale_snapshot_would_have_refused(self, assistant):
+        # The starting state: the add-on was switched on after bootstrap, so the
+        # snapshot still says there is no desktop.
+        assistant.desktop_url = "https://vm.example/api"
+        assert assistant.has_managed_desktop is False
+
+    def test_the_ready_signal_makes_the_desktop_usable(self, assistant):
+        _apply()
+        assert assistant.has_managed_desktop is True
+        assert assistant.managed_desktop_entitled is True
+
+    def test_both_surfaces_now_agree(self, assistant):
+        # The browser only ever needed the URL; the exec surface needs
+        # entitlement. Disagreement between them is the whole defect.
+        _apply()
+        browser_can_reach = bool(assistant.desktop_url)
+        exec_can_reach = assistant.has_managed_desktop
+        assert browser_can_reach is exec_can_reach is True
+
+    def test_a_windows_desktop_is_recorded_as_windows(self, assistant):
+        _apply(vm_type="windows")
+        assert assistant.desktop_mode == "windows"
+        assert assistant.has_managed_desktop is True
+
+
+class TestAnInvalidModeIsNeverWrittenBack:
+    def test_the_unset_sentinel_does_not_round_trip(self, assistant):
+        # One caller passes ``vm_type=SESSION_DETAILS.assistant.desktop_mode or
+        # "ubuntu"``, and the unset value is the *string* "none" -- truthy, so
+        # it survives the ``or`` and would be written straight back as a mode.
+        _apply(vm_type="none")
+        assert assistant.desktop_mode == "none"
+        assert assistant.has_managed_desktop is False
+
+    def test_an_unrecognised_mode_leaves_the_existing_one(self, assistant):
+        assistant.desktop_mode = "ubuntu"
+        _apply(vm_type="macos")
+        assert assistant.desktop_mode == "ubuntu"

--- a/unify/common/runtime_oauth.py
+++ b/unify/common/runtime_oauth.py
@@ -326,13 +326,20 @@ def connected_oauth_providers() -> list[str]:
     secret store is the connection: it is what the proxy will exchange for
     real access. No network call is made, so this is safe to evaluate at
     prompt-build time.
+
+    The lookup must go through :func:`_read_access_token`, which consults the
+    in-memory OAuth store first. Raw tokens are deliberately withheld from the
+    ``Secrets`` context, ``.env`` and ``os.environ``, so a plain secret lookup
+    sees a correctly-stored token as absent and reports every provider
+    disconnected — inverting the check into one that passes only when the
+    sandbox-isolation invariant has been broken.
     """
     secret_manager = _get_secret_manager()
     connected: list[str] = []
     for name, metadata in sorted(_OAUTH_PROVIDER_METADATA.items()):
         token_names = [metadata.refresh_token_secret, metadata.access_token_secret]
         if any(
-            _get_secret_value(secret_manager, token_name)
+            _read_access_token(secret_manager, token_name)
             for token_name in token_names
             if token_name
         ):

--- a/unify/conversation_manager/conversation_manager.py
+++ b/unify/conversation_manager/conversation_manager.py
@@ -3263,7 +3263,18 @@ class ConversationManager(metaclass=SingletonABCMeta):
         )
         self.binding_id = payload.get("binding_id", "")
         self.desktop_mode = payload.get("desktop_mode", "none")
-        self.managed_desktop_status = payload.get("managed_desktop_status")
+        # Default to the current value, for the same reason as the Teams bot
+        # flag below: AssistantUpdateEvent does not carry this key at all, so
+        # reading it as absent-means-None turned every assistant update -- a
+        # rename, a voice change, a membership change, an OAuth re-auth -- into
+        # a silent revocation of the managed desktop. ``desktop_url`` survives
+        # the repopulate, so the result was a session claiming a desktop it was
+        # no longer entitled to use: the browser kept working off the URL while
+        # shell, python and file access refused.
+        self.managed_desktop_status = payload.get(
+            "managed_desktop_status",
+            getattr(self, "managed_desktop_status", None),
+        )
         self.user_desktops = payload.get("user_desktops") or []
         self.org_id: int | None = payload.get("org_id")
         self.org_name: str = payload.get("org_name", "")
@@ -3303,6 +3314,11 @@ class ConversationManager(metaclass=SingletonABCMeta):
             assistant_slack_bot_user_id=self.assistant_slack_bot_user_id,
             assistant_slack_team_id=self.assistant_slack_team_id,
             assistant_has_ms_teams_bot=self.assistant_has_ms_teams_bot,
+            # Passed explicitly from the live session: omitting it let
+            # ``populate`` apply its own default and clear a tenant id adopted
+            # at runtime, which is exactly the failure the bot flag beside it
+            # was already patched for.
+            assistant_ms_teams_tenant_id=SESSION_DETAILS.assistant.ms_teams_tenant_id,
             user_id=self.user_id,
             user_first_name=self.user_first_name,
             user_surname=self.user_surname,

--- a/unify/conversation_manager/domains/self_host_desktop.py
+++ b/unify/conversation_manager/domains/self_host_desktop.py
@@ -79,6 +79,23 @@ async def apply_managed_desktop_ready(
     if desktop_secret:
         SESSION_DETAILS.assistant.desktop_secret = desktop_secret
 
+    # The entitlement fields come from the assistant row read at bootstrap, so a
+    # desktop enabled after this pod started leaves them saying the add-on is
+    # off. The URL above would then be set while ``has_managed_desktop`` stayed
+    # false, and the two surfaces that reach this same VM would disagree: the
+    # browser resolves its container from the URL alone and works, while shell,
+    # python and file access consult entitlement and refuse with "no managed
+    # desktop is assigned" for the life of the pod. A VM that has just reported
+    # itself ready is the most current evidence available that the add-on is
+    # active, so it settles the question here rather than leaving a stale
+    # snapshot to contradict it.
+    # Only a real mode is written back: one caller derives ``vm_type`` from the
+    # same field it would overwrite, and the unset value is the string "none",
+    # which would round-trip an invalid mode straight back into the snapshot.
+    if vm_type in ("ubuntu", "windows"):
+        SESSION_DETAILS.assistant.desktop_mode = vm_type
+    SESSION_DETAILS.assistant.managed_desktop_status = "active"
+
     _t0 = time.perf_counter()
     await asyncio.to_thread(
         assistant_jobs.update_liveview_url,


### PR DESCRIPTION
…napshot

SESSION_DETAILS is a bootstrap-time copy of the assistant row, so enabling the managed desktop add-on while a pod is already running leaves desktop_mode and managed_desktop_status claiming it is off. The ready handler set desktop_url and nothing else, which split the two surfaces that reach the same machine: ComputerPrimitives resolves its container from the URL alone and worked, while shell, python and file access consult has_managed_desktop -- entitlement AND a URL -- and refused with "No managed desktop is assigned to this assistant" for the rest of that pod's life.

Observed live on staging. The desktop reported ready at 13:38:35 carrying its URL; sixteen minutes later the assistant drove a browser on that VM, downloaded a file to /Unity/Downloads, and could not then read the directory it had just written to. The pod had bootstrapped four minutes before the add-on was switched on, and nothing re-read the row afterwards.

A VM that has just reported itself ready is the most current evidence available that the add-on is active, so the handler now records that alongside the URL it already stored. Only a recognised mode is written back: one caller derives vm_type from the very field it would overwrite, and the unset value is the string "none" -- truthy, so it survives the `or` and would round-trip an invalid mode into the snapshot.

The general hazard is worth stating: any assistant setting a user can toggle mid-session goes stale in this snapshot, and desktop is simply the one that was caught. Integrations, file-access policy and other entitlements share the shape.

<!--
Thanks for contributing to Unify! Please fill out the sections below.
For trivial changes (typo fixes, comment-only edits) you can shorten this template — just keep the Summary.

PRs land on `staging`, not `main`. See CONTRIBUTING.md.
-->

## Summary

<!-- 1–3 sentences: what problem does this PR solve, and why is this the right approach? -->



## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes incorrect behavior)
- [ ] Feature (non-breaking change that adds functionality)
- [ ] Refactor (no behavior change)
- [ ] Breaking change (API or data-model change — Unify has zero-backward-compat policy, but please call it out)
- [ ] Test-only (no source changes)
- [ ] Docs / chore / CI

## Areas touched

<!-- Check all that apply. Helps reviewers route. -->

- [ ] Actor / CodeAct
- [ ] ConversationManager / slow brain
- [ ] A specific state manager (Contact / Knowledge / Task / Transcript / Guidance / Function / File / Image / Web / Secret / Blacklist / Data / Memory)
- [ ] Async tool loop (`unify/common/_async_tool/`)
- [ ] Event bus / observability
- [ ] Gateway / external comms
- [ ] Tests / test infra (`tests/`, `conftest.py`, `parallel_run.sh`)
- [ ] CI / build / packaging

## Test plan

<!--
How did you verify this? Paste the command(s) you ran and the result.

The default expectation is to run the relevant directory:
  tests/parallel_run.sh tests/<module>/

For infrastructure changes that are hard to reach via tests, a quick
verification script under tests/_verify_*.py is encouraged
(see .agents/rules/surgical-verification-before-tests.md).
-->

```
tests/parallel_run.sh tests/...
```

- [ ] All relevant tests pass locally
- [ ] If this is a bug fix, I added a regression test (or explained why one isn't feasible)

## Behavior / migration notes

<!--
- Did this change a public manager API, primitive, or event payload?
- Are there schema/context changes in Orchestra that need a migration?
- Any new env vars or config flags? (Update `.env.advanced.example`.)
- If yes to any of the above, describe upgrade steps.
-->

None.

## Checklist

- [ ] PR is targeted at `staging` (not `main`)
- [ ] Followed conventional commit style (`feat(scope):`, `fix(scope):`, `refactor(scope):`, `chore(scope):`, etc.)
- [ ] No `try/except` added defensively — only around specific, recoverable errors
- [ ] No "new" / "updated" / "TODO from chat" temporal comments (see `.agents/rules/no-temporal-comments.md`)
- [ ] No test-specific shortcuts in production code (see `.agents/rules/no-test-info-in-production-code.md`)
- [ ] Updated `AGENTS.md` / `ARCHITECTURE.md` if I changed architectural conventions
