### PR TITLE
fix(sharepoint): prevent malformed upload content from being corrupted

### DIFF
--- a/tests/gateway/channels/sharepoint/test_views.py
+++ b/tests/gateway/channels/sharepoint/test_views.py
@@ -393,12 +393,36 @@ def test_upload_decodes_base64_content(client: TestClient) -> None:
     )
 
 
-def test_upload_falls_back_to_plain_text_when_not_base64(
+@pytest.mark.parametrize(
+    "content",
+    [
+        "not-real-base64-content!!",
+        {"unexpected": "object"},
+    ],
+)
+def test_upload_rejects_invalid_base64_before_graph_lookup(
     client: TestClient,
+    content: object,
 ) -> None:
-    """Non-base64 content is encoded as UTF-8 plain text."""
+    get_graph_client = AsyncMock()
+    with patch(
+        "unify.gateway.channels.sharepoint.views.get_graph_client",
+        new=get_graph_client,
+    ):
+        resp = client.put(
+            "/sharepoint/drives/me/upload",
+            params={"user_email": "u@x.com"},
+            json={"path": "x.txt", "content": content},
+        )
+
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "content must be valid base64"
+    get_graph_client.assert_not_awaited()
+
+
+def test_upload_accepts_empty_base64_content(client: TestClient) -> None:
     fake_graph = _make_graph_mock()
-    uploaded = MagicMock(id="u-1", name="x.txt", web_url="x", size=5)
+    uploaded = MagicMock(id="u-1", name="empty.txt", web_url="x", size=0)
     captured: dict = {}
 
     async def _capture(payload):
@@ -417,17 +441,11 @@ def test_upload_falls_back_to_plain_text_when_not_base64(
         resp = client.put(
             "/sharepoint/drives/me/upload",
             params={"user_email": "u@x.com"},
-            # base64.b64decode("not-real-base64-content!!") may succeed in
-            # tolerant mode; use a clearly non-b64 payload that errors out
-            # so the fallback path triggers.
-            json={"path": "x.txt", "content": "hello"},
+            json={"path": "empty.txt", "content": ""},
         )
+
     assert resp.status_code == 200
-    # The fallback either decoded "hello" as base64 (resulting in random
-    # bytes) or fell through to UTF-8 encode. Either way the upload
-    # succeeded; the important contract is that put() was called with
-    # bytes (not a string).
-    assert isinstance(captured["bytes"], bytes)
+    assert captured["bytes"] == b""
 
 
 def test_create_folder_missing_name_returns_400(client: TestClient) -> None:

--- a/unify/gateway/channels/sharepoint/views.py
+++ b/unify/gateway/channels/sharepoint/views.py
@@ -14,6 +14,7 @@ change.
 from __future__ import annotations
 
 import base64
+import binascii
 import logging
 from typing import Optional
 from urllib.parse import quote
@@ -321,13 +322,16 @@ async def upload_file(request: Request, user_email: str, drive_id: str):
                 detail="Missing required fields: path, content",
             )
 
+        try:
+            file_bytes = base64.b64decode(content, validate=True)
+        except (binascii.Error, TypeError, ValueError) as exc:
+            raise HTTPException(
+                status_code=400,
+                detail="content must be valid base64",
+            ) from exc
+
         graph = await get_graph_client(user_email)
         drive_id, drive = await _drive_ref(graph, drive_id)
-
-        try:
-            file_bytes = base64.b64decode(content)
-        except Exception:
-            file_bytes = content.encode("utf-8")
 
         result = (
             await drive.items.by_drive_item_id("root")


### PR DESCRIPTION
## Summary

The SharePoint upload endpoint documents `content` as Base64, but its decoder accepted malformed input and could upload silently corrupted bytes. This change makes the existing contract explicit: invalid Base64 now returns `400` before the Graph client is resolved.

Valid Base64 uploads are unchanged, including empty files.

## Type of change

- [x] Bug fix
- [x] Tests

## Areas touched

- [x] Gateway / external comms
- [x] Tests

## Test plan

```text
tests/parallel_run.sh --timeout 300 tests/gateway/channels/sharepoint/test_views.py
# 23 passed

.venv/bin/autoflake --check --remove-all-unused-imports --remove-duplicate-keys \
  unify/gateway/channels/sharepoint/views.py \
  tests/gateway/channels/sharepoint/test_views.py

.venv/bin/black --check \
  unify/gateway/channels/sharepoint/views.py \
  tests/gateway/channels/sharepoint/test_views.py

.venv/bin/python -m pre_commit run detect-secrets --files \
  unify/gateway/channels/sharepoint/views.py \
  tests/gateway/channels/sharepoint/test_views.py
```

The regression coverage verifies that malformed strings and non-string JSON values return `400` without resolving the Graph client. It also verifies that empty Base64 content still uploads as zero bytes.

## Behavior / migration notes

Callers that relied on the undocumented plain-text fallback must Base64-encode upload content. No request fields or configuration change.

## Checklist

- [x] PR targets `staging`
- [x] Relevant tests pass locally
- [x] Regression coverage added
- [x] No dependency or schema changes
