### PR TITLE
Release: staging → main

### DIFF
--- a/.github/workflows/agent-service.yml
+++ b/.github/workflows/agent-service.yml
@@ -37,7 +37,6 @@ jobs:
         repository: unifyai/magnitude
         ref: main
         path: magnitude
-        token: ${{ secrets.CLONE_TOKEN }}
         fetch-depth: 1
 
     - uses: actions/setup-node@v4

--- a/.github/workflows/flow-smoke-release-gate.yml
+++ b/.github/workflows/flow-smoke-release-gate.yml
@@ -119,13 +119,26 @@ jobs:
           exit 1
         fi
 
+    # Mints an installation token that can read orchestra and nothing
+    # else, then revokes it when the job ends. 4606137 is the
+    # unifyai-ci-clone App, which holds Contents: Read only; an App id is
+    # not a secret.
+    - name: Mint a token that can read orchestra
+      id: clone-token
+      uses: actions/create-github-app-token@v3
+      with:
+        app-id: '4606137'
+        private-key: ${{ secrets.CI_CLONE_APP_PRIVATE_KEY }}
+        owner: ${{ github.repository_owner }}
+        repositories: orchestra
+
     - name: Clone orchestra repo for local deployment
       uses: actions/checkout@v4
       with:
         repository: unifyai/orchestra
         ref: ${{ github.ref_name == 'main' && 'main' || 'staging' }}
         path: orchestra
-        token: ${{ secrets.CLONE_TOKEN }}
+        token: ${{ steps.clone-token.outputs.token }}
         fetch-depth: 1
 
     - name: Clone unify repo
@@ -134,7 +147,6 @@ jobs:
         repository: unifyai/unisdk
         ref: ${{ github.ref_name == 'main' && 'main' || 'staging' }}
         path: unisdk
-        token: ${{ secrets.CLONE_TOKEN }}
         fetch-depth: 1
 
     - name: Clone unillm repo
@@ -143,7 +155,6 @@ jobs:
         repository: unifyai/unillm
         ref: ${{ github.ref_name == 'main' && 'main' || 'staging' }}
         path: unillm
-        token: ${{ secrets.CLONE_TOKEN }}
         fetch-depth: 1
 
     - name: Authenticate to Google Cloud

--- a/.github/workflows/flow-smoke.yml
+++ b/.github/workflows/flow-smoke.yml
@@ -240,13 +240,26 @@ jobs:
           exit 1
         fi
 
+    # Mints an installation token that can read orchestra and nothing
+    # else, then revokes it when the job ends. 4606137 is the
+    # unifyai-ci-clone App, which holds Contents: Read only; an App id is
+    # not a secret.
+    - name: Mint a token that can read orchestra
+      id: clone-token
+      uses: actions/create-github-app-token@v3
+      with:
+        app-id: '4606137'
+        private-key: ${{ secrets.CI_CLONE_APP_PRIVATE_KEY }}
+        owner: ${{ github.repository_owner }}
+        repositories: orchestra
+
     - name: Clone orchestra repo for local deployment
       uses: actions/checkout@v4
       with:
         repository: unifyai/orchestra
         ref: ${{ github.ref_name == 'main' && 'main' || 'staging' }}
         path: orchestra
-        token: ${{ secrets.CLONE_TOKEN }}
+        token: ${{ steps.clone-token.outputs.token }}
         fetch-depth: 1
 
     - name: Clone unify repo
@@ -255,7 +268,6 @@ jobs:
         repository: unifyai/unisdk
         ref: ${{ github.ref_name == 'main' && 'main' || 'staging' }}
         path: unisdk
-        token: ${{ secrets.CLONE_TOKEN }}
         fetch-depth: 1
 
     - name: Clone unillm repo
@@ -264,7 +276,6 @@ jobs:
         repository: unifyai/unillm
         ref: ${{ github.ref_name == 'main' && 'main' || 'staging' }}
         path: unillm
