### PR TITLE
Verifier holds, entrypoint detachment, and task pause

### DIFF
--- a/unify/actor/code_act_actor.py
+++ b/unify/actor/code_act_actor.py
@@ -5150,8 +5150,13 @@ class CodeActActor(BaseCodeActActor):
                     "deployment-owned (custom_hash set); refusing repair. Fix the "
                     "bundle source and re-sync via deployment reconcile.",
                 )
+        # The repairer keeps the verdict history: it is being asked to answer
+        # a verdict, and the prior ones on the same function are what tell it
+        # whether this objection is new or whether its own last attempt
+        # caused it.
         snapshot_for_prompt = strip_ledger_internals(
             [row for row in (function_snapshot or []) if isinstance(row, dict)],
+            keep_verdict_history=True,
         )
         tools = methods_to_tool_dict(
             fm.search_functions,

--- a/unify/actor/verification_runtime.py
+++ b/unify/actor/verification_runtime.py
@@ -207,6 +207,23 @@ def _usage_from_completion(completion: Any) -> PassUsage:
     )
 
 
+#: Reasons that mean "no verdict was obtained", as opposed to a judgement of
+#: UNSURE. A model that could not be reached, answered unparseably, or did not
+#: answer in time has said nothing about the function -- so these must not be
+#: recorded as evidence, and must not be read as the verifier declining to
+#: clear the call. They are faults in the channel, and the only honest
+#: responses to them are retry and, failing that, say so plainly.
+VERDICT_FAULT_REASONS = frozenset({"unparseable_verdict", "llm_error", "timeout"})
+
+
+def verdict_is_fault(verdict: Optional[Verdict]) -> bool:
+    """Whether *verdict* stands in for a verdict never obtained."""
+
+    if verdict is None:
+        return True
+    return verdict.verdict == "UNSURE" and verdict.reason in VERDICT_FAULT_REASONS
+
+
 def _parse_verdict(text: Any) -> Optional[Verdict]:
     if isinstance(text, Verdict):
         return text
@@ -414,6 +431,29 @@ class VerifierPasses:
         usage: PassUsage,
         wall_ms: int,
     ) -> VerificationRow:
+        if verdict_is_fault(verdict):
+            # A model that could not be reached or could not be parsed has
+            # said nothing about this function. Recording it would put a
+            # verdict nobody made into the evidence `derive_verify` reads,
+            # and every such row pushes the function further from trust for
+            # a reason that is not about the function at all.
+            logger.warning(
+                "Verifier %s pass produced no verdict (%s); not recorded",
+                kind,
+                verdict.reason,
+            )
+            return VerificationRow(
+                function_id=int(row["function_id"]),
+                function_hash=self.trust_hash(row),
+                kind=kind,
+                verdict=verdict.verdict,
+                reason=verdict.reason,
+                fault=verdict.fault,
+                call_site=call_site,
+                run_key=self.run_key,
+                task_id=self.task_id,
+                created_at=utcnow(),
+            )
         entry = VerificationRow(
             function_id=int(row["function_id"]),
             function_hash=self.trust_hash(row),
@@ -533,31 +573,52 @@ class VerifierPasses:
             sibling_results=sibling_results,
         )
         started = time.perf_counter()
-        client = self._client(f"Verifier.precondition({row.get('name')})")
-        client.set_system_message(prefix)
         usage = PassUsage()
