### PR TITLE
fix(oauth): a workspace token held in memory reads as connected

### DIFF
--- a/tests/common/test_runtime_oauth.py
+++ b/tests/common/test_runtime_oauth.py
@@ -219,3 +219,116 @@ def test_refresh_token_oauth_token_names_are_sensitive_subset():
     # Expiry / granted-scope metadata is NOT sensitive and stays out of this set.
     assert "MICROSOFT_TOKEN_EXPIRES_AT" not in names
     assert "GOOGLE_GRANTED_SCOPES" not in names
+
+
+# ── Connected-provider reporting (actor prompt context) ──────────────────────
+
+
+class _IsolatedSecretManager:
+    """A SecretManager holding raw tokens the way production does.
+
+    ``_sync_assistant_secrets`` keeps access/refresh tokens in an in-memory
+    store and never mirrors them to the ``Secrets`` context, ``.env`` or
+    ``os.environ``, so sandboxed actor code cannot read them and bypass the
+    provider proxy. Only non-sensitive metadata (expiry, granted scopes) is
+    reachable through ``_get_secret_value``.
+    """
+
+    def __init__(self, oauth_tokens: dict[str, str], secrets: dict[str, str]) -> None:
+        self._oauth_tokens = oauth_tokens
+        self.secrets = secrets
+
+    def get_oauth_token(self, name: str) -> str | None:
+        return self._oauth_tokens.get(name)
+
+    def _get_secret_value(self, name: str) -> str | None:
+        return self.secrets.get(name)
+
+
+def test_connected_providers_sees_tokens_held_only_in_memory(monkeypatch):
+    # The production storage shape: the token is present and usable, but is
+    # deliberately absent from the secret store the legacy lookup consults.
+    sm = _IsolatedSecretManager(
+        oauth_tokens={"MICROSOFT_ACCESS_TOKEN": "real-ms-token"},
+        secrets={"MICROSOFT_GRANTED_SCOPES": "Files.Read.All"},
+    )
+    _install_secret_manager(monkeypatch, sm)
+
+    assert runtime_oauth.connected_oauth_providers() == ["microsoft"]
+
+
+def test_connected_providers_reports_each_provider_independently(monkeypatch):
+    sm = _IsolatedSecretManager(
+        oauth_tokens={
+            "GOOGLE_REFRESH_TOKEN": "real-google-refresh",
+            "MICROSOFT_ACCESS_TOKEN": "real-ms-token",
+        },
+        secrets={},
+    )
+    _install_secret_manager(monkeypatch, sm)
+
+    assert runtime_oauth.connected_oauth_providers() == ["google", "microsoft"]
+
+
+def test_a_refresh_token_alone_is_a_connection(monkeypatch):
+    # The proxy exchanges the refresh token for access, so a provider with only
+    # a refresh token stored is still connected.
+    sm = _IsolatedSecretManager(
+        oauth_tokens={"MICROSOFT_REFRESH_TOKEN": "real-ms-refresh"},
+        secrets={},
+    )
+    _install_secret_manager(monkeypatch, sm)
+
+    assert runtime_oauth.connected_oauth_providers() == ["microsoft"]
+
+
+def test_no_tokens_reports_nothing_connected(monkeypatch):
+    # Non-sensitive metadata lingering in the secret store must not read as a
+    # connection on its own -- only a token the proxy can exchange counts.
+    sm = _IsolatedSecretManager(
+        oauth_tokens={},
+        secrets={
+            "MICROSOFT_GRANTED_SCOPES": "Files.Read.All",
+            "MICROSOFT_TOKEN_EXPIRES_AT": _future_expiry(),
+        },
+    )
+    _install_secret_manager(monkeypatch, sm)
+
+    assert runtime_oauth.connected_oauth_providers() == []
+
+
+def test_the_actor_prompt_names_a_connected_provider(monkeypatch):
+    # The single consumer: an inverted check tells the actor the workspace is
+    # unavailable, and an actor forbidden from falling back then refuses
+    # without ever issuing a request.
+    sm = _IsolatedSecretManager(
+        oauth_tokens={"MICROSOFT_ACCESS_TOKEN": "real-ms-token"},
+        secrets={},
+    )
+    _install_secret_manager(monkeypatch, sm)
+    _install_fake_proxy(monkeypatch)
+
+    context = runtime_oauth.get_oauth_prompt_context()
+
+    assert "Currently connected workspace providers" in context
+    assert "`microsoft`" in context
+    assert "No workspace provider is currently connected" not in context
+
+
+def test_the_actor_prompt_still_reports_a_genuine_disconnection(monkeypatch):
+    sm = _IsolatedSecretManager(oauth_tokens={}, secrets={})
+    _install_secret_manager(monkeypatch, sm)
+    _install_fake_proxy(monkeypatch)
+
+    context = runtime_oauth.get_oauth_prompt_context()
+
+    assert "No workspace provider is currently connected" in context
+
+
+def test_a_legacy_secret_store_token_still_counts(monkeypatch):
+    # Self-host and test environments that still populate the secret store
+    # directly keep working: _read_access_token falls back to it.
+    sm = _FakeSecretManager({"GOOGLE_ACCESS_TOKEN": "legacy-google-token"})
+    _install_secret_manager(monkeypatch, sm)
+
+    assert runtime_oauth.connected_oauth_providers() == ["google"]

