### PR TITLE
fix(ingestion): pull the desktop's writes before calling a path missing

### DIFF
--- a/tests/ingestion_manager/test_lazy_desktop_sync.py
+++ b/tests/ingestion_manager/test_lazy_desktop_sync.py
@@ -1,0 +1,138 @@
+"""A file the desktop just downloaded is pulled before it is called missing.
+
+The managed desktop and this workspace share one tree, but they share it
+through a sync that runs around desktop *execution*. A file the assistant just
+downloaded in a browser therefore exists on the desktop and not yet here, and
+ingesting it moments later measures an empty set -- the same shape of silent
+shortfall as a listing that omits what it was never asked to include, and the
+one that made a shared folder read as revoked for a week.
+
+The sync is triggered only by an absent path under the shared root, so the
+ordinary case costs nothing: files already present, and files that were never
+on the desktop, do not touch the network.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from unify.ingestion_manager.ingestion_manager import IngestionManager
+
+
+class _Source:
+    def __init__(self, kind, **kw):
+        self.kind = kind
+        for k, v in kw.items():
+            setattr(self, k, v)
+
+
+class _SyncManager:
+    def __init__(self):
+        self._started = True
+        self.calls = 0
+
+    async def sync_remote_changes(self):
+        self.calls += 1
+        return True
+
+
+@pytest.fixture()
+def workspace(tmp_path, monkeypatch):
+    root = tmp_path / "Local"
+    (root / "Downloads").mkdir(parents=True)
+    monkeypatch.setattr(
+        "unify.file_manager.settings.get_local_root",
+        lambda: str(root),
+    )
+    return root
+
+
+@pytest.fixture()
+def syncing(monkeypatch):
+    manager = _SyncManager()
+    monkeypatch.setattr(IngestionManager, "_sync_manager", lambda self: manager)
+    return manager
+
+
+def _resolve(source):
+    return IngestionManager._resolve_paths(object.__new__(IngestionManager), source)
+
+
+class TestWhenTheSyncRuns:
+    def test_an_absent_path_under_the_workspace_pulls_first(self, workspace, syncing):
+        missing = workspace / "Downloads" / "repairs.csv"
+        _resolve(_Source("files", paths=[str(missing)]))
+
+        assert syncing.calls == 1
+
+    def test_a_present_file_does_not(self, workspace, syncing):
+        present = workspace / "Downloads" / "already.csv"
+        present.write_text("a,b\n")
+
+        _resolve(_Source("files", paths=[str(present)]))
+
+        assert syncing.calls == 0
+
+    def test_a_path_outside_the_workspace_does_not(self, workspace, syncing, tmp_path):
+        # Syncing cannot make it appear, so the round trip would buy nothing.
+        _resolve(_Source("files", paths=[str(tmp_path / "elsewhere" / "x.csv")]))
+
+        assert syncing.calls == 0
+
+    def test_one_absent_path_among_present_ones_still_pulls(self, workspace, syncing):
+        present = workspace / "Downloads" / "here.csv"
+        present.write_text("x\n")
+        missing = workspace / "Downloads" / "not-here.csv"
+
+        _resolve(_Source("files", paths=[str(present), str(missing)]))
+
+        assert syncing.calls == 1
+
+    def test_a_folder_source_pulls_when_the_folder_is_absent(self, workspace, syncing):
+        _resolve(
+            _Source(
+                "folder",
+                path=str(workspace / "Downloads" / "extract"),
+                pattern="*.csv",
+                recursive=True,
+            ),
+        )
+
+        assert syncing.calls == 1
+
+
+class TestWhenNothingIsSyncing:
+    def test_no_sync_manager_is_not_an_error(self, workspace, monkeypatch):
+        # Most deployments have no managed desktop at all; ingestion must not
+        # depend on one existing.
+        monkeypatch.setattr(IngestionManager, "_sync_manager", lambda self: None)
+
+        paths = _resolve(_Source("files", paths=[str(workspace / "gone.csv")]))
+
+        assert paths == [str(workspace / "gone.csv")]
+
+    def test_a_failing_sync_does_not_abandon_the_run(self, workspace, monkeypatch):
+        # The paths may be present for another reason, and the run's own
+        # reporting is a better place to discover they are not.
+        class _Broken:
+            _started = True
+
+            async def sync_remote_changes(self):
+                raise RuntimeError("sftp down")
+
+        monkeypatch.setattr(IngestionManager, "_sync_manager", lambda self: _Broken())
+
+        paths = _resolve(_Source("files", paths=[str(workspace / "gone.csv")]))
+
+        assert paths == [str(workspace / "gone.csv")]
+
+
+class TestTheContainmentCheck:
+    def test_a_path_inside_the_root_is_recognised(self, tmp_path):
+        assert IngestionManager._under(tmp_path, tmp_path / "a" / "b.csv") is True
+
+    def test_a_sibling_directory_is_not_inside(self, tmp_path):
+        # Prefix matching on strings would call /root-other a child of /root.
+        root = tmp_path / "root"
+        root.mkdir()
+        assert IngestionManager._under(root, tmp_path / "root-other" / "x") is False

--- a/unify/ingestion_manager/ingestion_manager.py
+++ b/unify/ingestion_manager/ingestion_manager.py
@@ -1098,12 +1098,77 @@ class IngestionManager(BaseIngestionManager):
         mid-run is not silently half-included.
         """
         if source.kind == "files":
