### PR TITLE
Fix/task run ledger

### DIFF
--- a/tests/task_scheduler/test_active_task_guard.py
+++ b/tests/task_scheduler/test_active_task_guard.py
@@ -13,7 +13,15 @@ def _scheduler_with_task(
     destination: str | None = None,
 ) -> TaskScheduler:
     scheduler = TaskScheduler.__new__(TaskScheduler)
-    scheduler._get_task_or_raise = lambda tid: SimpleNamespace(destination=destination)
+    # Both the resolved task's destination and its trigger: the callers here
+    # reach a task through `_resolve_task_for_mutation`, which asks whether it
+    # carries a provider-event trigger before returning it. A stub with only
+    # `destination` raised AttributeError from inside the code under test, so
+    # every test in this file failed for a reason none of them were about.
+    scheduler._get_task_or_raise = lambda tid: SimpleNamespace(
+        destination=destination,
+        trigger=None,
+    )
     return scheduler
 
 
@@ -36,7 +44,17 @@ def _fake_find_running_execution(*, running_states):
         queried = states if states is not None else _DEFAULT_OPEN_STATES
         for state in queried:
             if state in running_states:
-                return SimpleNamespace(task_id=task_id, state=state.value)
+                # Enough of a real snapshot to reference the row: cancelling
+                # one now patches the execution it already found rather than
+                # looking it up again, which is what the lookup it replaced
+                # could not do without a source_task_log_id it never had.
+                return SimpleNamespace(
+                    task_id=task_id,
+                    state=state.value,
+                    run_key=f"live:scheduled:42:{task_id}:rev:once",
+                    assistant_id="42",
+                    source_task_log_id=555,
+                )
         return None
 
     return _fake
@@ -91,17 +109,16 @@ def test_cancel_open_executions_still_cancels_non_running_open_states(
         "update_task_run_record",
         lambda reference, updates: update_calls.append(updates),
     )
-    monkeypatch.setattr(
-        task_scheduler_module,
-        "latest_task_run_reference_for_source",
-        lambda **kwargs: "run-ref",
-    )
     scheduler = _scheduler_with_task()
 
     scheduler._cancel_open_executions(0)
 
     assert len(update_calls) == 1
     assert update_calls[0]["state"] == ExecutionState.cancelled.value
+    # `completed_at`, not `ended_at`. Nothing reads `ended_at`, so a cancelled
+    # run showed no finish time anywhere it was displayed.
+    assert update_calls[0]["completed_at"]
+    assert "ended_at" not in update_calls[0]
 
 
 def _reconcile_one_update(scheduler) -> list[int]:

--- a/unify/actor/prompt_builders.py
+++ b/unify/actor/prompt_builders.py
@@ -188,6 +188,14 @@ _WORKFLOW_SHELF = textwrap.dedent("""
     the workflow's recorded installation settings, already resolved. The
     settings tool exists for reading and discussing configuration with the
     user, not for runs to fetch their own.
+
+    **"Is it working?" is a question about runs.** A workflow reports what
+    it planted and whether its jobs are armed; neither says whether the work
+    is happening. For "has my briefing been running", "did it go out this
+    morning", "why did I not get one" — take the `task_id` from the
+    installation's `jobs` and ask `primitives.tasks` about that task's runs.
+    An armed job whose occurrences are all failing looks identical to a
+    healthy one from the installation record alone.
 """)
 
 

--- a/unify/actor/prompt_builders.py
+++ b/unify/actor/prompt_builders.py
@@ -189,13 +189,10 @@ _WORKFLOW_SHELF = textwrap.dedent("""
     settings tool exists for reading and discussing configuration with the
     user, not for runs to fetch their own.
 
-    **"Is it working?" is a question about runs.** A workflow reports what
-    it planted and whether its jobs are armed; neither says whether the work
-    is happening. For "has my briefing been running", "did it go out this
-    morning", "why did I not get one" — take the `task_id` from the
-    installation's `jobs` and ask `primitives.tasks` about that task's runs.
-    An armed job whose occurrences are all failing looks identical to a
-    healthy one from the installation record alone.
+    **"Is it working?" is a question about runs.** `jobs` reports arming,
+    never whether the work happened — an armed job whose every occurrence
+    fails looks identical to a healthy one here. Take its `task_id` and ask
+    `primitives.tasks` about that task's runs.
 """)
 
 

