### PR TITLE
Release: staging → main (env prefix fix)

### DIFF
--- a/unify/conversation_manager/settings.py
+++ b/unify/conversation_manager/settings.py
@@ -67,7 +67,7 @@ class ConversationSettings(BaseSettings):
     IMPL: str = "real"
     COMMS_URL: str = Field(default="", validation_alias="UNIFY_COMMS_URL")
     ADAPTERS_URL: str = Field(default="", validation_alias="UNIFY_ADAPTERS_URL")
-    JOB_NAME: str = ""
+    JOB_NAME: str = Field(default="", validation_alias="UNITY_CONVERSATION_JOB_NAME")
     CONTACT_ID: str = "1"
     BLACKLIST_CHECKS_ENABLED: bool = False
     ASSISTANT_SESSION_GROUP: str = "infra.unify.ai"
@@ -82,11 +82,17 @@ class ConversationSettings(BaseSettings):
     LOCAL_COMMS_PUBLIC_URL: str = ""
     LOCAL_COMMS_PUBLIC_URL_FILE: str = "/runtime/call-tunnel-url"
     LOCAL_EMAIL_POLL_INTERVAL: float = 15.0
-    INGRESS_TRANSPORT: str = ""
-    OUTBOUND_TRANSPORT: str = ""
+    INGRESS_TRANSPORT: str = Field(
+        default="",
+        validation_alias="UNITY_CONVERSATION_INGRESS_TRANSPORT",
+    )
+    OUTBOUND_TRANSPORT: str = Field(
+        default="",
+        validation_alias="UNITY_CONVERSATION_OUTBOUND_TRANSPORT",
+    )
 
     model_config = SettingsConfigDict(
-        env_prefix="UNITY_CONVERSATION_",
+        env_prefix="UNIFY_CONVERSATION_",
         case_sensitive=True,
         extra="ignore",
     )

--- a/unify/file_manager/settings.py
+++ b/unify/file_manager/settings.py
@@ -59,8 +59,14 @@ class FileSettings(BaseSettings):
     # ``SETTINGS.GCP_PROJECT_ID`` + ``SETTINGS.ENV_SUFFIX``) instead of running
     # the in-process ``AttachmentIngestionPool``.  Completion events arrive
     # back on the per-assistant topic and are handled by ``CommsManager``.
-    PIPELINE_DISPATCH_ENABLED: bool = False
-    PIPELINE_ARTIFACT_BUCKET: str = ""
+    PIPELINE_DISPATCH_ENABLED: bool = Field(
+        default=False,
+        validation_alias="UNITY_FILE_PIPELINE_DISPATCH_ENABLED",
+    )
+    PIPELINE_ARTIFACT_BUCKET: str = Field(
+        default="",
+        validation_alias="UNITY_FILE_PIPELINE_ARTIFACT_BUCKET",
+    )
 
     # Plot API settings
     PLOT_API_ENDPOINT: str = "/logs/plot"
@@ -75,7 +81,7 @@ class FileSettings(BaseSettings):
     TABLE_VIEW_API_RETRY_BACKOFF: float = 1.0
 
     model_config = SettingsConfigDict(
-        env_prefix="UNITY_FILE_",
+        env_prefix="UNIFY_FILE_",
         case_sensitive=True,
         extra="ignore",
     )


### PR DESCRIPTION
Follow-up to #167.

The env var rename matched whole variable names, but pydantic `env_prefix` values build the name at runtime from prefix + field. The prefix was left behind, so `UNIFY_CONVERSATION_LOCAL_COMMS_MODE` was being set while `UNITY_CONVERSATION_LOCAL_COMMS_MODE` was being read — the setting silently fell back to its default.

Moves the `ConversationSettings` and `FileSettings` prefixes to `UNIFY_`, and pins the fields whose values come from outside the repo (`JOB_NAME`, `INGRESS_TRANSPORT`, `OUTBOUND_TRANSPORT`, `PIPELINE_DISPATCH_ENABLED`, `PIPELINE_ARTIFACT_BUCKET`) to their real names with an explicit `validation_alias`, so moving the prefix cannot detach them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)