### PR TITLE
fix(pipeline): name the assistant's ingestion path as a dispatch origin

### DIFF
--- a/tests/common/pipeline/test_dispatch_contract.py
+++ b/tests/common/pipeline/test_dispatch_contract.py
@@ -1,0 +1,90 @@
+"""Every value the dispatch path sends must be one the model accepts.
+
+Three separate outages came from the same shape in one week. A field is typed as
+a ``Literal`` enumerating the values known when it was written; a new caller
+appears and sends something outside the set; nothing catches it until a live
+dispatch fails validation. In order:
+
+* ``execution_target="hosted"`` -- not a member, so every brokered publish was
+  refused before parsing;
+* environment detection answering ``"development"`` -- same field, would have
+  broken every self-host deployment the moment the first was fixed;
+* ``source="ingestion_manager"`` -- the assistant's own ingestion path, the one
+  callers actually reach, missing from the manifest's origin list.
+
+Each cost a full round trip through deploy-and-retest to discover, and each
+looked like a platform outage rather than a bad field. These tests pin the
+contract from the sending side, so a value the senders use but the models reject
+fails here instead of in production.
+"""
+
+from __future__ import annotations
+
+from typing import get_args
+
+import pytest
+
+from unify.common.pipeline.deployment.types import (
+    DeploymentExecutionTarget,
+    DeploymentRunMode,
+    DispatchManifest,
+)
+
+
+class TestTheManifestAcceptsEveryRealOrigin:
+    @pytest.mark.parametrize(
+        "origin",
+        [
+            "dispatch_pipeline",  # the batch script
+            "pipeline_control",  # the operator CLI
+            "ingestion_manager",  # the assistant's own ingestion path
+        ],
+    )
+    def test_a_known_publisher_is_accepted(self, origin):
+        assert DispatchManifest(dispatch_id="d1", source=origin).source == origin
+
+    def test_an_unknown_origin_is_still_rejected(self):
+        # The set is a contract, not a formality: an unrecognised origin should
+        # fail loudly here rather than be written into a manifest nobody can
+        # attribute later.
+        with pytest.raises(Exception):
+            DispatchManifest(dispatch_id="d1", source="somewhere_new")
+
+    def test_the_assistant_path_is_named_in_the_type(self):
+        # Guards the specific regression: the brokered path publishing as
+        # ingestion_manager is the one users reach.
+        assert "ingestion_manager" in get_args(
+            DispatchManifest.model_fields["source"].annotation,
+        )
+
+
+class TestExecutionTargetsAreEnvironmentAgnostic:
+    """The deploy layer maps environments onto these; both sides must agree."""
+
+    def test_the_target_set_is_what_the_mapper_targets(self):
+        # unify-deploy's _execution_target maps every environment it can detect
+        # into this set. If a value is added or renamed here without updating
+        # that mapping, dispatches fail validation at runtime -- which is
+        # exactly how "hosted" and "development" reached production.
+        assert set(get_args(DeploymentExecutionTarget)) == {
+            "local",
+            "local_with_gcp",
+            "staging",
+            "production",
+        }
+
+    @pytest.mark.parametrize("bad", ["hosted", "development", "", "cloud"])
+    def test_values_that_have_been_sent_by_mistake_are_not_members(self, bad):
+        # Each of these was sent in earnest at some point. Keeping them named
+        # here makes a future re-introduction a failing test rather than a
+        # failed dispatch.
+        assert bad not in get_args(DeploymentExecutionTarget)
+
+
+class TestRunModesCoverBothIngestionShapes:
+    def test_file_and_data_manager_are_both_addressable(self):
+        # publish_submit picks between these from the ingestion mode; a missing
+        # member would fail the same way as the fields above.
+        modes = get_args(DeploymentRunMode)
+        assert "file_manager" in modes
+        assert "data_manager" in modes

--- a/unify/common/pipeline/deployment/types.py
+++ b/unify/common/pipeline/deployment/types.py
@@ -168,7 +168,16 @@ class DispatchManifest(BaseModel):
 
     dispatch_id: str
     created_at: str = Field(default_factory=utc_now_iso)