-            return list(source.paths)
+            paths = list(source.paths)
+            self._sync_if_absent(paths)
+            return paths
         if source.kind != "folder":
             return []
         root = Path(source.path)
+        self._sync_if_absent([str(root)])
         walker = root.rglob if source.recursive else root.glob
         return [str(path) for path in sorted(walker(source.pattern)) if path.is_file()]
+
+    def _sync_if_absent(self, paths: List[str]) -> None:
+        """Pull the managed desktop's writes before deciding a path is missing.
+
+        The desktop and this workspace share one tree, but they share it through
+        a sync that runs around desktop *execution*. A file the assistant just
+        downloaded in a browser therefore exists on the desktop and not yet
+        here, and ingesting it moments later measures an empty set -- the same
+        shape of silent shortfall as a listing that omits what it was not asked
+        to include.
+
+        Only an absent path under the shared root triggers this, so the ordinary
+        case costs nothing: paths that are already present, and paths that were
+        never on the desktop, do not touch the network.
+        """
+        missing = [p for p in paths if p and not Path(p).exists()]
+        if not missing:
+            return
+        from unify.file_manager.settings import get_local_root
+
+        try:
+            root = Path(get_local_root()).resolve()
+        except Exception:
+            return
+        if not any(self._under(root, Path(p)) for p in missing):
+            return
+
+        from unify.common.asyncio_compat import run_coro_sync
+
+        manager = self._sync_manager()
+        if manager is None:
+            return
+        logger.info(
+            "Pulling desktop changes before ingesting %d absent path(s).",
+            len(missing),
+        )
+        try:
+            run_coro_sync(manager.sync_remote_changes)
+        except Exception as exc:
+            # A sync that cannot run is not a reason to abandon the ingestion:
+            # the paths may be present for some other reason, and the run's own
+            # reporting is a better place to discover they are not.
+            logger.warning("Pre-ingestion sync failed: %s: %s", type(exc).__name__, exc)
+
+    @staticmethod
+    def _under(root: Path, candidate: Path) -> bool:
+        try:
+            candidate.resolve().relative_to(root)
+        except (ValueError, OSError):
+            return False
+        return True
+
+    def _sync_manager(self) -> Any:
+        """The live file-sync manager, or ``None`` when nothing is syncing."""
+        from unify.manager_registry import ManagerRegistry
+
+        file_manager = ManagerRegistry.get_file_manager()
+        adapter = getattr(file_manager, "_adapter", None)
+        manager = getattr(adapter, "_sync_manager", None)
+        if manager is None or not getattr(manager, "_started", False):
+            return None
+        return manager
 
     # ── observing ─────────────────────────────────────────────────────────
 