--- a/unify/actor/prompt_examples.py
+++ b/unify/actor/prompt_examples.py
@@ -975,11 +975,45 @@ async def execute_task_by_description_with_guidance(description: str) -> str:
 '''
 
 
+def get_primitives_task_run_history_example() -> str:
+    """Example: answering whether a task actually ran, and finding its run_key."""
+
+    return '''
+# Example: "Did my daily briefing run this morning? Is it still working?"
+async def check_task_is_running_as_intended(task_name: str) -> str:
+    """Answer from the runs, never from the schedule.
+
+    A task row says when it is *meant* to run and whether it is armed. It
+    cannot say whether it ran, and a task can be perfectly armed while every
+    occurrence is being lost. Reading the cadence back to the user as if it
+    were an answer is exactly the mistake this avoids.
+    """
+    handle = await primitives.tasks.ask(
+        f"For the task named '{task_name}': list its recent runs, and say "
+        "whether it ran today, what the last run produced, whether any run "
+        "failed and why, and when the next run is due."
+    )
+    return await handle.result()
+
+
+# The run_key the next example needs comes from that same history: each run
+# carries one, and it is the only way to reach a run's internals.
+async def diagnose_last_failure(task_name: str) -> str:
+    handle = await primitives.tasks.ask(
+        f"For the task named '{task_name}': return the run_key and error of "
+        "its most recent failed run, or say that none failed."
+    )
+    return await handle.result()
+'''
+
+
 def get_primitives_task_run_event_children_example() -> str:
     """Example: depth-1 EventBus walk for a failed Tasks/Executions run."""
 
     return '''
 # Example: Diagnose a failed task execution via depth-1 EventBus walk
+# `run_key` comes from the task's run history -- see the run-history example;
+# there is no other way to obtain one.
 async def diagnose_failed_execution(run_key: str) -> str:
     """Walk EventBus children one level at a time; expand only failing nodes."""
     notify({"type": "progress", "message": f"Inspecting EventBus children for {run_key}."})
@@ -1943,6 +1977,7 @@ def get_example_function_map() -> dict[str, callable]:
         "get_primitives_contact_update_example": get_primitives_contact_update_example,
         # Tasks
         "get_primitives_task_execute_example": get_primitives_task_execute_example,
+        "get_primitives_task_run_history_example": get_primitives_task_run_history_example,
         "get_primitives_task_run_event_children_example": get_primitives_task_run_event_children_example,
         "get_primitives_task_recurring_creation_example": get_primitives_task_recurring_creation_example,
         # Knowledge (JSON tools — not primitives)

--- a/unify/actor/prompt_examples.py
+++ b/unify/actor/prompt_examples.py
@@ -975,45 +975,11 @@ async def execute_task_by_description_with_guidance(description: str) -> str:
 '''
 
 
-def get_primitives_task_run_history_example() -> str:
-    """Example: answering whether a task actually ran, and finding its run_key."""
-
-    return '''
-# Example: "Did my daily briefing run this morning? Is it still working?"
-async def check_task_is_running_as_intended(task_name: str) -> str:
-    """Answer from the runs, never from the schedule.
-
-    A task row says when it is *meant* to run and whether it is armed. It
-    cannot say whether it ran, and a task can be perfectly armed while every
-    occurrence is being lost. Reading the cadence back to the user as if it
-    were an answer is exactly the mistake this avoids.
-    """
-    handle = await primitives.tasks.ask(
-        f"For the task named '{task_name}': list its recent runs, and say "
-        "whether it ran today, what the last run produced, whether any run "
-        "failed and why, and when the next run is due."
-    )
-    return await handle.result()
-
-
-# The run_key the next example needs comes from that same history: each run
-# carries one, and it is the only way to reach a run's internals.
-async def diagnose_last_failure(task_name: str) -> str:
-    handle = await primitives.tasks.ask(
-        f"For the task named '{task_name}': return the run_key and error of "
-        "its most recent failed run, or say that none failed."
-    )
-    return await handle.result()
-'''
-
-
 def get_primitives_task_run_event_children_example() -> str:
     """Example: depth-1 EventBus walk for a failed Tasks/Executions run."""
 
     return '''
 # Example: Diagnose a failed task execution via depth-1 EventBus walk