-        token: ${{ secrets.CLONE_TOKEN }}
         fetch-depth: 1
 
     - name: Authenticate to Google Cloud

--- a/.github/workflows/llm-cache-refresh.yml
+++ b/.github/workflows/llm-cache-refresh.yml
@@ -257,13 +257,26 @@ jobs:
         normalized=$(echo "$RAW_PATH" | tr '/ *' '___' | tr -cd '[:alnum:]_-' | cut -c1-80)
         echo "test_path_normalized=$normalized" >> "$GITHUB_OUTPUT"
 
+    # Mints an installation token that can read orchestra and nothing
+    # else, then revokes it when the job ends. 4606137 is the
+    # unifyai-ci-clone App, which holds Contents: Read only; an App id is
+    # not a secret.
+    - name: Mint a token that can read orchestra
+      id: clone-token
+      uses: actions/create-github-app-token@v3
+      with:
+        app-id: '4606137'
+        private-key: ${{ secrets.CI_CLONE_APP_PRIVATE_KEY }}
+        owner: ${{ github.repository_owner }}
+        repositories: orchestra
+
     - name: Clone orchestra repo for local deployment
       uses: actions/checkout@v4
       with:
         repository: unifyai/orchestra
         ref: ${{ github.ref_name == 'main' && 'main' || 'staging' }}
         path: orchestra
-        token: ${{ secrets.CLONE_TOKEN }}
+        token: ${{ steps.clone-token.outputs.token }}
         fetch-depth: 1
 
     - name: Clone unisdk repo
@@ -272,7 +285,6 @@ jobs:
         repository: unifyai/unisdk
         ref: ${{ github.ref_name == 'main' && 'main' || 'staging' }}
         path: unisdk
-        token: ${{ secrets.CLONE_TOKEN }}
         fetch-depth: 1
 
     - name: Clone unillm repo
@@ -281,7 +293,6 @@ jobs:
         repository: unifyai/unillm
         ref: ${{ github.ref_name == 'main' && 'main' || 'staging' }}
         path: unillm
-        token: ${{ secrets.CLONE_TOKEN }}
         fetch-depth: 1
 
     - name: Authenticate to Google Cloud

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -704,7 +704,6 @@ jobs:
         ref: ${{ github.ref_name == 'main' && 'main' || 'staging' }}
         path: unisdk
         submodules: false
-        token: ${{ secrets.CLONE_TOKEN }}
         fetch-depth: 1
 
     - name: Install unisdk client
@@ -803,13 +802,26 @@ jobs:
       with:
         fetch-depth: 1
 
+    # Mints an installation token that can read orchestra and nothing
+    # else, then revokes it when the job ends. 4606137 is the
+    # unifyai-ci-clone App, which holds Contents: Read only; an App id is
+    # not a secret.
+    - name: Mint a token that can read orchestra
+      id: clone-token
+      uses: actions/create-github-app-token@v3
+      with:
+        app-id: '4606137'
+        private-key: ${{ secrets.CI_CLONE_APP_PRIVATE_KEY }}
+        owner: ${{ github.repository_owner }}
+        repositories: orchestra
+
     - name: Clone orchestra repo for local deployment
       uses: actions/checkout@v4
       with:
         repository: unifyai/orchestra
         ref: ${{ needs.discover.outputs.orchestra_branch }}
         path: orchestra
-        token: ${{ secrets.CLONE_TOKEN }}
+        token: ${{ steps.clone-token.outputs.token }}
         fetch-depth: 1
 
     - name: Clone unify repo
@@ -818,7 +830,6 @@ jobs:
         repository: unifyai/unisdk
         ref: ${{ github.ref_name == 'main' && 'main' || 'staging' }}
         path: unisdk
-        token: ${{ secrets.CLONE_TOKEN }}
         fetch-depth: 1
 
     - name: Clone unillm repo
@@ -827,7 +838,6 @@ jobs:
         repository: unifyai/unillm
         ref: ${{ github.ref_name == 'main' && 'main' || 'staging' }}
         path: unillm
