### PR TITLE
Add Telegram Bot channel integration

### DIFF
--- a/unify/comms/primitives.py
+++ b/unify/comms/primitives.py
@@ -45,6 +45,8 @@ from unify.conversation_manager.events import (
     SlackChannelMessageSent,
     SlackMessageSent,
     SMSSent,
+    TelegramGroupMessageSent,
+    TelegramMessageSent,
     TeamsChannelCreated,
     TeamsChannelMessageSent,
     TeamsMeetCreated,
@@ -76,6 +78,7 @@ _DETAIL_LABELS = {
     "whatsapp_number": "WhatsApp number",
     "discord_id": "Discord ID",
     "slack_user_id": "Slack user ID",
+    "telegram_id": "Telegram ID",
 }
 
 _VOICE_SESSION_CLEAR_TIMEOUT_SECONDS = 15.0
@@ -2450,6 +2453,231 @@ class CommsPrimitives:
                 "thread_ts": thread_ts or "",
                 "contact_id": anchor_contact_id,
             },
+            history_metadata={
+                "contact_display_name": _get_contact_display_name(anchor_contact),
+            },
+        )
+
+    async def send_telegram_message(
+        self,
+        *,
+        contact_id: int | str,
+        content: str,
+        telegram_id: str | None = None,
+        chat_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Send an assistant-owned Telegram direct message to an existing contact.
+
+        Use this for one-to-one Telegram replies. For group chat posts, use
+        ``send_telegram_group_message`` instead.
+
+        - If the contact already has a Telegram ID on file, omit ``telegram_id``.
+        - If the contact is missing a Telegram ID but you know it, pass it via
+          ``telegram_id`` and the contact record will be updated before the message
+          is sent.
+
+        Parameters
+        ----------
+        contact_id : int | str
+            Recipient contact from ``active_conversations`` or from contact
+            search/create tools.
+        content : str
+            Message body to send.
+        telegram_id : str | None, optional
+            Recipient Telegram user ID when the contact does not already have one
+            on file.
+        chat_id : str | None, optional
+            Telegram chat ID. Defaults to the contact's telegram_id (private chat).
+
+        Returns
+        -------
+        dict[str, Any]
+            ``{"status": "ok"}`` on success, or an error payload.
+        """
+        contact_id = _coerce_contact_id(contact_id)
+        content = normalize_outbound_plain_text(content)
+        if is_placeholder_outbound_content(content):
+            return {"error": PLACEHOLDER_CONTENT_ERROR}
+        offline_reservation = None
+        contact = self._get_contact(contact_id=contact_id)
+        topic = "app:comms:telegram_message_sent"
+
+        outbound_error = self._check_outbound_allowed(contact)
+        if outbound_error:
+            return await self._surface_comms_error(
+                outbound_error,
+                topic,
+                contact_id=contact_id,
+                medium=Medium.TELEGRAM_MESSAGE,
+                offline_reservation=offline_reservation,
+                attempted_content=content,
+                receiver_ids=[contact_id],
+                target_metadata={
+                    "contact_id": contact_id,
+                    "telegram_id": (contact or {}).get("telegram_id") or telegram_id or "",
+                },
+                history_metadata={
+                    "contact_display_name": _get_contact_display_name(contact),
+                },
+            )
+
+        detail_error, contact = self._resolve_or_attach_detail(
+            contact=contact,
+            contact_id=contact_id,
+            field_name="telegram_id",
+            inline_value=telegram_id,
+            medium_label="Telegram",
+        )
+        if detail_error:
+            return await self._surface_comms_error(
+                detail_error,
+                topic,
+                contact_id=contact_id,
+                medium=Medium.TELEGRAM_MESSAGE,
+                offline_reservation=offline_reservation,
+                attempted_content=content,
+                receiver_ids=[contact_id],
+                target_metadata={
+                    "contact_id": contact_id,
+                    "telegram_id": (contact or {}).get("telegram_id") or telegram_id or "",
+                },
+                history_metadata={
+                    "contact_display_name": _get_contact_display_name(contact),
+                },
+            )
+
+        offline_reservation, offline_response = self._reserve_offline_operation(
+            method_name="send_telegram_message",
+            medium=Medium.TELEGRAM_MESSAGE,
+            target_kind="contact",
+            target_metadata={
+                "contact_id": (contact or {}).get("contact_id") or contact_id,
+                "telegram_id": (contact or {}).get("telegram_id") or telegram_id or "",
+            },
+            contact_id=(contact or {}).get("contact_id") or contact_id,
+        )
+        if offline_response is not None:
+            return offline_response
+
+        resolved_chat_id = chat_id or (contact or {}).get("telegram_id") or ""
+        response = await comms_utils.send_telegram_message(
+            chat_id=resolved_chat_id,
+            body=content,
+        )
+        if response.get("success"):
+            fresh_contact = self._get_contact(contact_id=contact_id) or contact or {}
+            event = TelegramMessageSent(
+                contact=fresh_contact,
+                content=content,
+                **self._onboarding_event_kwargs(Medium.TELEGRAM_MESSAGE),
+            )
+            await self._publish_comms_event(topic, event)
+            self._record_offline_success(
+                offline_reservation,
+                attempted_content=content,
+                receiver_ids=[fresh_contact.get("contact_id") or contact_id],
+                target_metadata={
+                    "contact_id": fresh_contact.get("contact_id") or contact_id,
+                    "telegram_id": resolved_chat_id,
+                },
+                history_metadata={
+                    "contact_display_name": _get_contact_display_name(fresh_contact),
+                },
+                provider_response=response,
+            )
+            return {"status": "ok"}
+
+        return await self._surface_comms_error(
+            "Failed to send Telegram message",
+            topic,
+            contact_id=contact_id,
+            medium=Medium.TELEGRAM_MESSAGE,
+            offline_reservation=offline_reservation,
+            attempted_content=content,
+            receiver_ids=[contact_id],
+            target_metadata={
+                "contact_id": contact_id,
+                "telegram_id": resolved_chat_id or telegram_id or "",
+            },
+            history_metadata={
+                "contact_display_name": _get_contact_display_name(contact),
+            },
+        )
+
+    async def send_telegram_group_message(
+        self,
+        *,
+        chat_id: str,
+        content: str,
+        contact_id: int | str | None = None,
+    ) -> dict[str, Any]:
+        """Post a message into a Telegram group chat.
+
+        Parameters
+        ----------
+        chat_id : str
+            Telegram group chat ID.
+        content : str
+            Message body to send.
+        contact_id : int | str | None, optional
+            Contact who triggered this reply (for attribution).
+
+        Returns
+        -------
+        dict[str, Any]
+            ``{"status": "ok"}`` on success, or an error payload.
+        """
+        content = normalize_outbound_plain_text(content)
+        if is_placeholder_outbound_content(content):
+            return {"error": PLACEHOLDER_CONTENT_ERROR}
+        topic = "app:comms:telegram_group_message_sent"
+
+        anchor_contact_id = _coerce_contact_id(contact_id) if contact_id is not None else None
+        anchor_contact = self._get_contact(contact_id=anchor_contact_id) if anchor_contact_id else None
+
+        offline_reservation, offline_response = self._reserve_offline_operation(
+            method_name="send_telegram_group_message",
+            medium=Medium.TELEGRAM_GROUP_MESSAGE,
+            target_kind="channel",
+            target_metadata={"chat_id": chat_id, "contact_id": anchor_contact_id},
+            contact_id=anchor_contact_id,
+        )
+        if offline_response is not None:
+            return offline_response
+
+        response = await comms_utils.send_telegram_message(
+            chat_id=chat_id,
+            body=content,
+        )
+        if response.get("success"):
+            event = TelegramGroupMessageSent(
+                contact=anchor_contact or {},
+                content=content,
+                chat_id=chat_id,
+                **self._onboarding_event_kwargs(Medium.TELEGRAM_GROUP_MESSAGE),
+            )
+            await self._publish_comms_event(topic, event)
+            self._record_offline_success(
+                offline_reservation,
+                attempted_content=content,
+                receiver_ids=[anchor_contact_id] if anchor_contact_id is not None else None,
+                target_metadata={"chat_id": chat_id, "contact_id": anchor_contact_id},
+                history_metadata={
+                    "contact_display_name": _get_contact_display_name(anchor_contact),
+                },
+                provider_response=response,
+            )
+            return {"status": "ok"}
+
+        return await self._surface_comms_error(
+            "Failed to send Telegram group message",
+            topic,
+            contact_id=anchor_contact_id,
+            medium=Medium.TELEGRAM_GROUP_MESSAGE,
+            offline_reservation=offline_reservation,
+            attempted_content=content,
+            receiver_ids=[anchor_contact_id] if anchor_contact_id is not None else None,
+            target_metadata={"chat_id": chat_id, "contact_id": anchor_contact_id},
             history_metadata={
                 "contact_display_name": _get_contact_display_name(anchor_contact),
             },

--- a/unify/conversation_manager/cm_types/medium.py
+++ b/unify/conversation_manager/cm_types/medium.py
@@ -47,6 +47,8 @@ class Medium(StrEnum):
     TEAMS_CHANNEL_MESSAGE = "teams_channel_message"
     MS_TEAMS_BOT_MESSAGE = "ms_teams_bot_message"
     MS_TEAMS_BOT_CHANNEL_MESSAGE = "ms_teams_bot_channel_message"
+    TELEGRAM_MESSAGE = "telegram_message"
+    TELEGRAM_GROUP_MESSAGE = "telegram_group_message"
     UNIFY_REACTION = "unify_reaction"
     WHATSAPP_REACTION = "whatsapp_reaction"
 
@@ -166,6 +168,16 @@ MEDIUM_REGISTRY: dict[Medium, MediumInfo] = {
         ),
         mode=Mode.TEXT,
     ),
+    Medium.TELEGRAM_MESSAGE: MediumInfo(
+        value=Medium.TELEGRAM_MESSAGE,
+        description="A direct message sent via a Telegram bot.",
+        mode=Mode.TEXT,
+    ),
+    Medium.TELEGRAM_GROUP_MESSAGE: MediumInfo(
+        value=Medium.TELEGRAM_GROUP_MESSAGE,
+        description="A message in a Telegram group chat, triggered by messaging the bot.",
+        mode=Mode.TEXT,
+    ),
     Medium.UNIFY_REACTION: MediumInfo(
         value=Medium.UNIFY_REACTION,
         description="An emoji reaction on a Unify console chat message.",
@@ -204,4 +216,6 @@ MEDIUM_TO_CONTACT_FIELD: dict[Medium, str] = {
     Medium.TEAMS_MEET: "email_address",
     Medium.MS_TEAMS_BOT_MESSAGE: "email_address",
     Medium.MS_TEAMS_BOT_CHANNEL_MESSAGE: "email_address",
+    Medium.TELEGRAM_MESSAGE: "telegram_id",
+    Medium.TELEGRAM_GROUP_MESSAGE: "telegram_id",
 }

--- a/unify/conversation_manager/comms_manager.py
+++ b/unify/conversation_manager/comms_manager.py
@@ -150,6 +150,23 @@ def _already_seen_slack(message_key: str) -> bool:
     return False
 
 
+_seen_telegram_ids: dict[str, float] = {}
+_TELEGRAM_DEDUP_TTL = 300.0
+
+
+def _already_seen_telegram(message_id: str) -> bool:
+    """Return True if this Telegram message_id was already processed recently."""
+    now = time.time()
+    cutoff = now - _TELEGRAM_DEDUP_TTL
+    expired = [k for k, t in _seen_telegram_ids.items() if t < cutoff]
+    for k in expired:
+        del _seen_telegram_ids[k]
+    if message_id in _seen_telegram_ids:
+        return True
+    _seen_telegram_ids[message_id] = now
+    return False
+
+
 # In-memory dedup for inbound Unify Teams bot activities. The Bot Connector
 # retries delivery when a webhook ack is slow, so we guard on the stable
 # activity id the same way the Graph Teams and Slack paths do.
@@ -377,6 +394,7 @@ events_map: dict[str, Event] = {
     "teams_chat": TeamsMessageReceived,
     "teams_channel": TeamsChannelMessageReceived,
     "ms_teams_bot": MsTeamsBotMessageReceived,
+    "telegram": TelegramMessageReceived,
 }
 
 
@@ -1902,6 +1920,96 @@ class CommsManager:
                         await publish(
                             "app:comms:slack_message",
                             events_map[thread](**common_kwargs).to_json(),
+                        )
+
+                    if attachments:
+                        schedule(add_unify_message_attachments(attachments))
+
+                    if is_new_unknown:
+                        await publish(
+                            "app:comms:unknown_contact_created",
+                            UnknownContactCreated(
+                                contact=contact,
+                                medium=medium_for_blacklist,
+                                message_preview=content[:100] if content else "",
+                            ).to_json(),
+                        )
+
+                    ack_now()
+                    return
+
+                if thread == "telegram":
+                    sender_telegram_id = event.get("sender_telegram_id", "")
+                    message_id = event.get("message_id", "")
+                    chat_id = event.get("chat_id", "")
+                    is_group = event.get("is_group", False)
+                    attachments = event.get("attachments") or []
+
+                    if message_id and _already_seen_telegram(message_id):
+                        LOGGER.debug(
+                            f"{DEFAULT_ICON} Skipping duplicate Telegram message {message_id}",
+                        )
+                        ack_now()
+                        return
+
+                    medium_for_blacklist = (
+                        Medium.TELEGRAM_GROUP_MESSAGE
+                        if is_group
+                        else Medium.TELEGRAM_MESSAGE
+                    )
+
+                    if _is_blacklisted(medium_for_blacklist, sender_telegram_id):
+                        LOGGER.debug(
+                            f"{DEFAULT_ICON} Ignoring blacklisted Telegram from: {sender_telegram_id}",
+                        )
+                        ack_now()
+                        return
+
+                    contact = next(
+                        (
+                            c
+                            for c in contacts
+                            if c.get("telegram_id") == sender_telegram_id
+                        ),
+                        None,
+                    )
+                    is_new_unknown = False
+                    if contact is None:
+                        contact = _get_or_create_unknown_contact(
+                            medium_for_blacklist,
+                            sender_telegram_id,
+                        )
+                        is_new_unknown = contact is not None
+
+                    if contact is None:
+                        LOGGER.error(
+                            f"{DEFAULT_ICON} Failed to resolve contact for Telegram from: {sender_telegram_id}",
+                        )
+                        ack_now()
+                        return
+
+                    if is_group:
+                        telegram_event = TelegramGroupMessageReceived(
+                            contact=contact,
+                            content=content,
+                            chat_id=chat_id,
+                            message_id=message_id,
+                            attachments=attachments,
+                        )
+                        await publish(
+                            "app:comms:telegram_group_message",
+                            telegram_event.to_json(),
+                        )
+                    else:
+                        await publish(
+                            "app:comms:telegram_message",
+                            TelegramMessageReceived(
+                                contact=contact,
+                                content=content,
+                                chat_id=chat_id,
+                                message_id=message_id,
+                                attachments=attachments,
+                            ).to_json(),
                         )
 
                     if attachments:

--- a/unify/conversation_manager/conversation_manager.py
+++ b/unify/conversation_manager/conversation_manager.py
@@ -316,6 +316,7 @@ class ConversationManager(metaclass=SingletonABCMeta):
         assistant_slack_bot_user_id: str = "",
         assistant_slack_team_id: str = "",
         assistant_has_ms_teams_bot: bool = False,
+        assistant_has_telegram: bool = False,
         assistant_job_title: str = "",
         past_events: list | None = None,
         conv_context_length: int = 50,
@@ -348,6 +349,7 @@ class ConversationManager(metaclass=SingletonABCMeta):
         # ``assistant_has_teams`` MS365 mailbox capability). Sourced from the
         # assistant profile and adopted at runtime from inbound bot activities.
         self.assistant_has_ms_teams_bot = assistant_has_ms_teams_bot
+        self.assistant_has_telegram = assistant_has_telegram
         # Global onboarding scaffolding gate, mirrored from Orchestra's
         # ``Coordinator/State`` and refreshed on a short TTL. When False the
         # slow-brain drops all onboarding scaffolding. Defaults to True until
@@ -2053,6 +2055,19 @@ class ConversationManager(metaclass=SingletonABCMeta):
                 channel_id=reply_context["channel_id"],
                 team_id=reply_context.get("team_id") or "",
                 thread_ts=reply_context.get("thread_ts"),
+                contact_id=contact_id,
+                content=content,
+            )
+        elif medium == Medium.TELEGRAM_MESSAGE.value and contact_id is not None:
+            await tools.send_telegram_message(
+                contact_id=contact_id,
+                content=content,
+            )
+        elif medium == Medium.TELEGRAM_GROUP_MESSAGE.value and reply_context.get(
+            "chat_id",
+        ):
+            await tools.send_telegram_group_message(
+                chat_id=reply_context["chat_id"],
                 contact_id=contact_id,
                 content=content,
             )

--- a/unify/conversation_manager/domains/brain.py
+++ b/unify/conversation_manager/domains/brain.py
@@ -235,6 +235,7 @@ def build_brain_spec(
         assistant_has_discord=bool(cm.assistant_discord_bot_id),
         assistant_has_slack=bool(cm.assistant_slack_bot_user_id),
         assistant_has_ms_teams_bot=bool(cm.assistant_has_ms_teams_bot),
+        assistant_has_telegram=bool(cm.assistant_has_telegram),
         assistant_has_teams=bool(cm.assistant_has_teams),
         has_linked_user_desktop=_user_desktop_link is not None,
         user_filesys_consented=bool(

--- a/unify/conversation_manager/domains/brain_action_tools.py
+++ b/unify/conversation_manager/domains/brain_action_tools.py
@@ -596,6 +596,61 @@ class ConversationManagerBrainActionTools:
         )
 
     @slow_brain_direct_comms
+    @wraps(CommsPrimitives.send_telegram_message)
+    async def send_telegram_message(
+        self,
+        *,
+        contact_id: int | str,
+        content: str,
+        telegram_id: str | None = None,
+        chat_id: str | None = None,
+    ) -> dict[str, Any]:
+        return await self._comms.send_telegram_message(
+            contact_id=contact_id,
+            content=content,
+            telegram_id=telegram_id,
+            chat_id=chat_id,
+        )
+
+    @slow_brain_direct_comms
+    async def send_telegram_message_to_boss(
+        self,
+        *,
+        content: str,
+    ) -> dict[str, Any]:
+        """Send a Telegram direct message to my boss only.
+
+        This Coordinator direct communication tool is restricted to the boss
+        contact. It cannot be used to message anyone else. If my boss asks me
+        to draft or send a Telegram message on their behalf, route that work
+        through ``act`` instead.
+
+        Parameters
+        ----------
+        content : str
+            Message body to send to my boss.
+        """
+        return await self._comms.send_telegram_message(
+            contact_id=self._boss_contact_id(),
+            content=content,
+        )
+
+    @slow_brain_direct_comms
+    @wraps(CommsPrimitives.send_telegram_group_message)
+    async def send_telegram_group_message(
+        self,
+        *,
+        chat_id: str,
+        content: str,
+        contact_id: int | str | None = None,
+    ) -> dict[str, Any]:
+        return await self._comms.send_telegram_group_message(
+            chat_id=chat_id,
+            content=content,
+            contact_id=contact_id,
+        )
+
+    @slow_brain_direct_comms
     @wraps(CommsPrimitives.send_teams_message)
     async def send_teams_message(
         self,

--- a/unify/conversation_manager/domains/comms_utils.py
+++ b/unify/conversation_manager/domains/comms_utils.py
@@ -1411,6 +1411,52 @@ async def send_slack_message(
             return result
 
 
+async def send_telegram_message(
+    *,
+    chat_id: str,
+    body: str = "",
+    reply_to_message_id: int | None = None,
+) -> dict:
+    """Send a Telegram message via the gateway.
+
+    Args:
+        chat_id: Telegram chat ID (user or group).
+        body: The text content to send.
+        reply_to_message_id: Optional message ID to reply to.
+
+    Returns:
+        dict with ``success`` and optionally ``message_id`` / ``chat_id``.
+    """
+    agent_id = SESSION_DETAILS.assistant.agent_id
+    if agent_id is None:
+        return {"success": False}
+
+    body = normalize_outbound_plain_text(body)
+
+    payload: dict = {
+        "chat_id": chat_id,
+        "body": body,
+        "assistant_id": agent_id,
+    }
+    if reply_to_message_id:
+        payload["reply_to_message_id"] = reply_to_message_id
+
+    async with aiohttp.ClientSession() as session:
+        async with session.post(
+            f"{SETTINGS.conversation.COMMS_URL}/telegram/send",
+            headers=_assistant_headers(),
+            json=payload,
+        ) as response:
+            try:
+                response.raise_for_status()
+            except Exception as e:
+                LOGGER.error(f"{ICONS['comms_outbound']} Telegram send failed: {e}")
+                return {"success": False}
+            result = await response.json()
+            result["success"] = True
+            return result
+
+
 async def find_ms_teams_bot_conversation_route(
     *,
     conversation_type: str = "personal",

--- a/unify/conversation_manager/domains/event_handlers.py
+++ b/unify/conversation_manager/domains/event_handlers.py
@@ -2694,6 +2694,10 @@ def _credit_gate_reply_context(
         MsTeamsBotMessageReceived,
         MsTeamsBotChannelMessageSent,
         MsTeamsBotChannelMessageReceived,
+        TelegramMessageReceived,
+        TelegramMessageSent,
+        TelegramGroupMessageReceived,
+        TelegramGroupMessageSent,
     ),
 )
 async def _(event, cm: "ConversationManager", *args, **kwargs):
@@ -3058,6 +3062,55 @@ async def _(event, cm: "ConversationManager", *args, **kwargs):
             cm._session_logger.info(
                 "slack_channel_message_received",
                 f"Slack channel from {sender_name}: {event.content}",
+            )
+        case TelegramMessageSent():
+            medium = Medium.TELEGRAM_MESSAGE
+            message_content = event.content
+            notif_content = f"Telegram DM sent to {sender_name}"
+            role = "assistant"
+            event_trace = getattr(cm, "_current_event_trace", None) or {}
+            cm._session_logger.info(
+                "telegram_message_sent",
+                f"Telegram DM to {sender_name}: {event.content}",
+            )
+        case TelegramMessageReceived():
+            cm.assistant_has_telegram = True
+            medium = Medium.TELEGRAM_MESSAGE
+            message_content = event.content
+            attachments = event.attachments
+            chat_id = getattr(event, "chat_id", "") or None
+            message_id = getattr(event, "message_id", "") or None
+            notif_content = f"Telegram DM from {sender_name}"
+            role = "user"
+            event_trace = getattr(cm, "_current_event_trace", None) or {}
+            cm._session_logger.info(
+                "telegram_message_received",
+                f"Telegram DM from {sender_name}: {event.content}",
+            )
+        case TelegramGroupMessageSent():
+            medium = Medium.TELEGRAM_GROUP_MESSAGE
+            message_content = event.content
+            chat_id = getattr(event, "chat_id", "") or None
+            notif_content = "Telegram group message sent"
+            role = "assistant"
+            event_trace = getattr(cm, "_current_event_trace", None) or {}
+            cm._session_logger.info(
+                "telegram_group_message_sent",
+                f"Telegram group message: {event.content}",
+            )
+        case TelegramGroupMessageReceived():
+            cm.assistant_has_telegram = True
+            medium = Medium.TELEGRAM_GROUP_MESSAGE
+            message_content = event.content
+            attachments = event.attachments
+            chat_id = getattr(event, "chat_id", "") or None
+            message_id = getattr(event, "message_id", "") or None
+            notif_content = f"Telegram group message from {sender_name}"
+            role = "user"
+            event_trace = getattr(cm, "_current_event_trace", None) or {}
+            cm._session_logger.info(
+                "telegram_group_message_received",
+                f"Telegram group from {sender_name}: {event.content}",
             )
         case TeamsMessageSent():
             medium = Medium.TEAMS_MESSAGE

--- a/unify/conversation_manager/domains/prose_send_healing.py
+++ b/unify/conversation_manager/domains/prose_send_healing.py
@@ -39,6 +39,10 @@ _SEND_TOOL_BY_MEDIUM: dict[Medium, tuple[str, str]] = {
         "send_ms_teams_bot_message",
         "send_ms_teams_bot_message_to_boss",
     ),
+    Medium.TELEGRAM_MESSAGE: (
+        "send_telegram_message",
+        "send_telegram_message_to_boss",
+    ),
 }
 
 _CHANNEL_SEND_TOOL_BY_MEDIUM: dict[Medium, str] = {
@@ -46,6 +50,7 @@ _CHANNEL_SEND_TOOL_BY_MEDIUM: dict[Medium, str] = {
     Medium.SLACK_CHANNEL_MESSAGE: "send_slack_channel_message",
     Medium.TEAMS_CHANNEL_MESSAGE: "send_teams_message",
     Medium.MS_TEAMS_BOT_CHANNEL_MESSAGE: "send_ms_teams_bot_channel_message",
+    Medium.TELEGRAM_GROUP_MESSAGE: "send_telegram_group_message",
 }
 
 

--- a/unify/conversation_manager/events.py
+++ b/unify/conversation_manager/events.py
@@ -937,6 +937,65 @@ class SlackChannelMessageSent(Event):
 
 
 @dataclass
+class TelegramMessageReceived(Event):
+    """A direct message received from a user via a Telegram bot."""
+
+    topic: ClassVar[str | None] = "app:comms:telegram_message"
+    content_logged: ClassVar[bool] = True
+
+    contact: dict
+    content: str
+    chat_id: str = ""
+    message_id: str = ""
+    attachments: list[dict] = field(default_factory=list)
+
+
+@dataclass
+class TelegramGroupMessageReceived(Event):
+    """A message received in a Telegram group chat via the bot."""
+
+    topic: ClassVar[str | None] = "app:comms:telegram_group_message"
+    content_logged: ClassVar[bool] = True
+
+    contact: dict
+    content: str
+    chat_id: str = ""
+    message_id: str = ""
+    attachments: list[dict] = field(default_factory=list)
+
+
+@dataclass
+class TelegramMessageSent(Event):
+    """A direct message sent to a user via a Telegram bot."""
+
+    topic: ClassVar[str | None] = "app:comms:telegram_message_sent"
+    content_logged: ClassVar[bool] = True
+
+    contact: dict
+    content: str
+    onboarding_trigger_step_id: str | None = None
+    onboarding_reply_step_id: str | None = None
+    onboarding_request_id: str | None = None
+    onboarding_origin_event_id: str | None = None
+
+
+@dataclass
+class TelegramGroupMessageSent(Event):
+    """A message sent to a Telegram group chat via the bot."""
+
+    topic: ClassVar[str | None] = "app:comms:telegram_group_message_sent"
+    content_logged: ClassVar[bool] = True
+
+    contact: dict
+    content: str
+    chat_id: str = ""
+    onboarding_trigger_step_id: str | None = None
+    onboarding_reply_step_id: str | None = None
+    onboarding_request_id: str | None = None
+    onboarding_origin_event_id: str | None = None
+
+
+@dataclass
 class MsTeamsBotMessageSent(Event):
     """A proactive reply sent through the org-installed Unify Teams bot app.
 

--- a/unify/conversation_manager/prompt_builders.py
+++ b/unify/conversation_manager/prompt_builders.py
@@ -648,6 +648,7 @@ def _build_channels_str(
     assistant_has_teams: bool = False,
     assistant_has_ms_teams_bot: bool = False,
     assistant_has_slack: bool = False,
+    assistant_has_telegram: bool = False,
 ) -> str:
     """Build a human-readable comma-separated list of available channels."""
     available_channels: list[str] = ["unify messages"]
@@ -670,6 +671,11 @@ def _build_channels_str(
         available_channels.insert(
             available_channels.index("unify messages"),
             "Slack",
+        )
+    if assistant_has_telegram:
+        available_channels.insert(
+            available_channels.index("unify messages"),
+            "Telegram",
         )
     if assistant_has_teams:
         available_channels.insert(
@@ -705,6 +711,7 @@ def _build_comms_tool_listing(
     assistant_has_whatsapp: bool = False,
     assistant_has_discord: bool = False,
     assistant_has_slack: bool = False,
+    assistant_has_telegram: bool = False,
     assistant_has_teams: bool = False,
     assistant_has_ms_teams_bot: bool = False,
     is_coordinator: bool = False,
@@ -864,6 +871,16 @@ def _build_comms_tool_listing(
             "original message (for a top-level @mention it is that message's "
             "own id and starts the thread). Use when the inbound thread is "
             "`slack_channel_message`.",
+        )
+    if assistant_has_telegram:
+        lines.append(
+            "- `send_telegram_message`: Send a Telegram DM to a contact "
+            "(use when the inbound thread is `telegram_message`)",
+        )
+        lines.append(
+            "- `send_telegram_group_message`: Post into a Telegram group "
+            "chat. Pass `chat_id` from the inbound annotation. Use when the "
+            "inbound thread is `telegram_group_message`.",
         )
     if assistant_has_ms_teams_bot:
         lines.append(
@@ -1898,7 +1915,7 @@ CRITICAL: I have a tendency to be over-eager and verbose. I must fight this aggr
 - If a message depends on tool outcomes from the same turn, avoid claiming those outcomes until the evidence exists.
 - If I include a same-turn acknowledgment with action tools, it must be intent-only and never a completion claim.
 - **Outbound messages are "sent", never "arrived", until proof.** Calling a send tool (`send_whatsapp`, `send_sms`, `send_email`, `send_unify_message`, ...) does not confirm the message reached the contact in this turn. In the SAME turn I send, anything I say or guide must be intent-only ("I'm sending that to your WhatsApp now") — I never say it has arrived, is waiting, or is in their inbox. I confirm receipt ONLY after the proof transcript row appears (e.g. `[You WhatsApped <name>]`). WhatsApp specifically: if that proof row reads `[You WhatsApped <name> (not delivered directly)]`, only a generic placeholder reached them and my real text is queued to resend after they reply — so I tell them to reply to the placeholder first, and I do NOT claim the actual message arrived.
-- **Plain-text formatting on outbound channels** (`send_email`, `send_sms`, `send_whatsapp`, `send_unify_message`, `send_teams_message`, `send_slack_message`, `send_discord_message`, etc.): write prose as continuous lines that reflow naturally — do not hard-wrap near 80 columns. Use a blank line between paragraphs. For bullet or numbered lists, put each item on its own line (`- item`, `1. item`, etc.); do not fold list items into one wrapped paragraph.
+- **Plain-text formatting on outbound channels** (`send_email`, `send_sms`, `send_whatsapp`, `send_unify_message`, `send_teams_message`, `send_slack_message`, `send_discord_message`, `send_telegram_message`, etc.): write prose as continuous lines that reflow naturally — do not hard-wrap near 80 columns. Use a blank line between paragraphs. For bullet or numbered lists, put each item on its own line (`- item`, `1. item`, etc.); do not fold list items into one wrapped paragraph.
 
 **When to speak vs wait**:
 - NEW unify_message from user → respond with `send_unify_message` (one short message), then `wait`. Never `wait` while their chat line is still unanswered. On a live call, "respond" means `guide_voice_agent(message="...")` with the actual reply — I never `wait` silently on a user message that wants a response, because the Voice Agent only said a filler phrase. EXCEPTION: if a recent line of mine already fully answers their message and they are not asking me to recall or restate anything, it is handled — I `wait` or move to new content.
@@ -2474,6 +2491,7 @@ def _build_available_outbound_tool_names(
     assistant_has_whatsapp: bool,
     assistant_has_discord: bool,
     assistant_has_slack: bool,
+    assistant_has_telegram: bool,
     assistant_has_teams: bool,
     assistant_has_ms_teams_bot: bool,
     is_coordinator: bool,
@@ -2517,6 +2535,11 @@ def _build_available_outbound_tool_names(
         available_tool_names.insert(idx, "send_slack_message")
         if not is_coordinator:
             available_tool_names.insert(idx + 1, "send_slack_channel_message")
+    if assistant_has_telegram:
+        idx = available_tool_names.index("send_unify_message")
+        available_tool_names.insert(idx, "send_telegram_message")
+        if not is_coordinator:
+            available_tool_names.insert(idx + 1, "send_telegram_group_message")
     if assistant_has_ms_teams_bot:
         idx = available_tool_names.index("send_unify_message")
         available_tool_names.insert(idx, "send_ms_teams_bot_message")
@@ -2628,6 +2651,7 @@ def build_system_prompt(
     assistant_has_whatsapp: bool = False,
     assistant_has_discord: bool = False,
     assistant_has_slack: bool = False,
+    assistant_has_telegram: bool = False,
     assistant_has_teams: bool = False,
     assistant_has_ms_teams_bot: bool = False,
     is_coordinator: bool = False,
@@ -2809,6 +2833,7 @@ def build_system_prompt(
         assistant_has_whatsapp=assistant_has_whatsapp,
         assistant_has_discord=assistant_has_discord,
         assistant_has_slack=assistant_has_slack,
+        assistant_has_telegram=assistant_has_telegram,
         assistant_has_teams=assistant_has_teams,
         assistant_has_ms_teams_bot=assistant_has_ms_teams_bot,
         is_coordinator=private_coordinator,
@@ -2823,6 +2848,7 @@ def build_system_prompt(
         assistant_has_whatsapp,
         assistant_has_discord,
         assistant_has_slack,
+        assistant_has_telegram,
         assistant_has_teams,
         assistant_has_ms_teams_bot,
         private_coordinator,
@@ -3016,6 +3042,7 @@ Messages from the current turn have **NEW** tag prepended:
         assistant_has_teams=assistant_has_teams,
         assistant_has_ms_teams_bot=assistant_has_ms_teams_bot,
         assistant_has_slack=assistant_has_slack,
+        assistant_has_telegram=assistant_has_telegram,
     )
 
     # 8. Tool-usage decision guides.
@@ -3130,6 +3157,10 @@ Messages from the current turn have **NEW** tag prepended:
         if assistant_has_slack:
             inline_detail_examples.append(
                 '`send_slack_message(contact_id=5, content="Hi", team_id="T01ABC", slack_user_id="U01ABC234")`',
+            )
+        if assistant_has_telegram:
+            inline_detail_examples.append(
+                '`send_telegram_message(contact_id=5, content="Hi", telegram_id="123456789")`',
             )
         if assistant_has_teams:
             inline_detail_examples.append(

--- a/unify/gateway/adapters/__init__.py
+++ b/unify/gateway/adapters/__init__.py
@@ -5,6 +5,7 @@ from unify.gateway.adapters.internal import router as internal_router
 from unify.gateway.adapters.microsoft import router as microsoft_router
 from unify.gateway.adapters.ms_teams_bot import router as ms_teams_bot_adapter_router
 from unify.gateway.adapters.slack import router as slack_adapter_router
+from unify.gateway.adapters.telegram import router as telegram_adapter_router
 from unify.gateway.adapters.twilio import router as twilio_router
 
 __all__ = [
@@ -13,5 +14,6 @@ __all__ = [
     "microsoft_router",
     "ms_teams_bot_adapter_router",
     "slack_adapter_router",
+    "telegram_adapter_router",
     "twilio_router",
 ]

--- a/unify/gateway/adapters/telegram.py
+++ b/unify/gateway/adapters/telegram.py
@@ -1,0 +1,162 @@
+"""Telegram Bot API webhook adapter."""
+
+from __future__ import annotations
+
+import hmac
+import logging
+import time
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+
+from unify.gateway.adapters.common import (
+    default_contacts,
+    get_assistant,
+    publish_runtime_event,
+)
+from unify.gateway.context import GatewayContext, get_gateway_context
+
+logger = logging.getLogger("unify.gateway.adapters.telegram")
+
+router = APIRouter()
+
+_SEEN: dict[str, float] = {}
+_SEEN_TTL = 300.0
+
+
+def _already_seen(update_id: str) -> bool:
+    if not update_id:
+        return False
+    now = time.time()
+    cutoff = now - _SEEN_TTL
+    for key in [k for k, t in _SEEN.items() if t < cutoff]:
+        del _SEEN[key]
+    if update_id in _SEEN:
+        return True
+    _SEEN[update_id] = now
+    return False
+
+
+def _verify_secret_token(request: Request, context: GatewayContext) -> None:
+    """Verify the ``X-Telegram-Bot-Api-Secret-Token`` header if configured."""
+    expected = context.credentials.get_optional("TELEGRAM_WEBHOOK_SECRET", "")
+    if not expected:
+        return
+    actual = request.headers.get("X-Telegram-Bot-Api-Secret-Token", "")
+    if not hmac.compare_digest(expected, actual):
+        raise HTTPException(status_code=401, detail="Invalid secret token")
+
+
+def _extract_message(update: dict[str, Any]) -> dict[str, Any] | None:
+    """Return the message dict from an update.
+
+    Handles ``message``, ``edited_message``, and ``channel_post``.
+    ``channel_post`` lacks a ``from`` field (no user sender), so the
+    caller must tolerate an empty ``from`` dict.
+    """
+    return (
+        update.get("message")
+        or update.get("edited_message")
+        or update.get("channel_post")
+    )
+
+
+@router.post("/telegram/webhook")
+async def telegram_webhook(
+    request: Request,
+    context: GatewayContext = Depends(get_gateway_context),
+) -> dict[str, Any]:
+    _verify_secret_token(request, context)
+
+    update = await request.json()
+    update_id = str(update.get("update_id", ""))
+    if _already_seen(update_id):
+        return {"ok": True}
+
+    message = _extract_message(update)
+    if not message:
+        return {"ok": True}
+
+    text = message.get("text") or message.get("caption") or ""
+    if not text:
+        return {"ok": True}
+
+    from_user = message.get("from") or {}
+    if not from_user:
+        return {"ok": True}
+    if from_user.get("is_bot"):
+        return {"ok": True}
+
+    chat = message.get("chat", {})
+    chat_id = str(chat.get("id", ""))
+    chat_type = chat.get("type", "private")
+    sender_id = str(from_user.get("id", ""))
+    message_id = str(message.get("message_id", ""))
+    is_group = chat_type in ("group", "supergroup")
+
+    assistant_id = context.credentials.get_optional("TELEGRAM_ASSISTANT_ID", "")
+    if not assistant_id:
+        logger.warning("TELEGRAM_ASSISTANT_ID not configured; dropping update")
+        return {"ok": True}
+
+    assistant = await get_assistant(assistant_id=assistant_id)
+    if not assistant.get("assistant_id"):
+        return {"ok": True}
+
+    contacts = default_contacts(assistant)
+    await context.runtime_activator.activate(
+        assistant_id,
+        reason="telegram_message",
+        medium="telegram",
+        metadata={"assistant": assistant},
+    )
+
+    attachments: list[dict[str, Any]] = []
+    for doc in message.get("document") and [message["document"]] or []:
+        attachments.append(
+            {
+                "id": doc.get("file_id", ""),
+                "filename": doc.get("file_name", ""),
+                "mimetype": doc.get("mime_type", ""),
+                "size": doc.get("file_size", 0),
+            },
+        )
+    for photo_sizes in [message.get("photo")] if message.get("photo") else []:
+        if photo_sizes:
+            largest = photo_sizes[-1]
+            attachments.append(
+                {
+                    "id": largest.get("file_id", ""),
+                    "filename": "photo.jpg",
+                    "mimetype": "image/jpeg",
+                    "size": largest.get("file_size", 0),
+                },
+            )
+
+    sender_first = from_user.get("first_name", "")
+    sender_last = from_user.get("last_name", "")
+    sender_username = from_user.get("username", "")
+
+    await publish_runtime_event(
+        context,
+        assistant_id=assistant_id,
+        thread="telegram",
+        event={
+            "update_id": update_id,
+            "message_id": message_id,
+            "chat_id": chat_id,
+            "chat_type": chat_type,
+            "sender_telegram_id": sender_id,
+            "sender_first_name": sender_first,
+            "sender_last_name": sender_last,
+            "sender_username": sender_username,
+            "body": text,
+            "is_group": is_group,
+            "attachments": attachments,
+            "contacts": contacts,
+        },
+    )
+    return {"ok": True}
+
+
+__all__ = ["router"]

--- a/unify/gateway/app.py
+++ b/unify/gateway/app.py
@@ -55,6 +55,7 @@ from unify.gateway.channels.phone import (
 from unify.gateway.channels.sharepoint import router as sharepoint_router
 from unify.gateway.channels.slack import auth_router as slack_auth_router
 from unify.gateway.channels.social import router as social_router
+from unify.gateway.channels.telegram import auth_router as telegram_auth_router
 from unify.gateway.channels.teams import router as teams_router
 from unify.gateway.channels.unillm import router as unillm_router
 from unify.gateway.channels.whatsapp import (
@@ -74,6 +75,7 @@ from unify.gateway.adapters import (
     microsoft_router,
     ms_teams_bot_adapter_router,
     slack_adapter_router,
+    telegram_adapter_router,
     twilio_router,
 )
 
@@ -298,6 +300,11 @@ def create_app(
         dependencies=admin_or_user_auth_dependency,
     )
     app.include_router(
+        telegram_auth_router,
+        prefix="/telegram",
+        dependencies=admin_or_user_auth_dependency,
+    )
+    app.include_router(
         internal_router,
         dependencies=admin_or_user_auth_dependency,
         tags=["internal-adapters"],
@@ -312,6 +319,10 @@ def create_app(
     app.include_router(
         ms_teams_bot_adapter_router,
         tags=["ms-teams-bot-adapters"],
+    )
+    app.include_router(
+        telegram_adapter_router,
+        tags=["telegram-adapters"],
     )
     app.include_router(twilio_router, tags=["twilio-adapters"])
 
@@ -365,6 +376,8 @@ def create_app(
             "whatsapp": twilio_wa,
             # Slack Events ingress.
             "slack": configured("SLACK_SIGNING_SECRET"),
+            # Telegram Bot webhook ingress.
+            "telegram": configured("TELEGRAM_BOT_TOKEN"),
             # User-side phone / WhatsApp verification codes (Twilio social verify).
             "social_verify_phone": twilio,
             "social_verify_whatsapp": twilio_wa,

--- a/unify/gateway/channels/telegram/__init__.py
+++ b/unify/gateway/channels/telegram/__init__.py
@@ -1,0 +1,5 @@
+"""Telegram Bot channel: admin endpoints for outbound sends."""
+
+from unify.gateway.channels.telegram.views import auth_router
+
+__all__ = ["auth_router"]

--- a/unify/gateway/channels/telegram/views.py
+++ b/unify/gateway/channels/telegram/views.py
@@ -1,0 +1,116 @@
+"""Telegram admin endpoints (tenant-facing).
+
+Mounted under ``/telegram`` by ``unify.gateway.app``:
+
+* ``POST /send``   -- outbound message via ``sendMessage``. Resolves
+  the bot token from the gateway credential store.
+* ``GET  /status`` -- basic health check (``getMe``).
+"""
+
+from __future__ import annotations
+
+import logging
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException, Request
+
+from unify.gateway.common.auth import require_assistant_ownership
+from unify.gateway.context import GatewayContext, get_gateway_context
+
+logger = logging.getLogger("unify.gateway.channels.telegram.views")
+
+auth_router = APIRouter()
+
+TELEGRAM_API_BASE = "https://api.telegram.org"
+
+
+def _bot_url(token: str, method: str) -> str:
+    return f"{TELEGRAM_API_BASE}/bot{token}/{method}"
+
+
+def _get_bot_token(context: GatewayContext) -> str:
+    token = context.credentials.get_optional("TELEGRAM_BOT_TOKEN", "")
+    if not token:
+        raise HTTPException(
+            status_code=503,
+            detail="TELEGRAM_BOT_TOKEN is not configured",
+        )
+    return token
+
+
+@auth_router.post("/send")
+async def send_telegram_message(
+    request: Request,
+    context: GatewayContext = Depends(get_gateway_context),
+):
+    """Send a Telegram message via ``sendMessage``.
+
+    Body::
+
+        {
+            "chat_id": str | int,
+            "body": str,
+            "assistant_id": str | None,
+            "reply_to_message_id": int | None,
+        }
+    """
+    data = await request.json()
+    chat_id = data.get("chat_id")
+    body = data.get("body", "")
+    await require_assistant_ownership(request, data.get("assistant_id"))
+
+    if not chat_id:
+        raise HTTPException(status_code=400, detail="'chat_id' is required")
+    if not body:
+        raise HTTPException(status_code=400, detail="'body' is required")
+
+    token = _get_bot_token(context)
+    payload: dict = {"chat_id": chat_id, "text": body}
+    reply_to = data.get("reply_to_message_id")
+    if reply_to:
+        payload["reply_parameters"] = {"message_id": int(reply_to)}
+
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            _bot_url(token, "sendMessage"),
+            json=payload,
+            timeout=10.0,
+        )
+    resp_data = resp.json()
+    if not resp_data.get("ok"):
+        raise HTTPException(
+            status_code=502,
+            detail=f"Telegram sendMessage failed: {resp_data.get('description')}",
+        )
+    sent = resp_data.get("result", {})
+    logger.info(
+        "sent Telegram message to chat_id=%s (message_id=%s)",
+        chat_id,
+        sent.get("message_id"),
+    )
+    return {
+        "success": True,
+        "message_id": sent.get("message_id"),
+        "chat_id": chat_id,
+    }
+
+
+@auth_router.get("/status")
+async def status(
+    request: Request,
+    context: GatewayContext = Depends(get_gateway_context),
+):
+    """Health check via ``getMe``."""
+    token = _get_bot_token(context)
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(_bot_url(token, "getMe"), timeout=10.0)
+    resp_data = resp.json()
+    if not resp_data.get("ok"):
+        raise HTTPException(
+            status_code=502,
+            detail=f"Telegram getMe failed: {resp_data.get('description')}",
+        )
+    return resp_data.get("result", {})
+
+
+__all__ = ["auth_router"]

--- a/unify/gateway/envelopes.py
+++ b/unify/gateway/envelopes.py
@@ -78,6 +78,7 @@ KNOWN_THREADS: frozenset[str] = frozenset(
         "whatsapp_call_not_answered",
         "whatsapp_call_sent",
         "discord",
+        "telegram",
         "teams_chat",
         "teams_channel",
         "unify_message_reaction",

--- a/unify/gateway/local_setup.py
+++ b/unify/gateway/local_setup.py
@@ -318,6 +318,32 @@ CHANNEL_SETUPS: tuple[ChannelSetup, ...] = (
         ),
     ),
     ChannelSetup(
+        name="telegram",
+        title="Telegram",
+        summary="Telegram Bot API webhook ingress plus outbound send and status routes.",
+        credentials=(
+            CredentialSpec("TELEGRAM_BOT_TOKEN", "Telegram bot token from @BotFather"),
+            CredentialSpec("TELEGRAM_ASSISTANT_ID", "Assistant ID to route inbound messages to"),
+            CredentialSpec(
+                "TELEGRAM_WEBHOOK_SECRET",
+                "Secret token for webhook signature verification",
+                required=False,
+            ),
+        ),
+        callbacks=(CallbackSpec("Telegram webhook URL", "/telegram/webhook"),),
+        public_https_required=True,
+        signup_url="https://t.me/BotFather",
+        dashboard_url="https://t.me/BotFather",
+        setup_steps=(
+            "Create a bot via @BotFather on Telegram and save the bot token.",
+            "Set the webhook URL via the Telegram Bot API setWebhook method.",
+            "Optionally set a secret_token for webhook verification.",
+        ),
+        notes=(
+            "Use `https://api.telegram.org/bot<token>/setWebhook?url=<webhook_url>&secret_token=<secret>` to register.",
+        ),
+    ),
+    ChannelSetup(
         name="email",
         title="Generic Email",
         summary="Generic email send and attachment routes.",


### PR DESCRIPTION
## Summary

- Full two-way Telegram Bot API integration: inbound webhook adapter + outbound sendMessage channel
- Wired into the runtime: Medium enum, events, comms_manager thread handler, CommsPrimitives send methods, brain action tools, prompt builders
- Verified against official Telegram Bot API docs (reply_parameters, secret token header, Update object structure)

## Changes

**Gateway layer (3 new files, 4 modified):**
- `adapters/telegram.py` — `POST /telegram/webhook` with secret token verification, dedup, bot-message filtering, document/photo attachment extraction
- `channels/telegram/views.py` — `POST /telegram/send` (sendMessage) + `GET /telegram/status` (getMe)
- Mounted in `app.py`, registered in `adapters/__init__.py`, added to `KNOWN_THREADS`, `local_setup.py`, `/features`

**Runtime layer (11 modified):**
- `Medium.TELEGRAM_MESSAGE` + `Medium.TELEGRAM_GROUP_MESSAGE` with `telegram_id` contact field
- 4 events: `TelegramMessage{Received,Sent}`, `TelegramGroupMessage{Received,Sent}`
- `comms_manager.py` — inbound `"telegram"` thread handler with dedup, blacklist, contact resolution
- `comms/primitives.py` — `send_telegram_message` + `send_telegram_group_message` with offline reservation
- `brain_action_tools.py` — LLM-callable tools including `send_telegram_message_to_boss`
- `conversation_manager.py` — medium-based reply routing, `assistant_has_telegram` flag
- `prompt_builders.py` — channel listing, tool listing, inline examples

## Setup

1. Set env vars: `TELEGRAM_BOT_TOKEN`, `TELEGRAM_ASSISTANT_ID`, optionally `TELEGRAM_WEBHOOK_SECRET`
2. Register webhook: `https://api.telegram.org/bot<token>/setWebhook?url=<gateway>/telegram/webhook&secret_token=<secret>`

## Test plan

- [ ] Verify gateway boots with Telegram routes mounted (`/telegram/send`, `/telegram/status`, `/telegram/webhook`)
- [ ] Send a Telegram message to the bot → verify it arrives as a `telegram_message` event in the runtime
- [ ] Reply from the assistant → verify it arrives back in Telegram via sendMessage
- [ ] Test group message → verify `telegram_group_message` medium and `send_telegram_group_message` routing
- [ ] Verify secret token rejection when `TELEGRAM_WEBHOOK_SECRET` is set and header is missing/wrong
- [ ] Verify bot messages are ignored (is_bot filter)
- [ ] Verify edited_message updates are handled
- [ ] Verify channel_post updates without a `from` field are safely skipped