### PR DESCRIPTION
The managed desktop and the assistant's workspace share one tree, but they share it through a sync that runs around desktop execution. A file downloaded in a browser therefore exists on the desktop and not yet here, and ingesting it moments later measures an empty set rather than failing -- the same silent shortfall as a listing that omits what it was never asked to include, which is the shape of bug that made a live shared folder read as revoked.

Path resolution now syncs when a named path is absent, so the file arriving is a property of the pipeline rather than something the model has to remember to ask for. collect_downloads stays useful as an explicit pull, but is no longer load-bearing.

The trigger is deliberately narrow: only an absent path under the shared root. Files already present cost nothing, and files that were never on the desktop cost nothing, because syncing could not make those appear. Containment is checked by resolving and relativising rather than comparing prefixes, so /root-other is not treated as living inside /root.

Neither a missing sync manager nor a failing sync abandons the run. Most deployments have no managed desktop at all, and where one exists the paths may be present for another reason -- the run's own reporting is a better place to discover they are not than an exception in path resolution.

Uses the existing run_coro_sync bridge; submit and its callers are synchronous end to end, so this is a sync façade over async work rather than a new pattern.

<!--
Thanks for contributing to Unify! Please fill out the sections below.
For trivial changes (typo fixes, comment-only edits) you can shorten this template — just keep the Summary.

PRs land on `staging`, not `main`. See CONTRIBUTING.md.
-->

## Summary

<!-- 1–3 sentences: what problem does this PR solve, and why is this the right approach? -->



## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes incorrect behavior)
- [ ] Feature (non-breaking change that adds functionality)
- [ ] Refactor (no behavior change)
- [ ] Breaking change (API or data-model change — Unify has zero-backward-compat policy, but please call it out)
- [ ] Test-only (no source changes)
- [ ] Docs / chore / CI

## Areas touched

<!-- Check all that apply. Helps reviewers route. -->

- [ ] Actor / CodeAct
- [ ] ConversationManager / slow brain
- [ ] A specific state manager (Contact / Knowledge / Task / Transcript / Guidance / Function / File / Image / Web / Secret / Blacklist / Data / Memory)
- [ ] Async tool loop (`unify/common/_async_tool/`)
- [ ] Event bus / observability
- [ ] Gateway / external comms
- [ ] Tests / test infra (`tests/`, `conftest.py`, `parallel_run.sh`)
- [ ] CI / build / packaging

## Test plan

<!--
How did you verify this? Paste the command(s) you ran and the result.

The default expectation is to run the relevant directory:
  tests/parallel_run.sh tests/<module>/

For infrastructure changes that are hard to reach via tests, a quick
verification script under tests/_verify_*.py is encouraged
(see .agents/rules/surgical-verification-before-tests.md).
-->

```
tests/parallel_run.sh tests/...
```

- [ ] All relevant tests pass locally
- [ ] If this is a bug fix, I added a regression test (or explained why one isn't feasible)

## Behavior / migration notes

<!--
- Did this change a public manager API, primitive, or event payload?
- Are there schema/context changes in Orchestra that need a migration?
- Any new env vars or config flags? (Update `.env.advanced.example`.)
- If yes to any of the above, describe upgrade steps.
-->

None.

## Checklist

- [ ] PR is targeted at `staging` (not `main`)
- [ ] Followed conventional commit style (`feat(scope):`, `fix(scope):`, `refactor(scope):`, `chore(scope):`, etc.)
- [ ] No `try/except` added defensively — only around specific, recoverable errors
- [ ] No "new" / "updated" / "TODO from chat" temporal comments (see `.agents/rules/no-temporal-comments.md`)
- [ ] No test-specific shortcuts in production code (see `.agents/rules/no-test-info-in-production-code.md`)
- [ ] Updated `AGENTS.md` / `ARCHITECTURE.md` if I changed architectural conventions