-        token: ${{ secrets.CLONE_TOKEN }}
         fetch-depth: 1
 
     - name: Authenticate to Google Cloud
@@ -1143,7 +1153,6 @@ jobs:
         repository: unifyai/magnitude
         ref: main
         path: magnitude
-        token: ${{ secrets.CLONE_TOKEN }}
         fetch-depth: 1
 
     - name: Install bun (agent-service tests, magnitude packageManager dep)
@@ -1541,7 +1550,6 @@ jobs:
         ref: ${{ github.ref_name == 'main' && 'main' || 'staging' }}
         path: unisdk
         submodules: false
-        token: ${{ secrets.CLONE_TOKEN }}
         fetch-depth: 1
 
     - name: Install unisdk client

--- a/.github/workflows/trigger-selfhost-images.yml
+++ b/.github/workflows/trigger-selfhost-images.yml
@@ -28,18 +28,28 @@ jobs:
   dispatch:
     runs-on: ubuntu-latest
     steps:
+    # A repository dispatch is a write on the target repository, so this uses
+    # unifyai-ci-dispatch (4606148) rather than the clone App: it is the one
+    # App that carries Contents: Write, and it is installed on unify-deploy
+    # alone, so that write cannot reach any other repository. An App id is not
+    # a secret. This step fails loudly when the key is absent, which is what
+    # the hand-rolled empty check here used to do.
+    - name: Mint a token that can dispatch to unify-deploy
+      id: dispatch-token
+      uses: actions/create-github-app-token@v3
+      with:
+        app-id: '4606148'
+        private-key: ${{ secrets.CI_DISPATCH_APP_PRIVATE_KEY }}
+        owner: ${{ github.repository_owner }}
+        repositories: unify-deploy
+
     - name: Trigger unifyai/unify-deploy Publish self-host images
       env:
-        GH_TOKEN: ${{ secrets.CLONE_TOKEN }}
+        GH_TOKEN: ${{ steps.dispatch-token.outputs.token }}
         UNITY_REF: ${{ github.ref_name }}
         UNITY_SHA: ${{ github.sha }}
       run: |
         set -euo pipefail
-        if [[ -z "${GH_TOKEN}" ]]; then
-          echo "::error::CLONE_TOKEN secret is not configured on unity."
-          echo "It must be a PAT that can dispatch workflows on unifyai/unify-deploy."
-          exit 1
-        fi
         gh api repos/unifyai/unify-deploy/dispatches \
           --method POST \
           --input - <<EOF

--- a/.github/workflows/uv-lockfile-check.yml
+++ b/.github/workflows/uv-lockfile-check.yml
@@ -76,7 +76,6 @@ jobs:
         # pushes targeting main must resolve against main siblings so the check
         # matches post-merge behavior on main.
         ref: ${{ (github.ref == 'refs/heads/main' || github.base_ref == 'main') && 'main' || 'staging' }}
-        token: ${{ secrets.CLONE_TOKEN || github.token }}
 
     - name: Checkout unillm (sibling editable dep)
       uses: actions/checkout@v6
@@ -84,7 +83,6 @@ jobs:
         repository: unifyai/unillm
         path: unillm
         ref: ${{ (github.ref == 'refs/heads/main' || github.base_ref == 'main') && 'main' || 'staging' }}
-        token: ${{ secrets.CLONE_TOKEN || github.token }}
 
     - name: Install uv
       # SHA-pinned per repo CodeQL policy (no unpinned 3rd-party actions)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1521,6 +1521,39 @@ token before the repo: GitHub answers 404 rather than 403 when a credential
 cannot see a private repository, so an expired, unauthorised, or
 wrong-account token looks exactly like a missing one.
 