-# `run_key` comes from the task's run history -- see the run-history example;
-# there is no other way to obtain one.
 async def diagnose_failed_execution(run_key: str) -> str:
     """Walk EventBus children one level at a time; expand only failing nodes."""
     notify({"type": "progress", "message": f"Inspecting EventBus children for {run_key}."})
@@ -1977,7 +1943,6 @@ def get_example_function_map() -> dict[str, callable]:
         "get_primitives_contact_update_example": get_primitives_contact_update_example,
         # Tasks
         "get_primitives_task_execute_example": get_primitives_task_execute_example,
-        "get_primitives_task_run_history_example": get_primitives_task_run_history_example,
         "get_primitives_task_run_event_children_example": get_primitives_task_run_event_children_example,
         "get_primitives_task_recurring_creation_example": get_primitives_task_recurring_creation_example,
         # Knowledge (JSON tools — not primitives)

--- a/unify/conversation_manager/domains/task_execution.py
+++ b/unify/conversation_manager/domains/task_execution.py
@@ -1,6 +1,7 @@
 """Task-execution wake-reason helpers for conversation-manager handlers."""
 
 import asyncio
+from datetime import datetime, timezone
 import hashlib
 from time import perf_counter
 import uuid
@@ -25,13 +26,15 @@ from unify.logger import LOGGER
 from unify.manager_registry import ManagerRegistry
 from unify.session_details import SESSION_DETAILS
 from unify.task_scheduler.types.activated_by import ActivatedBy
-from unify.task_scheduler.types.execution import Delivery, Wake
+from unify.task_scheduler.types.execution import Delivery, ExecutionState, Wake
 from unify.task_scheduler.machine_state import (
     TaskExecutionSnapshot,
     TaskRunProvenance,
+    TaskRunReference,
     get_open_task_execution,
     list_trigger_executions,
     remember_live_task_run_provenance,
+    update_task_run_record,
     validate_task_due_execution,
 )
 
@@ -91,6 +94,42 @@ class _ConversationTaskExecutionDelegate:
             persist=False,
             _reuse_actor_slot=entrypoint is not None,
         )
+
+
+def _record_task_start_failure(
+    *,
+    activation: TaskExecutionSnapshot | None,
+    assistant_id: str | None,
+    reason: str,
+) -> None:
+    """Terminalize an occurrence that fired and could not be started.
+
+    Failing to start used to leave the ledger exactly as it was: the row
+    stayed ``scheduled`` with no error and no end, so nothing recorded that a
+    run had been lost. Worse than the missing audit line, projection reads the
+    earliest open occurrence as the definition's head, so the row that never
+    ran kept that seat and no later occurrence was ever minted -- a transient
+    failure to start ended the series for good.
+
+    Recorded here rather than left to the supervisor sweep because this is the
+    one place that knows *why*. The sweep expires the same row half an hour
+    later with a generic reason; this writes the actual one, immediately.
+    """
+
+    if activation is None or not activation.run_key:
+        return
+    update_task_run_record(
+        TaskRunReference(
+            assistant_id=activation.assistant_id or (assistant_id or ""),
+            run_key=activation.run_key,
+            source_task_log_id=activation.source_task_log_id,
+        ),
+        {
+            "state": ExecutionState.failed.value,
+            "completed_at": datetime.now(timezone.utc).isoformat(),
+            "error": reason,
+        },
+    )
 
 
 async def _register_live_task_handle(
@@ -609,6 +648,11 @@ async def _handle_task_due_event(event: TaskDue, cm: "ConversationManager") -> b
             f"Scheduled task '{_task_due_label(event, activation)}' failed to start "
             f"through TaskScheduler.execute: {type(exc).__name__}: {exc}"
         )