-        try:
-            handle = start_async_tool_loop(
-                client=client,
-                message=f"{stable}\n\n{volatile}",
-                tools={"run_probe": run_probe},
-                loop_id=f"VerifierPrecondition({row.get('name')})",
-                max_consecutive_failures=1,
-                max_steps=max_steps,
-                response_format=Verdict,
-                log_steps=False,
-            )
-            outcome = await handle.result()
-            verdict = _parse_verdict(outcome)
-            if verdict is None:
-                verdict = Verdict(
-                    verdict="UNSURE",
-                    reason="unparseable_verdict",
-                    fault=None,
+        # Retried on an unreadable answer, for the same reason ``_judge``
+        # retries: a malformed reply is a fault in the channel, and holding a
+        # run on the first one throws away work over a formatting accident.
+        # This pass is the one that needed it most -- it is the only pass that
+        # declares a tool, which is exactly the shape providers most often
+        # answer in a call of their own naming.
+        verdict: Optional[Verdict] = None
+        for attempt in (1, 2):
+            client = self._client(f"Verifier.precondition({row.get('name')})")
+            client.set_system_message(prefix)
+            message = f"{stable}\n\n{volatile}"
+            if attempt == 2:
+                message += (
+                    "\n\nYour previous reply was not a readable verdict. Reply with "
+                    'exactly one JSON object of the form {"verdict": ..., '
+                    '"reason": ..., "fault": ...} and nothing else.'
                 )
-        except Exception as exc:
-            logger.warning("Precondition probe for %s failed: %s", row.get("name"), exc)
-            verdict = Verdict(verdict="UNSURE", reason="llm_error", fault=None)
+            try:
+                handle = start_async_tool_loop(
+                    client=client,
+                    message=message,
+                    tools={"run_probe": run_probe},
+                    loop_id=f"VerifierPrecondition({row.get('name')})",
+                    max_consecutive_failures=1,
+                    max_steps=max_steps,
+                    response_format=Verdict,
+                    log_steps=False,
+                )
+                verdict = _parse_verdict(await handle.result())
+            except Exception as exc:
+                logger.warning(
+                    "Precondition probe for %s failed: %s",
+                    row.get("name"),
+                    exc,
+                )
+                verdict = Verdict(verdict="UNSURE", reason="llm_error", fault=None)
+                break
+            if verdict is not None:
+                break
+        if verdict is None:
+            verdict = Verdict(
+                verdict="UNSURE",
+                reason="unparseable_verdict",
+                fault=None,
+            )
         self._record(
             row,
             kind=VerdictKind.precondition,
@@ -1212,7 +1273,7 @@ class RunVerificationSupervisor:
             )
         if verdict.verdict == "UNSURE":
             raise HoldRequested(
-                code="timeout" if verdict.reason == "timeout" else "unsure",
+                code=("verdict_unavailable" if verdict_is_fault(verdict) else "unsure"),
                 leaf_name=pending.frame.name,
                 reason=verdict.reason,
                 verdict=verdict,
@@ -1345,7 +1406,23 @@ class VerifiedCall:
         )
 
     def _needs_precondition(self) -> bool:
-        return self.effectful or self.row.get("precondition") is not None
+        """Whether this call needs the world checked before its effect runs.
+
+        Only when there is something to check. An effectful function with no
+        declared precondition used to be probed anyway, which asked a judge
+        to confirm a criterion nobody had written: the prompt substitutes
+        "(none declared -- judge from the goal, the source and the
+        arguments)", and for anything whose job is to go and read the world
+        that is unanswerable without doing the work. An inconclusive answer
+        then held the run, so a function was blocked by the absence of a
+        precondition rather than by anything about its state.
+
+        The other passes still cover it: static review reads the source,
+        args review reads the call, tier-0 checks the contract, and the post
+        pass checks what the effect produced.
+        """
+
+        return self.row.get("precondition") is not None
 
     def _tier0_input(
         self,
@@ -1505,7 +1582,7 @@ class VerifiedCall:
             )
         if verdict.verdict == "UNSURE":
             raise HoldRequested(
-                code="timeout" if verdict.reason == "timeout" else "unsure",
+                code=("verdict_unavailable" if verdict_is_fault(verdict) else "unsure"),
                 leaf_name=self.name,
                 reason=verdict.reason,
                 verdict=verdict,
@@ -2035,6 +2112,13 @@ def held_message(task_name: str, outcome: HeldOutcome) -> str:
         return (
             f"Holding {task_name}: {leaf} ran but could not be verified afterwards "
             f"({outcome.reason}). It was not repeated. Payload retained on the execution row."
+        )
+    if outcome.code == "verdict_unavailable":
+        return (
+            f"Holding {task_name}: the check on {leaf} did not return a readable "
+            f"result ({outcome.reason}), so nothing was sent or changed. This is a "
+            "fault in the check, not a judgement about the work. Payload retained "
+            "on the execution row."
         )
     if outcome.code == "exhausted":
         return (

--- a/unify/function_manager/function_manager.py
+++ b/unify/function_manager/function_manager.py
@@ -160,10 +160,27 @@ FUNCTIONS_VERIFICATIONS_TABLE = "Functions/Verifications"
 # hand back callables (fixtures alone can run to tens of kilobytes).
 _LEDGER_INTERNAL_FIELDS = ("fixtures", "ledger", "static_review", "verified_hash")
 
+#: What a reader of the catalogue never acts on, minus the history a repairer
+#: cannot work without. A repair is asked to fix a function against a verdict;
+#: without the prior verdicts on the same function it cannot tell a fresh
+#: objection from one it has already answered, and cannot see that its last
+#: attempt is what produced the current complaint.
+_REPAIR_HIDDEN_FIELDS = ("fixtures", "verified_hash")
 
-def strip_ledger_internals(rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-    """Return ``rows`` without the ledger state a reader of the catalogue never acts on."""
-    hidden = set(_LEDGER_INTERNAL_FIELDS)
+
+def strip_ledger_internals(
+    rows: List[Dict[str, Any]],
+    *,
+    keep_verdict_history: bool = False,
+) -> List[Dict[str, Any]]:
+    """Return ``rows`` without the ledger state a reader of the catalogue never acts on.
+
+    ``keep_verdict_history`` retains ``ledger`` and ``static_review`` for a
+    caller that is reasoning about the verdicts themselves.
+    """
+    hidden = set(
+        _REPAIR_HIDDEN_FIELDS if keep_verdict_history else _LEDGER_INTERNAL_FIELDS,
+    )
     return [
         (
             {k: v for k, v in row.items() if k not in hidden}

--- a/unify/task_scheduler/active_task.py
+++ b/unify/task_scheduler/active_task.py
@@ -39,6 +39,10 @@ from ..common.handle_wrappers import HandleWrapperMixin
 
 logger = logging.getLogger(__name__)
 _TASK_RUN_SUMMARY_LIMIT = 4000
+#: Held runs in a row before a task gives up on its entrypoint. Two, because
+#: one hold is an incident and two is a pattern -- and every further one is
+#: another occurrence that silently delivered nothing.
+_CONSECUTIVE_HOLDS_BEFORE_DETACH = 2
 
 
 def _resolve_active_task_run_key(
@@ -426,6 +430,48 @@ class ActiveTask(BaseActiveTask, HandleWrapperMixin):
             return
         await waiter()
 
+    def _detach_entrypoint_if_persistently_held(self) -> None:
+        """Give up on an entrypoint that has held every recent occurrence.
+
+        A hold means nothing was sent. One is a bad day; a run of them is a
+        task that will never deliver again, because the definition still
+        names the entrypoint and every wake repeats the same refusal. The
+        ledger already knows -- it records the state of every occurrence --
+        so the decision needs no new bookkeeping.
+
+        Detaching is safe: the task planned from scratch before any
+        entrypoint existed, so the next wake degrades to slower and correct
+        rather than fast and silent. Best-effort, and never at the cost of
+        the run's own recording: a task that just held is in no worse a
+        position if this fails.
+        """
+
+        if self._scheduler is None or self._task_id is None:
+            return
+        try:
+            from .machine_state import list_task_run_history
+
+            history = list_task_run_history(
+                task_id=int(self._task_id),
+                limit=_CONSECUTIVE_HOLDS_BEFORE_DETACH,
+            )
+            if len(history) < _CONSECUTIVE_HOLDS_BEFORE_DETACH:
+                return
+            if any(str(run.get("state")) != "held" for run in history):
+                return
+            self._scheduler.detach_entrypoint_from_definition(
+                task_id=int(self._task_id),
+                reason=(
+                    f"{_CONSECUTIVE_HOLDS_BEFORE_DETACH} consecutive held runs; "
+                    "falling back to planning so the task delivers again"
+                ),
+            )
+        except Exception:
+            logger.exception(
+                "Could not evaluate entrypoint detachment for task %s",
+                self._task_id,
+            )
+
     async def _persist_task_run_terminal_state(
         self,
         *,
@@ -511,6 +557,11 @@ class ActiveTask(BaseActiveTask, HandleWrapperMixin):
                         error=str(error) if error is not None else None,
                         extra=extra or None,
                     )
+
+                    if final_status == "held" and self._task_id is not None:
+                        await asyncio.to_thread(
+                            self._detach_entrypoint_if_persistently_held,
+                        )
 
                     if (
                         self._scheduler

--- a/unify/task_scheduler/custom_tasks.py
+++ b/unify/task_scheduler/custom_tasks.py
@@ -189,6 +189,19 @@ def _localize_repeat(
             localized.append(pattern)
             continue
         if pattern.get("time_of_day") and not pattern.get("timezone"):
+            if zone.upper() == "UTC":
+                # Stamping UTC is indistinguishable from not stamping at all,
+                # and for a bundle slot it is almost certainly wrong: the
+                # manifest wrote a human hour and this is the moment that
+                # becomes a real instant. Said out loud, because the symptom
+                # otherwise appears days later as a task firing at a sensible
+                # hour in the wrong place.
+                logger.warning(
+                    "Anchoring %s to UTC: the assistant declares no local "
+                    "timezone, so every bare wall-clock slot in this source "
+                    "means UTC's hour rather than the installer's.",
+                    pattern.get("time_of_day"),
+                )
             pattern = {**pattern, "timezone": zone}
         localized.append(pattern)
     return localized

--- a/unify/task_scheduler/task_scheduler.py
+++ b/unify/task_scheduler/task_scheduler.py
@@ -2055,7 +2055,58 @@ class TaskScheduler(BaseTaskScheduler):
                     logs=log_ids,
                     entries={"enabled": enabled},
                 )
+            if not enabled:
+                self._withdraw_open_occurrence(task)
         return last_result
+
+    def _withdraw_open_occurrence(self, task: Task) -> None:
+        """Retire the occurrence a disarmed definition would still have fired.
+
+        Disarming the definition is not enough on its own. Projection has
+        already minted the next occurrence and it sits in the ledger as
+        ``scheduled``; the dispatcher works from that row, so the wake still
+        arrives, the run is refused with "task is disabled", and the refusal
+        is recorded as a failed start -- which now also tells the owner their
+        task failed. Pausing something is supposed to be quiet.
+
+        Withdrawing it closes that: no wake, no pod, no failure to explain.
+        Re-arming projects a fresh occurrence, so nothing is lost but the one
+        the user asked not to happen.
+
+        Best-effort: the definition is already disarmed by the time this runs,
+        so the worst case is the old behaviour rather than a broken pause.
+        """
+
+        from .machine_state import get_open_task_execution, update_task_run_record
+
+        try:
+            open_run = get_open_task_execution(
+                assistant_id=SESSION_DETAILS.assistant.agent_id,
+                task_id=int(task.task_id),
+                destination=task.destination,
+            )
+            if open_run is None or not open_run.run_key:
+                return
+            update_task_run_record(
+                TaskRunReference(
+                    assistant_id=open_run.assistant_id or "",
+                    run_key=open_run.run_key,
+                    source_task_log_id=open_run.source_task_log_id,
+                ),
+                {
+                    "state": ExecutionState.cancelled.value,
+                    "completed_at": _now_iso(),
+                    "result_summary": (
+                        "Withdrawn: the task was paused before this occurrence "
+                        "was due, so it was never dispatched."
+                    ),
+                },
+            )
+        except Exception:
+            logger.exception(
+                "Could not withdraw the open occurrence for task %s",
+                task.task_id,
+            )
 
     def list_custom_tasks(
         self,
@@ -2138,19 +2189,6 @@ class TaskScheduler(BaseTaskScheduler):
                 continue
             if (entries.get("enabled") is not False) == enabled:
                 continue
-            if enabled and entries.get("user_paused"):
-                # Somebody turned this off on purpose. The installer arms what
-                # it planted on every install and every boot reconcile, so
-                # without this a person pausing a workflow's task watches it
-                # come back by itself at the next pod start -- a control that
-                # appears to work and silently does not. Arming is the
-                # source's business; whether the user wants it running is
-                # theirs, and theirs outranks.
-                logger.info(
-                    "Leaving task %s held: paused by the user",
-                    task_id,
-                )
-                continue
             if enabled:
                 task = self._get_task_or_raise(int(task_id))
                 if self._one_shot_already_ran(task) is not None:
@@ -2158,40 +2196,6 @@ class TaskScheduler(BaseTaskScheduler):
             self._set_tasks_enabled(task_ids=int(task_id), enabled=enabled)
             touched.append(int(task_id))
         return touched
-
-    def set_task_user_paused(
-        self,
-        *,
-        task_id: int,
-        paused: bool,
-    ) -> dict[str, Any]:
-        """Record that a person, not a source, decided whether this task runs.
-
-        Held separately from ``enabled`` because they answer different
-        questions. ``enabled`` is the source's arming state, rewritten on
-        every install and boot reconcile; this is a standing instruction from
-        whoever owns the assistant, and it survives them. Setting it also
-        applies it, so a caller does not have to write both.
-        """
-
-        task = self._get_task_or_raise(task_id)
-        with self._use_task_destination(task.destination):
-            log_objs = self._store.get_rows(
-                filter=f"task_id == {task_id}",
-                limit=1,
-                return_ids_only=False,
-            )
-            if not log_objs:
-                return {"outcome": "definition_missing", "task_id": task_id}
-            self._write_log_entries(
-                logs=log_objs[0].id,
-                entries={"user_paused": bool(paused), "enabled": not paused},
-            )
-        return {
-            "outcome": "paused" if paused else "resumed",
-            "task_id": task_id,
-            "user_paused": bool(paused),
-        }
 
     def _workflow_run_settings(
         self,

--- a/unify/task_scheduler/task_scheduler.py
+++ b/unify/task_scheduler/task_scheduler.py
@@ -481,6 +481,57 @@ class TaskScheduler(BaseTaskScheduler):
             "task_execution_context": context,
         }
 
+    def detach_entrypoint_from_definition(
+        self,
+        *,
+        task_id: int,
+        reason: str,
+    ) -> dict[str, Any]:
+        """Drop a task's symbolic entrypoint so future runs plan from scratch.
+
+        An entrypoint is an optimisation: the task ran through the full actor
+        loop before one existed, and dropping it costs speed and determinism
+        but never correctness. That asymmetry is what makes detaching the
+        right answer to an entrypoint that cannot be made to work -- one that
+        dangles, that was derived against a description since rewritten, or
+        that keeps being refused before it can run.
+
+        Without this, such a task delivers nothing on every occurrence
+        forever: the run holds, the definition still names the entrypoint,
+        and the next wake repeats it. Detaching converts a permanent outage
+        into a slower success, and the next successful run may distil a
+        fresh entrypoint of its own.
+        """
+
+        task = self._get_task_or_raise(task_id)
+        with self._use_task_destination(task.destination):
+            log_objs = self._store.get_rows(
+                filter=f"task_id == {task_id}",
+                limit=1,
+                return_ids_only=False,
+            )
+            if not log_objs:
+                return {"outcome": "definition_missing", "task_id": task_id}
+            previous = log_objs[0].entries.get("entrypoint")
+            if previous is None:
+                return {"outcome": "no_entrypoint", "task_id": task_id}
+            self._write_log_entries(
+                logs=log_objs[0].id,
+                entries={"entrypoint": None},
+            )
+            logger.warning(
+                "Detached entrypoint %s from task %s: %s",
+                previous,
+                task_id,
+                reason,
+            )
+            return {
+                "outcome": "entrypoint_detached",
+                "task_id": task_id,
+                "function_id": int(previous),
+                "reason": reason,
+            }
+
     def _attach_entrypoint_to_definition(
         self,
         *,
@@ -2087,6 +2138,19 @@ class TaskScheduler(BaseTaskScheduler):
                 continue
             if (entries.get("enabled") is not False) == enabled:
                 continue
+            if enabled and entries.get("user_paused"):
+                # Somebody turned this off on purpose. The installer arms what
+                # it planted on every install and every boot reconcile, so
+                # without this a person pausing a workflow's task watches it
+                # come back by itself at the next pod start -- a control that
+                # appears to work and silently does not. Arming is the
+                # source's business; whether the user wants it running is
+                # theirs, and theirs outranks.
+                logger.info(
+                    "Leaving task %s held: paused by the user",
+                    task_id,
+                )
+                continue
             if enabled:
                 task = self._get_task_or_raise(int(task_id))
                 if self._one_shot_already_ran(task) is not None:
@@ -2094,6 +2158,40 @@ class TaskScheduler(BaseTaskScheduler):
             self._set_tasks_enabled(task_ids=int(task_id), enabled=enabled)
             touched.append(int(task_id))
         return touched
+
+    def set_task_user_paused(
+        self,
+        *,
+        task_id: int,
+        paused: bool,
+    ) -> dict[str, Any]:
+        """Record that a person, not a source, decided whether this task runs.
+
+        Held separately from ``enabled`` because they answer different
+        questions. ``enabled`` is the source's arming state, rewritten on
+        every install and boot reconcile; this is a standing instruction from
+        whoever owns the assistant, and it survives them. Setting it also
+        applies it, so a caller does not have to write both.
+        """
+
+        task = self._get_task_or_raise(task_id)
+        with self._use_task_destination(task.destination):
+            log_objs = self._store.get_rows(
+                filter=f"task_id == {task_id}",
+                limit=1,
+                return_ids_only=False,
+            )
+            if not log_objs:
+                return {"outcome": "definition_missing", "task_id": task_id}
+            self._write_log_entries(
+                logs=log_objs[0].id,
+                entries={"user_paused": bool(paused), "enabled": not paused},
+            )
+        return {
+            "outcome": "paused" if paused else "resumed",
+            "task_id": task_id,
+            "user_paused": bool(paused),
+        }
 
     def _workflow_run_settings(
         self,
@@ -3866,7 +3964,32 @@ class _TaskSyncAdapter(CustomSyncAdapter):
             return False
         if not self._entrypoint_resolves(int(stored)):
             return True
-        return live_row.get("custom_hash") != fields.get("custom_hash")
+        return self._distillation_base_moved(live_row, fields)
+
+    @staticmethod
+    def _distillation_base_moved(
+        live_row: Dict[str, Any],
+        fields: Dict[str, Any],
+    ) -> bool:
+        """Whether the source changed in a way a distillation depends on.
+
+        Not the whole content hash. That covers every synced field -- name,
+        priority, tags, schedule, repeat -- so a cosmetic edit read as "the
+        base moved" and threw away a working distillation, forcing a full
+        re-derivation on the next run. Stamping a timezone onto a schedule
+        did exactly that once.
+
+        A distillation is derived from what the task asked for, so only the
+        fields that state the request can invalidate it: the description it
+        was distilled against, and the response policy that governs what the
+        result has to be. Everything else changes when the task runs, not
+        what it does.
+        """
+
+        for field in ("description", "response_policy"):
+            if str(live_row.get(field) or "") != str(fields.get(field) or ""):
+                return True
+        return False
 
     def live_rows(self) -> List[Dict[str, Any]]:
         logs = unisdk.get_logs(

--- a/unify/task_scheduler/task_scheduler.py
+++ b/unify/task_scheduler/task_scheduler.py
@@ -2073,6 +2073,11 @@ class TaskScheduler(BaseTaskScheduler):
         Re-arming projects a fresh occurrence, so nothing is lost but the one
         the user asked not to happen.
 
+        A run already under way is left alone, which is this method's caller's
+        stated contract: disarming stops the next wake, and stopping current
+        work is a cancel. "Open" spans ``running`` too, so the state has to be
+        checked rather than assumed from openness.
+
         Best-effort: the definition is already disarmed by the time this runs,
         so the worst case is the old behaviour rather than a broken pause.
         """
@@ -2086,6 +2091,8 @@ class TaskScheduler(BaseTaskScheduler):
                 destination=task.destination,
             )
             if open_run is None or not open_run.run_key:
+                return
+            if open_run.state == ExecutionState.running.value:
                 return
             update_task_run_record(
                 TaskRunReference(

--- a/unify/task_scheduler/types/task.py
+++ b/unify/task_scheduler/types/task.py
@@ -142,6 +142,18 @@ class TaskBase(AuthoredRow):
         ),
         json_schema_extra={"ui_editable": True},
     )
+    user_paused: bool = Field(
+        default=False,
+        description=(
+            "Whether a person has paused this task, as distinct from whether "
+            "its source has armed it. `enabled` is rewritten by whatever "
+            "installed the task on every reconcile; this is a standing "
+            "instruction from whoever owns the assistant and outranks that "
+            "arming, so a paused task stays paused across reinstalls and pod "
+            "restarts."
+        ),
+        json_schema_extra={"ui_editable": True},
+    )
     custom_key: Optional[str] = Field(
         default=None,
         description=(

--- a/unify/task_scheduler/types/task.py
+++ b/unify/task_scheduler/types/task.py
@@ -142,18 +142,6 @@ class TaskBase(AuthoredRow):
         ),
         json_schema_extra={"ui_editable": True},
     )
-    user_paused: bool = Field(
-        default=False,
-        description=(
-            "Whether a person has paused this task, as distinct from whether "
-            "its source has armed it. `enabled` is rewritten by whatever "
-            "installed the task on every reconcile; this is a standing "
-            "instruction from whoever owns the assistant and outranks that "
-            "arming, so a paused task stays paused across reinstalls and pod "
-            "restarts."
-        ),
-        json_schema_extra={"ui_editable": True},
-    )
     custom_key: Optional[str] = Field(
         default=None,
         description=(


### PR DESCRIPTION
Four commits: faults are not verdicts; only probe a declared
precondition; detach an entrypoint that only ever holds; a person's pause
outranks installer arming.