-    source: Literal["dispatch_pipeline", "pipeline_control"] = "dispatch_pipeline"
+    # Every origin that can publish a dispatch has to be named here. The
+    # assistant's own ingestion path publishes through the brokered control
+    # plane, and omitting it meant a validated model rejected the one caller
+    # users actually reach -- fifteen files downloaded and none parsed, because
+    # the manifest describing them could not be written.
+    source: Literal[
+        "dispatch_pipeline",
+        "pipeline_control",
+        "ingestion_manager",
+    ] = "dispatch_pipeline"
     mode: str = ""
     config_path: str = ""
     job_ids: list[str] = Field(default_factory=list)


### PR DESCRIPTION
DispatchManifest.source enumerated the two publishers that existed when it was written. The brokered control plane publishes as ingestion_manager, so the manifest describing a dispatch could not be written at all: fifteen files downloaded, verified, and none parsed, because the index naming them failed validation.

This is the third field in a week to reject a value its own callers send -- after execution_target refused "hosted" and then "development". Each cost a deploy-and-retest cycle to find, and each looked like a platform outage rather than a bad field, because a Literal rejection says nothing about which caller was wrong.

So the contract is now pinned from the sending side. The tests assert every origin the publishers actually use is accepted, and name the values that have been sent by mistake as ones that must stay non-members, so re-introducing any of them fails here rather than in a live dispatch.

<!--
Thanks for contributing to Unify! Please fill out the sections below.
For trivial changes (typo fixes, comment-only edits) you can shorten this template — just keep the Summary.

PRs land on `staging`, not `main`. See CONTRIBUTING.md.
-->

## Summary

<!-- 1–3 sentences: what problem does this PR solve, and why is this the right approach? -->



## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes incorrect behavior)
- [ ] Feature (non-breaking change that adds functionality)
- [ ] Refactor (no behavior change)
- [ ] Breaking change (API or data-model change — Unify has zero-backward-compat policy, but please call it out)
- [ ] Test-only (no source changes)
- [ ] Docs / chore / CI

## Areas touched

<!-- Check all that apply. Helps reviewers route. -->

- [ ] Actor / CodeAct
- [ ] ConversationManager / slow brain
- [ ] A specific state manager (Contact / Knowledge / Task / Transcript / Guidance / Function / File / Image / Web / Secret / Blacklist / Data / Memory)
- [ ] Async tool loop (`unify/common/_async_tool/`)
- [ ] Event bus / observability
- [ ] Gateway / external comms
- [ ] Tests / test infra (`tests/`, `conftest.py`, `parallel_run.sh`)
- [ ] CI / build / packaging

## Test plan

<!--
How did you verify this? Paste the command(s) you ran and the result.

The default expectation is to run the relevant directory:
  tests/parallel_run.sh tests/<module>/

For infrastructure changes that are hard to reach via tests, a quick
verification script under tests/_verify_*.py is encouraged
(see .agents/rules/surgical-verification-before-tests.md).
-->

```
tests/parallel_run.sh tests/...
```

- [ ] All relevant tests pass locally
- [ ] If this is a bug fix, I added a regression test (or explained why one isn't feasible)

## Behavior / migration notes

<!--
- Did this change a public manager API, primitive, or event payload?
- Are there schema/context changes in Orchestra that need a migration?
- Any new env vars or config flags? (Update `.env.advanced.example`.)
- If yes to any of the above, describe upgrade steps.
-->

None.

## Checklist

- [ ] PR is targeted at `staging` (not `main`)
- [ ] Followed conventional commit style (`feat(scope):`, `fix(scope):`, `refactor(scope):`, `chore(scope):`, etc.)
- [ ] No `try/except` added defensively — only around specific, recoverable errors
- [ ] No "new" / "updated" / "TODO from chat" temporal comments (see `.agents/rules/no-temporal-comments.md`)
- [ ] No test-specific shortcuts in production code (see `.agents/rules/no-test-info-in-production-code.md`)
- [ ] Updated `AGENTS.md` / `ARCHITECTURE.md` if I changed architectural conventions