+        _record_task_start_failure(
+            activation=activation,
+            assistant_id=assistant_id_for_run,
+            reason=error_message,
+        )
         cm._session_logger.error("task_due", error_message)
         cm.notifications_bar.push_notif("Tasks", error_message, event.timestamp)
         publish_system_error(
@@ -688,6 +732,11 @@ async def _handle_task_trigger_requested_event(
         error_message = (
             f"REST-triggered task '{_task_trigger_label(event)}' failed to start "
             f"through TaskScheduler.execute: {type(exc).__name__}: {exc}"
+        )
+        _record_task_start_failure(
+            activation=activation,
+            assistant_id=assistant_id,
+            reason=error_message,
         )
         cm._session_logger.error("task_trigger", error_message)
         cm.notifications_bar.push_notif("Tasks", error_message, event.timestamp)

--- a/unify/task_scheduler/base.py
+++ b/unify/task_scheduler/base.py
@@ -108,6 +108,14 @@ class BaseTaskScheduler(BaseStateManager, metaclass=SingletonABCMeta):
         deadlines and triggers, or summarise/compare existing entries. This
         call must never create, modify, or delete tasks.
 
+        It also answers what a task has actually *done*: whether it ran, when
+        it last ran, whether a run failed and why, what a run produced, and
+        when the next run is due. A task's own fields are authored intent and
+        cannot answer any of those, so ask for the outcome you want rather
+        than for the schedule you would have to reason from — "did the daily
+        briefing run this morning, and what did it produce?" rather than "what
+        time is the daily briefing set to run?".
+
         Clarifications
         --------------
         Do not use this method to ask the human questions. If the caller needs

--- a/unify/task_scheduler/machine_state.py
+++ b/unify/task_scheduler/machine_state.py
@@ -73,6 +73,14 @@ _EXECUTION_QUERY_FIELDS = [
     "revision",
     "requires_filesystem",
     "requires_computer",
+    # What a run actually did. Omitting these meant no read path in the
+    # runtime could see whether an execution had started, when it finished or
+    # why it failed -- so nothing here could answer "did the briefing run this
+    # morning?" even though the ledger had recorded the answer.
+    "started_at",
+    "completed_at",
+    "result_summary",
+    "error",
 ]
 _DEFAULT_TRIGGER_PAGE_SIZE = 200
 _OPEN_EXECUTION_STATES = (
@@ -508,7 +516,14 @@ def update_task_run_record(
     run_reference: TaskRunReference | None,
     updates: Mapping[str, Any],
 ) -> None:
-    """Patch one previously materialized execution row back in Orchestra."""
+    """Patch one previously materialized execution row back in Orchestra.
+
+    The envelope drops its own empty fields, but ``updates`` is passed
+    through as given: a None in there is the caller saying "clear this".
+    Stripping it too meant a run that succeeded after a failed attempt on the
+    same run_key could never clear the earlier ``error``, and the row read as
+    a completed run that had also failed.
+    """
 
     if run_reference is None:
         return
@@ -520,9 +535,9 @@ def update_task_run_record(
                 "assistant_id": run_reference.assistant_id,
                 "run_key": run_reference.run_key,
                 "source_task_log_id": run_reference.source_task_log_id,
-                "updates": _drop_none_values(dict(updates)),
             },
-        ),
+        )
+        | {"updates": dict(updates)},
     )
 
 