+### `unify-dev-bot`'s credential already exists — find it before minting one
+
+The bot's PAT lives in **GCP Secret Manager as `DEVBOT_GITHUB_TOKEN`**: a
+classic PAT, `repo` scope, no expiry. Look there before hunting for the bot's
+*password*. On 2026-08-14 an engineer spent an afternoon on that hunt and
+minted a redundant second PAT while a working token sat in Secret Manager the
+whole time.
+
+**Read it from the right project.** The same secret name exists in three
+projects and one of them is dead:
+
+| Project | State |
+|---|---|
+| `saas-368716` | **Live — the authoritative copy** |
+| `unity-assistant-vms` | Live, byte-identical to the above |
+| `responsive-city-458413-a2` | **Dead — every version disabled** |
+
+Fetching the dead copy fails, and a script that does not check the exit status
+carries an empty string into `git clone` — which GitHub answers with
+`Repository not found`, the same 404-instead-of-403 as above. An empty secret
+and a missing repo are indistinguishable from the error alone. Confirm the
+project holds an enabled version before concluding a credential is broken:
+
+```bash
+gcloud secrets versions list DEVBOT_GITHUB_TOKEN --project=saas-368716
+```
+
+**Rotation needs a human at a browser.** GitHub exposes no API for minting a
+personal access token — it is web-UI only. Rotating any bot-owned PAT
+therefore requires the bot account's own password and 2FA, and no automation
+removes that step. It is a standing bottleneck; plan around it rather than
+discovering it mid-incident.
+
 ### When this applies
 
 - Any `staging` → `main` release PR the agent opens under the active author account

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1548,11 +1548,22 @@ project holds an enabled version before concluding a credential is broken:
 gcloud secrets versions list DEVBOT_GITHUB_TOKEN --project=saas-368716
 ```
 
-**Rotation needs a human at a browser.** GitHub exposes no API for minting a
-personal access token — it is web-UI only. Rotating any bot-owned PAT
-therefore requires the bot account's own password and 2FA, and no automation
-removes that step. It is a standing bottleneck; plan around it rather than
-discovering it mid-incident.
+**PATs are the old approach here — do not mint more.** GitHub exposes no API
+for creating a personal access token, so rotating one means signing into the
+web UI *as the account that owns it*. A token owned by a bot therefore needs
+the bot's password and 2FA; a token owned by a person makes that person the
+only one who can rotate it. Neither is acceptable, and sharing a login is not
+the way out of it — that is the practice being retired, not the fix.
+
+**A GitHub App is the direction.** An App has no login, no password and no
+2FA: it signs a JWT with a private key and exchanges it for an installation
+token that expires in an hour, scoped to chosen repositories and permissions.
+Rotation becomes a key swap that no one has to do at a browser, and a stolen
+token is worthless by the end of the hour.
+
+The self-hosted CI runner moves first, because its credential is a *personal*
+PAT expiring 2026-09-23; `CLONE_TOKEN`'s six consuming repos follow. Until
+then the tokens above are simply what exists — record them, and add none.
 
 ### When this applies
 


### PR DESCRIPTION
CI credential change plus shared agent-rules promotion.

- `trigger-selfhost-images.yml` mints a token from `unifyai-ci-dispatch` (installed on unify-deploy alone, Contents: Write) for the cross-repo `repository_dispatch`, and the clone paths mint from `unifyai-ci-clone` (Contents: Read). Replaces the shared `CLONE_TOKEN` PAT.
- `.agents/global-rules` pointer bump and regenerated `AGENTS.md`

Verified: the `dispatch` job was red at 18:25 UTC with `403 Resource not accessible by integration` because the App installation was still being provisioned (installation updated 18:44 UTC). Re-run after provisioning completed: green, and the dispatch reached unify-deploy.

The downstream `ghcr-selfhost` publish it triggers still fails, for an unrelated and already-understood reason: `repository_dispatch` runs the workflow from the **default branch**, and main's `ghcr-selfhost.yml` predates today's deploy-key and extraheader fixes (0 of 4 markers present on main, 4 of 4 on staging). Promoting unify-deploy resolves it.