--- a/unify/common/runtime_oauth.py
+++ b/unify/common/runtime_oauth.py
@@ -326,13 +326,20 @@ def connected_oauth_providers() -> list[str]:
     secret store is the connection: it is what the proxy will exchange for
     real access. No network call is made, so this is safe to evaluate at
     prompt-build time.
+
+    The lookup must go through :func:`_read_access_token`, which consults the
+    in-memory OAuth store first. Raw tokens are deliberately withheld from the
+    ``Secrets`` context, ``.env`` and ``os.environ``, so a plain secret lookup
+    sees a correctly-stored token as absent and reports every provider
+    disconnected — inverting the check into one that passes only when the
+    sandbox-isolation invariant has been broken.
     """
     secret_manager = _get_secret_manager()
     connected: list[str] = []
     for name, metadata in sorted(_OAUTH_PROVIDER_METADATA.items()):
         token_names = [metadata.refresh_token_secret, metadata.access_token_secret]
         if any(
-            _get_secret_value(secret_manager, token_name)
+            _read_access_token(secret_manager, token_name)
             for token_name in token_names
             if token_name
         ):


### PR DESCRIPTION
connected_oauth_providers resolved each provider's access and refresh token through _get_secret_value, which reads the Secrets context and os.environ. Those are precisely the two places the assistant-secret sync withholds raw tokens from, so that sandboxed actor code cannot read a bearer token and reach a provider outside the proxy's file-access allowlist. A correctly-stored token was therefore invisible to the check, and every provider reported disconnected; the check could only pass when a raw token had leaked into the secret store, inverting it into an assertion that the isolation invariant was broken.

_read_access_token already exists for this: it prefers the in-memory OAuth store and falls back to the secret lookup for self-host and test environments that still populate it.

The single consumer is the actor's OAuth prompt context, which is why this stayed latent -- the actor normally calls Graph regardless and the proxy resolves the real token correctly. It surfaces when the actor is told not to fall back: on staging it declined a Microsoft 365 request with "this session has no Microsoft Graph workspace capability exposed" and issued zero requests, while both Microsoft tokens sat in the store from a sync six minutes earlier.

The tests model the production storage shape -- token in the in-memory store, only expiry and granted scopes reachable through the secret lookup -- which the existing fake did not, and cover a legacy secret-store token still counting as a connection.

<!--
Thanks for contributing to Unify! Please fill out the sections below.
For trivial changes (typo fixes, comment-only edits) you can shorten this template — just keep the Summary.

PRs land on `staging`, not `main`. See CONTRIBUTING.md.
-->

## Summary

<!-- 1–3 sentences: what problem does this PR solve, and why is this the right approach? -->



## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes incorrect behavior)
- [ ] Feature (non-breaking change that adds functionality)
- [ ] Refactor (no behavior change)
- [ ] Breaking change (API or data-model change — Unify has zero-backward-compat policy, but please call it out)
- [ ] Test-only (no source changes)
- [ ] Docs / chore / CI

## Areas touched

<!-- Check all that apply. Helps reviewers route. -->

- [ ] Actor / CodeAct
- [ ] ConversationManager / slow brain
- [ ] A specific state manager (Contact / Knowledge / Task / Transcript / Guidance / Function / File / Image / Web / Secret / Blacklist / Data / Memory)
- [ ] Async tool loop (`unify/common/_async_tool/`)
- [ ] Event bus / observability
- [ ] Gateway / external comms
- [ ] Tests / test infra (`tests/`, `conftest.py`, `parallel_run.sh`)
- [ ] CI / build / packaging

## Test plan

<!--
How did you verify this? Paste the command(s) you ran and the result.

The default expectation is to run the relevant directory:
  tests/parallel_run.sh tests/<module>/

For infrastructure changes that are hard to reach via tests, a quick
verification script under tests/_verify_*.py is encouraged
(see .agents/rules/surgical-verification-before-tests.md).
-->

```
tests/parallel_run.sh tests/...
```

- [ ] All relevant tests pass locally
- [ ] If this is a bug fix, I added a regression test (or explained why one isn't feasible)

## Behavior / migration notes

<!--
- Did this change a public manager API, primitive, or event payload?
- Are there schema/context changes in Orchestra that need a migration?
- Any new env vars or config flags? (Update `.env.advanced.example`.)
- If yes to any of the above, describe upgrade steps.
-->

None.

## Checklist

- [ ] PR is targeted at `staging` (not `main`)
- [ ] Followed conventional commit style (`feat(scope):`, `fix(scope):`, `refactor(scope):`, `chore(scope):`, etc.)
- [ ] No `try/except` added defensively — only around specific, recoverable errors
- [ ] No "new" / "updated" / "TODO from chat" temporal comments (see `.agents/rules/no-temporal-comments.md`)
- [ ] No test-specific shortcuts in production code (see `.agents/rules/no-test-info-in-production-code.md`)
- [ ] Updated `AGENTS.md` / `ARCHITECTURE.md` if I changed architectural conventions