@@ -768,6 +783,73 @@ def find_running_execution_for_task(
     if not rows:
         return None
     return _row_to_execution(rows[0])
+
+
+#: The run facts worth handing a caller asking what happened, in the order a
+#: reader wants them. Deliberately not the whole row: trigger routing and
+#: dispatch offsets answer "how would this fire", not "what did it do".
+_RUN_HISTORY_FIELDS = (
+    "run_key",
+    "task_id",
+    "task_name",
+    "state",
+    "wake",
+    "delivery",
+    "scheduled_for",
+    "started_at",
+    "completed_at",
+    "result_summary",
+    "error",
+)
+
+
+def list_task_run_history(
+    *,
+    task_id: int,
+    destination: str | None = None,
+    limit: int = 20,
+) -> list[dict[str, Any]]:
+    """Return one task's occurrences, newest first, as plain run facts.
+
+    The ledger has always recorded when a task ran, what it produced and why
+    it failed, and nothing in the runtime could read it: the execution
+    helpers here each answer one dispatch question ("is one in flight?",
+    "has any finished?") and return a snapshot shaped for that decision. So
+    "did the briefing run this morning?" had no answer available to the
+    assistant, however plainly the rows said yes.
+
+    Dicts rather than ``TaskExecutionSnapshot`` because this is a different
+    question: the snapshot carries what dispatch needs to route a wake, and
+    none of what a reader wants to know about a run that already happened.
+
+    Includes the open occurrence when there is one, because "when does it run
+    next" is the same question asked forwards.
+    """
+
+    filter_clauses = [f"task_id == {int(task_id)}"]
+    normalized_destination = _canonical_destination_or_none(destination)
+    if normalized_destination is not None:
+        filter_clauses.append(f"destination == '{normalized_destination}'")
+    rows = _execution_store().get_rows(
+        filter=" and ".join(filter_clauses),
+        limit=max(int(limit), 1),
+        include_fields=_EXECUTION_QUERY_FIELDS,
+    )
+    history: list[dict[str, Any]] = []
+    for row in rows:
+        entries = getattr(row, "entries", row)
+        if not isinstance(entries, Mapping):
+            continue
+        history.append(
+            {key: entries.get(key) for key in _RUN_HISTORY_FIELDS if key in entries},
+        )
+    # Newest first by the moment the occurrence belongs to. An on-demand run
+    # has no scheduled_for, so it sorts by when it actually started.
+    history.sort(
+        key=lambda run: str(run.get("scheduled_for") or run.get("started_at") or ""),
+        reverse=True,
+    )
+    return history[: max(int(limit), 1)]
 
 
 def find_terminal_execution_for_task(

--- a/unify/task_scheduler/prompt_builders.py
+++ b/unify/task_scheduler/prompt_builders.py
@@ -175,6 +175,7 @@ def build_ask_prompt(
     filter_tasks_fname = tool_name(tools, "filter_tasks")
     search_tasks_fname = tool_name(tools, "search_tasks")
     reduce_fname = tool_name(tools, "reduce")
+    list_runs_fname = tool_name(tools, "list_task_runs")
     contact_ask_fname = tool_name(tools, "contactmanager")
     request_clar_fname = tool_name(tools, "request_clarification")
     catalog_fname = tool_name(tools, "list_provider_trigger_catalog")
@@ -215,6 +216,19 @@ def build_ask_prompt(
         f"For ANY other semantic question over free-form text (e.g., fuzzy name/description meaning), ALWAYS use `{search_tasks_fname}`. Never try to approximate meaning with brittle substring filters.",
         f"Use `{filter_tasks_fname}` for exact/boolean logic over structured fields (ids, arming flag, priority, timestamps, exact name) or for narrow, constrained text checks.",
         f"For questions about how to communicate with a specific person/role (tone, formality, how to address them, what wording to use), ALWAYS call `{contact_ask_fname}` to retrieve that contact's communication preferences/response policy. Do not guess.",
+        *(
+            [
+                "",
+                "- Setup vs. what actually happened (pick the right table) -",
+                f"A task row is authored intent: its schedule, whether it is armed, what it is for. `{filter_tasks_fname}` and `{search_tasks_fname}` read that and nothing else. No amount of filtering there can say whether a task ever ran.",
+                f"Anything about running — did it run today, when did it last run, did it fail and why, what did it produce, when is it due next — is `{list_runs_fname}(task_id=…)`, newest first.",
+                f"So: 'when is my briefing scheduled for?' is the task row; 'did my briefing run this morning?' is `{list_runs_fname}`. Answer the second from the runs, never by reading the schedule and reasoning about what should have happened.",
+                f"A task can be armed and still not have run. Reporting a cadence when asked about a run is the failure mode this pair exists to prevent — say what the runs show, including when they show nothing.",
+                f"To diagnose a failure past its `error`, take that run's `run_key` and walk it with the task-run event tools.",
+            ]
+            if list_runs_fname
+            else []
+        ),
         "",
         "- Semantic search across tasks (ranked by cosine distance) -",
         f"Find tasks about onboarding in Q3: `{search_tasks_fname}(references={{'name': 'onboarding', 'description': 'Q3'}}, k=5)`",

--- a/unify/task_scheduler/task_scheduler.py
+++ b/unify/task_scheduler/task_scheduler.py
@@ -82,7 +82,7 @@ from .machine_state import (
     consume_live_task_run_provenance,
     find_running_execution_for_task,
     find_terminal_execution_for_task,
-    latest_task_run_reference_for_source,
+    list_task_run_history,
     peek_live_task_run_provenance,
     remember_live_task_run_provenance,
     update_task_run_record,
@@ -254,6 +254,10 @@ class TaskScheduler(BaseTaskScheduler):
                 ToolSpec(fn=self._filter_tasks, display_label="Filtering tasks"),
                 ToolSpec(fn=self._search_tasks, display_label="Searching tasks"),
                 ToolSpec(fn=self._reduce, display_label="Summarising tasks"),
+                ToolSpec(
+                    fn=self._list_task_runs,
+                    display_label="Listing task runs",
+                ),
                 ToolSpec(
                     fn=self._list_provider_trigger_catalog,
                     display_label="Listing provider trigger catalog",
@@ -1614,14 +1618,23 @@ class TaskScheduler(BaseTaskScheduler):
         execution = self._running_execution(task_id)
         if execution is None:
             return
+        # The row this is cancelling is the one already in hand, so reference
+        # it directly. Looking it up again called
+        # latest_task_run_reference_for_source without its required
+        # source_task_log_id, which raised TypeError the moment anything
+        # reached here.
         update_task_run_record(
-            latest_task_run_reference_for_source(
-                assistant_id=SESSION_DETAILS.assistant_context,
-                task_id=int(task_id),
+            TaskRunReference(
+                assistant_id=execution.assistant_id
+                or str(SESSION_DETAILS.assistant_context),
+                run_key=execution.run_key,
+                source_task_log_id=execution.source_task_log_id,
             ),
             {
                 "state": ExecutionState.cancelled.value,
-                "ended_at": datetime.now(timezone.utc).isoformat(),
+                # completed_at, not ended_at: nothing reads ended_at, so
+                # cancelled runs showed no finish time anywhere.
+                "completed_at": datetime.now(timezone.utc).isoformat(),
             },
         )
 
@@ -3160,6 +3173,47 @@ class TaskScheduler(BaseTaskScheduler):
             unique_id_field="task_id",
         )
         return [Task(**self._sanitize_activation(dict(lg))) for lg in filled]
+
+    def _list_task_runs(
+        self,
+        *,
+        task_id: int,
+        limit: int = 20,
+    ) -> List[Dict[str, Any]]:
+        """Return one task's runs, newest first: when each ran and what happened.
+
+        Use this for any question about a task actually running, as opposed to
+        how it is set up: did it run today, when did it last run, did it fail,
+        what did it produce, when is it due next. The task row itself carries
+        only authored intent — its schedule and whether it is armed — and can
+        never answer these.
+
+        Each entry carries ``state`` (``scheduled`` for an occurrence still
+        ahead, then ``running`` and one of ``completed`` / ``failed`` /
+        ``cancelled``), ``scheduled_for`` (the moment it belongs to),
+        ``started_at`` / ``completed_at``, ``result_summary`` for what the run
+        produced, and ``error`` when it failed. A single ``scheduled`` entry
+        dated ahead is the next run; its absence means nothing is currently
+        armed for this task.
+
+        ``run_key`` identifies one run, and is what
+        ``get_run_event_children`` needs to walk that run's internals when a
+        failure needs diagnosing beyond its ``error``.
+
+        Parameters
+        ----------
+        task_id : int
+            The task whose runs to list.
+        limit : int, default ``20``
+            Maximum runs returned.
+        """
+
+        task = self._resolve_task_for_mutation(task_id)
+        return list_task_run_history(
+            task_id=int(task_id),
+            destination=task.destination,
+            limit=limit,
+        )
 
     def _filter_tasks(
         self,


### PR DESCRIPTION
<!--
Thanks for contributing to Unify! Please fill out the sections below.
For trivial changes (typo fixes, comment-only edits) you can shorten this template — just keep the Summary.

PRs land on `staging`, not `main`. See CONTRIBUTING.md.
-->

## Summary

<!-- 1–3 sentences: what problem does this PR solve, and why is this the right approach? -->



## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes incorrect behavior)
- [ ] Feature (non-breaking change that adds functionality)
- [ ] Refactor (no behavior change)
- [ ] Breaking change (API or data-model change — Unify has zero-backward-compat policy, but please call it out)
- [ ] Test-only (no source changes)
- [ ] Docs / chore / CI

## Areas touched

<!-- Check all that apply. Helps reviewers route. -->

- [ ] Actor / CodeAct
- [ ] ConversationManager / slow brain
- [ ] A specific state manager (Contact / Knowledge / Task / Transcript / Guidance / Function / File / Image / Web / Secret / Blacklist / Data / Memory)
- [ ] Async tool loop (`unify/common/_async_tool/`)
- [ ] Event bus / observability
- [ ] Gateway / external comms
- [ ] Tests / test infra (`tests/`, `conftest.py`, `parallel_run.sh`)
- [ ] CI / build / packaging

## Test plan

<!--
How did you verify this? Paste the command(s) you ran and the result.

The default expectation is to run the relevant directory:
  tests/parallel_run.sh tests/<module>/

For infrastructure changes that are hard to reach via tests, a quick
verification script under tests/_verify_*.py is encouraged
(see .agents/rules/surgical-verification-before-tests.md).
-->

```
tests/parallel_run.sh tests/...
```

- [ ] All relevant tests pass locally
- [ ] If this is a bug fix, I added a regression test (or explained why one isn't feasible)

## Behavior / migration notes

<!--
- Did this change a public manager API, primitive, or event payload?
- Are there schema/context changes in Orchestra that need a migration?
- Any new env vars or config flags? (Update `.env.advanced.example`.)
- If yes to any of the above, describe upgrade steps.
-->

None.

## Checklist

- [ ] PR is targeted at `staging` (not `main`)
- [ ] Followed conventional commit style (`feat(scope):`, `fix(scope):`, `refactor(scope):`, `chore(scope):`, etc.)
- [ ] No `try/except` added defensively — only around specific, recoverable errors
- [ ] No "new" / "updated" / "TODO from chat" temporal comments (see `.agents/rules/no-temporal-comments.md`)
- [ ] No test-specific shortcuts in production code (see `.agents/rules/no-test-info-in-production-code.md`)
- [ ] Updated `AGENTS.md` / `ARCHITECTURE.md` if I changed architectural conventions
